### PR TITLE
#651 - RabbitMQ Connector doesn't configure client to use virtual host

### DIFF
--- a/kafka-connect-rabbitmq/src/main/scala/com/datamountaineer/streamreactor/connect/rabbitmq/client/RabbitMQClient.scala
+++ b/kafka-connect-rabbitmq/src/main/scala/com/datamountaineer/streamreactor/connect/rabbitmq/client/RabbitMQClient.scala
@@ -24,7 +24,13 @@ abstract class RabbitMQClient(settings: RabbitMQSettings) extends StrictLogging 
         factory.setPort(settings.port)
         factory.setUsername(settings.username)
         factory.setPassword(settings.password)
-        factory.setVirtualHost(settings.virtualHost)
+        if (settings.virtualHost != "/") {
+            if (settings.virtualHost.startsWith("/")) {
+                factory.setVirtualHost(settings.virtualHost.substring(1))
+            } else {
+                factory.setVirtualHost(settings.virtualHost)
+            }
+        }
         if (settings.useTls != false) factory.useSslProtocol()
 
         factory.newConnection()

--- a/kafka-connect-rabbitmq/src/main/scala/com/datamountaineer/streamreactor/connect/rabbitmq/client/RabbitMQClient.scala
+++ b/kafka-connect-rabbitmq/src/main/scala/com/datamountaineer/streamreactor/connect/rabbitmq/client/RabbitMQClient.scala
@@ -24,6 +24,7 @@ abstract class RabbitMQClient(settings: RabbitMQSettings) extends StrictLogging 
         factory.setPort(settings.port)
         factory.setUsername(settings.username)
         factory.setPassword(settings.password)
+        factory.setVirtualHost(settings.virtualHost)
         if (settings.useTls != false) factory.useSslProtocol()
 
         factory.newConnection()


### PR DESCRIPTION
Add support for client virtual host configuration