### PR TITLE
updated documentDBversion

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -20,7 +20,7 @@ import de.undercouch.gradle.tasks.download.Download
 
 plugins {
     id "de.undercouch.download" version "3.4.3"
-    id "com.github.maiflai.scalatest" version "0.25"
+    id "com.github.maiflai.scalatest" version "0.23"
     id "com.github.johnrengelman.shadow" version "4.0.3"
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -20,7 +20,7 @@ import de.undercouch.gradle.tasks.download.Download
 
 plugins {
     id "de.undercouch.download" version "3.4.3"
-    id "com.github.maiflai.scalatest" version "0.23"
+    id "com.github.maiflai.scalatest" version "0.25"
     id "com.github.johnrengelman.shadow" version "4.0.3"
 }
 

--- a/kafka-connect-azure-documentdb/build.gradle
+++ b/kafka-connect-azure-documentdb/build.gradle
@@ -16,7 +16,7 @@
 
 project(":kafka-connect-azure-documentdb") {
     ext {
-        documentDbVersion = "1.16.0"
+        documentDbVersion = "2.4.7"
         avro4sVersion = "1.6.4"
     }
 


### PR DESCRIPTION
- Azure is deprecating v1.x of the API on May 30th, 2020. Updating to avoid issues.

resolves #665 