### PR TITLE
Add case for java.math.BigDecimal type with mongodb sink.

### DIFF
--- a/kafka-connect-mongodb/src/main/scala/com/datamountaineer/streamreactor/connect/mongodb/converters/SinkRecordConverter.scala
+++ b/kafka-connect-mongodb/src/main/scala/com/datamountaineer/streamreactor/connect/mongodb/converters/SinkRecordConverter.scala
@@ -122,6 +122,7 @@ object SinkRecordConverter extends StrictLogging {
               case Schema.Type.BYTES =>
                 if (schema != null && Decimal.LOGICAL_NAME == schema.name) {
                   value match {
+                    case jbd: java.math.BigDecimal => jbd
                     case bd: BigDecimal => bd.bigDecimal
                     case bb: ByteBuffer => Decimal.toLogical(schema, bb.array())
                     case _ => Decimal.toLogical(schema, value.asInstanceOf[Array[Byte]])


### PR DESCRIPTION
Fixes #658 by also checking for `java.math.BigDecimal`. Since the code uses `java.math.BigDecimal` as well as the scala `BigDecimal` in several places, I opted to add a new case for the `java.math.BigDecimal` instead of replacing the scala `BigDecimal` case.