### PR TITLE
JMS Source tasks parallelization

### DIFF
--- a/kafka-connect-jms/src/main/scala/com/datamountaineer/streamreactor/connect/jms/config/JMSConfig.scala
+++ b/kafka-connect-jms/src/main/scala/com/datamountaineer/streamreactor/connect/jms/config/JMSConfig.scala
@@ -91,6 +91,12 @@ object JMSConfig {
       JMSConfigConstants.EVICT_THRESHOLD_MINUTES_DEFAULT,
       Importance.MEDIUM, JMSConfigConstants.EVICT_THRESHOLD_MINUTES_DOC,
       "Settings", 2, ConfigDef.Width.MEDIUM, JMSConfigConstants.EVICT_THRESHOLD_MINUTES_DOC)
+
+    .define(JMSConfigConstants.TASK_PARALLELIZATION_TYPE,
+        Type.STRING,
+        JMSConfigConstants.TASK_PARALLELIZATION_TYPE_DEFAULT,
+        Importance.MEDIUM, JMSConfigConstants.TASK_PARALLELIZATION_TYPE_DOC,
+        "Settings", 4, ConfigDef.Width.MEDIUM, JMSConfigConstants.TASK_PARALLELIZATION_TYPE_DOC)
 }
 
 /**

--- a/kafka-connect-jms/src/main/scala/com/datamountaineer/streamreactor/connect/jms/config/JMSConfigConstants.scala
+++ b/kafka-connect-jms/src/main/scala/com/datamountaineer/streamreactor/connect/jms/config/JMSConfigConstants.scala
@@ -117,4 +117,8 @@ object JMSConfigConstants {
   val EVICT_THRESHOLD_MINUTES = s"$CONNECTOR_PREFIX.evict.threshold.minutes"
   private[config] val EVICT_THRESHOLD_MINUTES_DOC = "The number of minutes after which an uncommitted entry becomes evictable from the connector cache."
   private[config] val EVICT_THRESHOLD_MINUTES_DEFAULT = 10
+
+  val TASK_PARALLELIZATION_TYPE = s"$CONNECTOR_PREFIX.scale.type"
+  private[config] val TASK_PARALLELIZATION_TYPE_DOC = "How the connector tasks parallelization is decided. Available values are kcql and default. If kcql is provided it will be based on the number of KCQL statements written; otherwise it will be driven based on the connector tasks.max"
+  val TASK_PARALLELIZATION_TYPE_DEFAULT = "kcql"
 }

--- a/kafka-connect-jms/src/main/scala/com/datamountaineer/streamreactor/connect/jms/source/JMSSourceConnector.scala
+++ b/kafka-connect-jms/src/main/scala/com/datamountaineer/streamreactor/connect/jms/source/JMSSourceConnector.scala
@@ -81,9 +81,7 @@ class JMSSourceConnector extends SourceConnector with StrictLogging {
   override def config(): ConfigDef = configDef
 
   override def start(props: util.Map[String, String]): Unit = {
-    val actualConfig: util.Map[String, AnyRef] = JMSConfig.config.parse(props)
     val config = new JMSConfig(props)
-
     configProps = config.props
   }
 

--- a/kafka-connect-jms/src/main/scala/com/datamountaineer/streamreactor/connect/jms/source/JMSSourceTask.scala
+++ b/kafka-connect-jms/src/main/scala/com/datamountaineer/streamreactor/connect/jms/source/JMSSourceTask.scala
@@ -55,6 +55,7 @@ class JMSSourceTask extends SourceTask with StrictLogging {
   private var lastEvictedTimestamp: FiniteDuration = FiniteDuration(System.currentTimeMillis(), MILLISECONDS)
   private var evictInterval: Int = 0
   private var evictThreshold: Int = 0
+
   override def start(props: util.Map[String, String]): Unit = {
     logger.info(scala.io.Source.fromInputStream(getClass.getResourceAsStream("/jms-source-ascii.txt")).mkString + s" $version")
     logger.info(manifest.printManifest())


### PR DESCRIPTION
Allow the connector to respect the tasks.max value provided if the user `connect.jms.scale.type`