### PR TITLE
Kerberos support for the Hive source

### DIFF
--- a/kafka-connect-hive-1.1/src/main/scala/com/landoop/streamreactor/connect/hive/HadoopConfigurationExtension.scala
+++ b/kafka-connect-hive-1.1/src/main/scala/com/landoop/streamreactor/connect/hive/HadoopConfigurationExtension.scala
@@ -6,7 +6,6 @@ import com.landoop.streamreactor.connect.hive.kerberos.Kerberos
 import com.landoop.streamreactor.connect.hive.kerberos.KeytabSettings
 import com.landoop.streamreactor.connect.hive.kerberos.UserPasswordSettings
 import org.apache.hadoop.conf.Configuration
-import org.apache.hadoop.security.SecurityUtil
 
 object HadoopConfigurationExtension {
 

--- a/kafka-connect-hive-1.1/src/main/scala/com/landoop/streamreactor/connect/hive/sink/HiveSinkTask.scala
+++ b/kafka-connect-hive-1.1/src/main/scala/com/landoop/streamreactor/connect/hive/sink/HiveSinkTask.scala
@@ -84,7 +84,7 @@ class HiveSinkTask extends SinkTask {
 
     val databases = execute(client.getAllDatabases)
     if (!databases.contains(config.dbName.value)) {
-      throw new ConnectException(s"Can not find database [${config.dbName.value}]. Current database(-s): ${databases.asScala.mkString(",")}. Please make sure the database is created before sinking to it.")
+      throw new ConnectException(s"Cannot find database [${config.dbName.value}]. Current database(-s): ${databases.asScala.mkString(",")}. Please make sure the database is created before sinking to it.")
     }
   }
 
@@ -148,7 +148,7 @@ class HiveSinkTask extends SinkTask {
             context.offset(new KafkaTopicPartition(topic.value, partition), offset.value)
           }
         logger.info(s"Opening sink for ${config.dbName.value}.${tableName.value} for ${tp.topic.value}:${tp.partition}")
-        val sink = HiveSink.from(tableName, config)(client, fs)
+        val sink: HiveSink = HiveSink.from(tableName, config)(client, fs)
         sinks.put(tp, sink)
       }
     }

--- a/kafka-connect-hive-1.1/src/main/scala/com/landoop/streamreactor/connect/hive/source/HiveSourceTask.scala
+++ b/kafka-connect-hive-1.1/src/main/scala/com/landoop/streamreactor/connect/hive/source/HiveSourceTask.scala
@@ -3,28 +3,35 @@ package com.landoop.streamreactor.connect.hive.source
 import java.util
 
 import com.datamountaineer.streamreactor.connect.utils.JarManifest
+import com.landoop.streamreactor.connect.hive.kerberos.KerberosLogin
 import com.landoop.streamreactor.connect.hive.sink.config.SinkConfigSettings
 import com.landoop.streamreactor.connect.hive.source.config.HiveSourceConfig
 import com.landoop.streamreactor.connect.hive.source.offset.HiveSourceOffsetStorageReader
+import com.landoop.streamreactor.connect.hive.ConfigurationBuilder
+import com.landoop.streamreactor.connect.hive.HadoopConfigurationExtension._
 import com.typesafe.scalalogging.slf4j.StrictLogging
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.FileSystem
-import org.apache.hadoop.hive.conf.HiveConf
 import org.apache.hadoop.hive.metastore.HiveMetaStoreClient
+import org.apache.kafka.connect.errors.ConnectException
 import org.apache.kafka.connect.source.SourceRecord
 import org.apache.kafka.connect.source.SourceTask
 
 import scala.collection.JavaConverters._
+import scala.util.Try
 
 class HiveSourceTask extends SourceTask with StrictLogging {
 
-  private val manifest = JarManifest(getClass.getProtectionDomain.getCodeSource.getLocation)
+  private val manifest = JarManifest(
+    getClass.getProtectionDomain.getCodeSource.getLocation
+  )
   private var client: HiveMetaStoreClient = _
   private var fs: FileSystem = _
   private var config: HiveSourceConfig = _
 
   private var sources: Set[HiveSource] = Set.empty
   private var iterator: Iterator[SourceRecord] = Iterator.empty
+  private var kerberosLogin = Option.empty[KerberosLogin]
 
   def this(fs: FileSystem, client: HiveMetaStoreClient) {
     this()
@@ -35,20 +42,55 @@ class HiveSourceTask extends SourceTask with StrictLogging {
   override def start(props: util.Map[String, String]): Unit = {
     val configs = if (context.configs().isEmpty) props else context.configs()
 
-    if (client == null) {
-      val hiveConf = new HiveConf()
-      hiveConf.set("hive.metastore", configs.get(SinkConfigSettings.MetastoreTypeKey))
-      hiveConf.set("hive.metastore.uris", configs.get(SinkConfigSettings.MetastoreUrisKey))
+    config = HiveSourceConfig.fromProps(configs.asScala.toMap)
+
+    Option(fs).foreach(fs => Try(fs.close()))
+    Option(client).foreach(c => Try(c.close()))
+
+    val conf: Configuration =
+      ConfigurationBuilder.buildHdfsConfiguration(config.hadoopConfiguration)
+    conf.set("fs.defaultFS", configs.get(SinkConfigSettings.FsDefaultKey))
+
+    kerberosLogin = config.kerberos.map { kerberos =>
+      conf.withKerberos(kerberos)
+      KerberosLogin.from(kerberos, conf)
+    }
+
+    val hiveConf =
+      ConfigurationBuilder.buildHiveConfig(config.hadoopConfiguration)
+    hiveConf.set("hive.metastore.local", "false")
+    hiveConf.set(
+      "hive.metastore",
+      configs.get(SinkConfigSettings.MetastoreTypeKey)
+    )
+    hiveConf.set(
+      "hive.metastore.uris",
+      configs.get(SinkConfigSettings.MetastoreUrisKey)
+    )
+    config.kerberos.foreach { _ =>
+      val principal =
+        Option(configs.get(SinkConfigSettings.HiveMetastorePrincipalKey))
+          .getOrElse {
+            throw new ConnectException(
+              s"Missing configuration for [${SinkConfigSettings.HiveMetastorePrincipalKey}]. When using Kerberos it is required to set the configuration."
+            )
+          }
+
+      hiveConf.set("hive.metastore.kerberos.principal", principal)
+    }
+
+    def initialize(): Unit = {
+      fs = FileSystem.get(conf)
       client = new HiveMetaStoreClient(hiveConf)
     }
+    kerberosLogin.fold(initialize())(_.run(initialize()))
 
-    if (fs == null) {
-      val conf = new Configuration()
-      conf.set("fs.defaultFS", configs.get(SinkConfigSettings.FsDefaultKey))
-      fs = FileSystem.get(conf)
+    val databases = execute(client.getAllDatabases)
+    if (!databases.contains(config.dbName.value)) {
+      throw new ConnectException(
+        s"Cannot find database [${config.dbName.value}]. Current database(-s): ${databases.asScala.mkString(",")}. Please make sure the database is created before sinking to it."
+      )
     }
-
-    config = HiveSourceConfig.fromProps(configs.asScala.toMap)
 
     sources = config.tableOptions.map { options =>
       new HiveSource(
@@ -60,14 +102,27 @@ class HiveSourceTask extends SourceTask with StrictLogging {
       )(client, fs)
     }
 
-    iterator = sources.reduce((a: Iterator[SourceRecord], b: Iterator[SourceRecord]) => a ++ b)
+    iterator = sources.reduce(
+      (a: Iterator[SourceRecord], b: Iterator[SourceRecord]) => a ++ b
+    )
   }
 
   override def poll(): util.List[SourceRecord] = {
     iterator.take(config.pollSize).toList.asJava
   }
 
-  override def stop(): Unit = sources.foreach(_.close)
+  override def stop(): Unit = {
+    sources.foreach(_.close())
+    kerberosLogin.foreach(_.close())
+    kerberosLogin = None
+  }
 
   override def version(): String = manifest.version()
+
+  private def execute[T](thunk: => T): T = {
+    kerberosLogin match {
+      case None        => thunk
+      case Some(login) => login.run(thunk)
+    }
+  }
 }

--- a/kafka-connect-hive-1.1/src/main/scala/com/landoop/streamreactor/connect/hive/source/config/HiveSourceConfig.scala
+++ b/kafka-connect-hive-1.1/src/main/scala/com/landoop/streamreactor/connect/hive/source/config/HiveSourceConfig.scala
@@ -3,20 +3,28 @@ package com.landoop.streamreactor.connect.hive.source.config
 import java.util.Collections
 
 import cats.data.NonEmptyList
-import com.landoop.streamreactor.connect.hive.{DatabaseName, TableName, Topic}
+import com.landoop.streamreactor.connect.hive.DatabaseName
+import com.landoop.streamreactor.connect.hive.TableName
+import com.landoop.streamreactor.connect.hive.Topic
+import com.landoop.streamreactor.connect.hive.HadoopConfiguration
+import com.landoop.streamreactor.connect.hive.kerberos.Kerberos
 
 import scala.collection.JavaConverters._
 
 case class ProjectionField(name: String, alias: String)
 
 case class HiveSourceConfig(dbName: DatabaseName,
+                            kerberos: Option[Kerberos],
+                            hadoopConfiguration: HadoopConfiguration,
                             tableOptions: Set[SourceTableOptions] = Set.empty,
                             pollSize: Int = 1024)
 
-case class SourceTableOptions(tableName: TableName,
-                              topic: Topic,
-                              projection: Option[NonEmptyList[ProjectionField]] = None,
-                              limit: Int = Int.MaxValue)
+case class SourceTableOptions(
+  tableName: TableName,
+  topic: Topic,
+  projection: Option[NonEmptyList[ProjectionField]] = None,
+  limit: Int = Int.MaxValue
+)
 
 object HiveSourceConfig {
 
@@ -24,15 +32,18 @@ object HiveSourceConfig {
 
     val config = HiveSourceConfigDefBuilder(props.asJava)
     val tables = config.getKCQL.map { kcql =>
-
-      val fields = Option(kcql.getFields).getOrElse(Collections.emptyList).asScala.toList.map { field =>
-        ProjectionField(field.getName, field.getAlias)
-      }
+      val fields = Option(kcql.getFields)
+        .getOrElse(Collections.emptyList)
+        .asScala
+        .toList
+        .map { field =>
+          ProjectionField(field.getName, field.getAlias)
+        }
 
       val projection = fields match {
-        case Nil => None
+        case Nil                              => None
         case ProjectionField("*", "*") :: Nil => None
-        case _ => NonEmptyList.fromList(fields)
+        case _                                => NonEmptyList.fromList(fields)
       }
 
       SourceTableOptions(
@@ -46,7 +57,13 @@ object HiveSourceConfig {
     HiveSourceConfig(
       dbName = DatabaseName(props(HiveSourceConfigConstants.DatabaseNameKey)),
       tableOptions = tables,
-      props.getOrElse(HiveSourceConfigConstants.PollSizeKey, 1024).toString.toInt
+      kerberos = Kerberos.from(config, HiveSourceConfigConstants),
+      hadoopConfiguration =
+        HadoopConfiguration.from(config, HiveSourceConfigConstants),
+      pollSize = props
+        .getOrElse(HiveSourceConfigConstants.PollSizeKey, 1024)
+        .toString
+        .toInt
     )
   }
 }

--- a/kafka-connect-hive-1.1/src/main/scala/com/landoop/streamreactor/connect/hive/source/config/HiveSourceConfigConstants.scala
+++ b/kafka-connect-hive-1.1/src/main/scala/com/landoop/streamreactor/connect/hive/source/config/HiveSourceConfigConstants.scala
@@ -1,18 +1,25 @@
 package com.landoop.streamreactor.connect.hive.source.config
 
-import com.datamountaineer.streamreactor.connect.config.base.const.TraitConfigConst.{KCQL_PROP_SUFFIX, PROGRESS_ENABLED_CONST}
+import com.datamountaineer.streamreactor.connect.config.base.const.TraitConfigConst.KCQL_PROP_SUFFIX
+import com.datamountaineer.streamreactor.connect.config.base.const.TraitConfigConst.PROGRESS_ENABLED_CONST
+import com.landoop.streamreactor.connect.hive.HadoopConfigurationConstants
+import com.landoop.streamreactor.connect.hive.kerberos.KerberosSettings
 
-object HiveSourceConfigConstants {
+object HiveSourceConfigConstants
+    extends KerberosSettings
+    with HadoopConfigurationConstants {
 
   val CONNECTOR_PREFIX = "connect.hive"
 
   val KcqlKey = s"$CONNECTOR_PREFIX.$KCQL_PROP_SUFFIX"
   val KCQL_CONFIG = s"$CONNECTOR_PREFIX.$KCQL_PROP_SUFFIX"
-  val KCQL_DOC = "Contains the Kafka Connect Query Language describing the flow from Apache Hive tables to Apache Kafka topics"
+  val KCQL_DOC =
+    "Contains the Kafka Connect Query Language describing the flow from Apache Hive tables to Apache Kafka topics"
   val KCQL_DISPLAY = "KCQL commands"
 
   val PROGRESS_COUNTER_ENABLED = PROGRESS_ENABLED_CONST
-  val PROGRESS_COUNTER_ENABLED_DOC = "Enables the output for how many records have been processed"
+  val PROGRESS_COUNTER_ENABLED_DOC =
+    "Enables the output for how many records have been processed"
   val PROGRESS_COUNTER_ENABLED_DEFAULT = false
   val PROGRESS_COUNTER_ENABLED_DISPLAY = "Enable progress counter"
 

--- a/kafka-connect-hive-1.1/src/test/scala/com/landoop/streamreactor/connect/hive/source/HiveSourceTest.scala
+++ b/kafka-connect-hive-1.1/src/test/scala/com/landoop/streamreactor/connect/hive/source/HiveSourceTest.scala
@@ -23,7 +23,11 @@ import org.scalatest.WordSpec
 import scala.collection.JavaConverters._
 import scala.util.Try
 
-class HiveSourceTest extends WordSpec with Matchers with HiveTestConfig with StrictLogging {
+class HiveSourceTest
+    extends WordSpec
+    with Matchers
+    with HiveTestConfig
+    with StrictLogging {
 
   val dbname = "source_test2"
 
@@ -36,38 +40,74 @@ class HiveSourceTest extends WordSpec with Matchers with HiveTestConfig with Str
   }
 
   Try {
-    client.createDatabase(new Database(dbname, null, s"/user/hive/warehouse/$dbname", new util.HashMap()))
+    client.createDatabase(
+      new Database(
+        dbname,
+        null,
+        s"/user/hive/warehouse/$dbname",
+        new util.HashMap()
+      )
+    )
   }
 
-  val schema = SchemaBuilder.struct()
+  val schema = SchemaBuilder
+    .struct()
     .field("name", SchemaBuilder.string().required().build())
     .field("title", SchemaBuilder.string().optional().build())
     .field("salary", SchemaBuilder.float64().optional().build())
     .build()
 
-  def populateEmployees(table: String, partitions: Seq[PartitionField] = Nil): Unit = {
+  def populateEmployees(table: String,
+                        partitions: Seq[PartitionField] = Nil): Unit = {
     Try {
       client.dropTable(dbname, table, true, true)
     }
     val users = List(
-      new Struct(schema).put("name", "sam").put("title", "mr").put("salary", 100.43),
-      new Struct(schema).put("name", "laura").put("title", "ms").put("salary", 429.06),
-      new Struct(schema).put("name", "stef").put("title", "ms").put("salary", 329.06),
-      new Struct(schema).put("name", "andrew").put("title", "mr").put("salary", 529.06),
-      new Struct(schema).put("name", "ant").put("title", "mr").put("salary", 629.06),
-      new Struct(schema).put("name", "tom").put("title", "miss").put("salary", 395.44)
+      new Struct(schema)
+        .put("name", "sam")
+        .put("title", "mr")
+        .put("salary", 100.43),
+      new Struct(schema)
+        .put("name", "laura")
+        .put("title", "ms")
+        .put("salary", 429.06),
+      new Struct(schema)
+        .put("name", "stef")
+        .put("title", "ms")
+        .put("salary", 329.06),
+      new Struct(schema)
+        .put("name", "andrew")
+        .put("title", "mr")
+        .put("salary", 529.06),
+      new Struct(schema)
+        .put("name", "ant")
+        .put("title", "mr")
+        .put("salary", 629.06),
+      new Struct(schema)
+        .put("name", "tom")
+        .put("title", "miss")
+        .put("salary", 395.44)
     )
 
-    val sinkConfig = HiveSinkConfig(DatabaseName(dbname), tableOptions = Set(
-      TableOptions(TableName(table), Topic("mytopic"), true, true, partitions = partitions)
-    ),
+    val sinkConfig = HiveSinkConfig(
+      DatabaseName(dbname),
+      tableOptions = Set(
+        TableOptions(
+          TableName(table),
+          Topic("mytopic"),
+          true,
+          true,
+          partitions = partitions
+        )
+      ),
       kerberos = None,
       hadoopConfiguration = HadoopConfiguration.Empty
     )
 
     val sink = HiveSink.from(TableName(table), sinkConfig)
-    users.zipWithIndex.foreach { case (user, k) =>
-      sink.write(user, TopicPartitionOffset(Topic("mytopic"), 1, Offset(k)))
+    users.zipWithIndex.foreach {
+      case (user, k) =>
+        sink.write(user, TopicPartitionOffset(Topic("mytopic"), 1, Offset(k)))
     }
     sink.close()
   }
@@ -79,13 +119,34 @@ class HiveSourceTest extends WordSpec with Matchers with HiveTestConfig with Str
       val table = "employees"
       populateEmployees(table)
 
-      val reader = new HiveSourceOffsetStorageReader(new MockOffsetStorageReader(Map.empty))
-      val sourceConfig = HiveSourceConfig(DatabaseName(dbname), tableOptions = Set(
-        SourceTableOptions(TableName(table), Topic("mytopic"))
-      ))
-      val source = new HiveSource(DatabaseName(dbname), TableName(table), Topic("mytopic"), reader, sourceConfig)
-      source.toList.map(_.value.asInstanceOf[Struct]).map(StructUtils.extractValues) shouldBe
-        List(Vector("sam", "mr", 100.43), Vector("laura", "ms", 429.06), Vector("stef", "ms", 329.06), Vector("andrew", "mr", 529.06), Vector("ant", "mr", 629.06), Vector("tom", "miss", 395.44))
+      val reader = new HiveSourceOffsetStorageReader(
+        new MockOffsetStorageReader(Map.empty)
+      )
+      val sourceConfig = HiveSourceConfig(
+        DatabaseName(dbname),
+        tableOptions =
+          Set(SourceTableOptions(TableName(table), Topic("mytopic"))),
+        kerberos = None,
+        hadoopConfiguration = HadoopConfiguration.Empty
+      )
+      val source = new HiveSource(
+        DatabaseName(dbname),
+        TableName(table),
+        Topic("mytopic"),
+        reader,
+        sourceConfig
+      )
+      source.toList
+        .map(_.value.asInstanceOf[Struct])
+        .map(StructUtils.extractValues) shouldBe
+        List(
+          Vector("sam", "mr", 100.43),
+          Vector("laura", "ms", 429.06),
+          Vector("stef", "ms", 329.06),
+          Vector("andrew", "mr", 529.06),
+          Vector("ant", "mr", 629.06),
+          Vector("tom", "miss", 395.44)
+        )
     }
 
     "apply a projection to the read of a non-partitioned table" in {
@@ -93,15 +154,50 @@ class HiveSourceTest extends WordSpec with Matchers with HiveTestConfig with Str
       val table = "employees"
       populateEmployees(table)
 
-      val reader = new HiveSourceOffsetStorageReader(new MockOffsetStorageReader(Map.empty))
-      val sourceConfig = HiveSourceConfig(DatabaseName(dbname), tableOptions = Set(
-        SourceTableOptions(TableName(table), Topic("mytopic"), projection = Some(NonEmptyList.of(ProjectionField("title", "title"), ProjectionField("name", "name"))))
-      ))
-      val source = new HiveSource(DatabaseName(dbname), TableName(table), Topic("mytopic"), reader, sourceConfig)
+      val reader = new HiveSourceOffsetStorageReader(
+        new MockOffsetStorageReader(Map.empty)
+      )
+      val sourceConfig = HiveSourceConfig(
+        DatabaseName(dbname),
+        tableOptions = Set(
+          SourceTableOptions(
+            TableName(table),
+            Topic("mytopic"),
+            projection = Some(
+              NonEmptyList.of(
+                ProjectionField("title", "title"),
+                ProjectionField("name", "name")
+              )
+            )
+          )
+        ),
+        kerberos = None,
+        hadoopConfiguration = HadoopConfiguration.Empty
+      )
+      val source = new HiveSource(
+        DatabaseName(dbname),
+        TableName(table),
+        Topic("mytopic"),
+        reader,
+        sourceConfig
+      )
       val records = source.toList
-      records.head.valueSchema.fields().asScala.map(_.name) shouldBe Seq("title", "name")
-      records.map(_.value.asInstanceOf[Struct]).map(StructUtils.extractValues).toSet shouldBe
-        Set(Vector("mr", "ant"), Vector("miss", "tom"), Vector("ms", "stef"), Vector("ms", "laura"), Vector("mr", "andrew"), Vector("mr", "sam"))
+      records.head.valueSchema.fields().asScala.map(_.name) shouldBe Seq(
+        "title",
+        "name"
+      )
+      records
+        .map(_.value.asInstanceOf[Struct])
+        .map(StructUtils.extractValues)
+        .toSet shouldBe
+        Set(
+          Vector("mr", "ant"),
+          Vector("miss", "tom"),
+          Vector("ms", "stef"),
+          Vector("ms", "laura"),
+          Vector("mr", "andrew"),
+          Vector("mr", "sam")
+        )
     }
 
     "apply a projection with aliases to the read of a non-partitioned table" in {
@@ -109,15 +205,50 @@ class HiveSourceTest extends WordSpec with Matchers with HiveTestConfig with Str
       val table = "employees"
       populateEmployees(table)
 
-      val reader = new HiveSourceOffsetStorageReader(new MockOffsetStorageReader(Map.empty))
-      val sourceConfig = HiveSourceConfig(DatabaseName(dbname), tableOptions = Set(
-        SourceTableOptions(TableName(table), Topic("mytopic"), projection = Some(NonEmptyList.of(ProjectionField("title", "salutation"), ProjectionField("name", "name"))))
-      ))
-      val source = new HiveSource(DatabaseName(dbname), TableName(table), Topic("mytopic"), reader, sourceConfig)
+      val reader = new HiveSourceOffsetStorageReader(
+        new MockOffsetStorageReader(Map.empty)
+      )
+      val sourceConfig = HiveSourceConfig(
+        DatabaseName(dbname),
+        tableOptions = Set(
+          SourceTableOptions(
+            TableName(table),
+            Topic("mytopic"),
+            projection = Some(
+              NonEmptyList.of(
+                ProjectionField("title", "salutation"),
+                ProjectionField("name", "name")
+              )
+            )
+          )
+        ),
+        kerberos = None,
+        hadoopConfiguration = HadoopConfiguration.Empty
+      )
+      val source = new HiveSource(
+        DatabaseName(dbname),
+        TableName(table),
+        Topic("mytopic"),
+        reader,
+        sourceConfig
+      )
       val records = source.toList
-      records.head.valueSchema.fields().asScala.map(_.name) shouldBe Seq("salutation", "name")
-      records.map(_.value.asInstanceOf[Struct]).map(StructUtils.extractValues).toSet shouldBe
-        Set(Vector("mr", "ant"), Vector("miss", "tom"), Vector("ms", "stef"), Vector("ms", "laura"), Vector("mr", "andrew"), Vector("mr", "sam"))
+      records.head.valueSchema.fields().asScala.map(_.name) shouldBe Seq(
+        "salutation",
+        "name"
+      )
+      records
+        .map(_.value.asInstanceOf[Struct])
+        .map(StructUtils.extractValues)
+        .toSet shouldBe
+        Set(
+          Vector("mr", "ant"),
+          Vector("miss", "tom"),
+          Vector("ms", "stef"),
+          Vector("ms", "laura"),
+          Vector("mr", "andrew"),
+          Vector("mr", "sam")
+        )
     }
 
     "read from a partitioned table" in {
@@ -125,13 +256,35 @@ class HiveSourceTest extends WordSpec with Matchers with HiveTestConfig with Str
       val table = "employees_partitioned"
       populateEmployees(table, partitions = Seq(PartitionField("title")))
 
-      val reader = new HiveSourceOffsetStorageReader(new MockOffsetStorageReader(Map.empty))
-      val sourceConfig = HiveSourceConfig(DatabaseName(dbname), tableOptions = Set(
-        SourceTableOptions(TableName(table), Topic("mytopic"))
-      ))
-      val source = new HiveSource(DatabaseName(dbname), TableName(table), Topic("mytopic"), reader, sourceConfig)
-      source.map(_.value.asInstanceOf[Struct]).map(StructUtils.extractValues).toSet shouldBe
-        Set(Vector("tom", 395.44, "miss"), Vector("sam", 100.43, "mr"), Vector("andrew", 529.06, "mr"), Vector("ant", 629.06, "mr"), Vector("laura", 429.06, "ms"), Vector("stef", 329.06, "ms"))
+      val reader = new HiveSourceOffsetStorageReader(
+        new MockOffsetStorageReader(Map.empty)
+      )
+      val sourceConfig = HiveSourceConfig(
+        DatabaseName(dbname),
+        tableOptions =
+          Set(SourceTableOptions(TableName(table), Topic("mytopic"))),
+        kerberos = None,
+        hadoopConfiguration = HadoopConfiguration.Empty
+      )
+      val source = new HiveSource(
+        DatabaseName(dbname),
+        TableName(table),
+        Topic("mytopic"),
+        reader,
+        sourceConfig
+      )
+      source
+        .map(_.value.asInstanceOf[Struct])
+        .map(StructUtils.extractValues)
+        .toSet shouldBe
+        Set(
+          Vector("tom", 395.44, "miss"),
+          Vector("sam", 100.43, "mr"),
+          Vector("andrew", 529.06, "mr"),
+          Vector("ant", 629.06, "mr"),
+          Vector("laura", 429.06, "ms"),
+          Vector("stef", 329.06, "ms")
+        )
     }
 
     "apply a projection to the read of a partitioned table" in {
@@ -139,48 +292,121 @@ class HiveSourceTest extends WordSpec with Matchers with HiveTestConfig with Str
       val table = "employees_partitioned"
       populateEmployees(table, partitions = Seq(PartitionField("title")))
 
-      val reader = new HiveSourceOffsetStorageReader(new MockOffsetStorageReader(Map.empty))
-      val sourceConfig = HiveSourceConfig(DatabaseName(dbname), tableOptions = Set(
-        SourceTableOptions(TableName(table), Topic("mytopic"), projection = Some(NonEmptyList.of(ProjectionField("title", "title"), ProjectionField("name", "name"))))
-      ))
-      val source = new HiveSource(DatabaseName(dbname), TableName(table), Topic("mytopic"), reader, sourceConfig)
-      source.map(_.value.asInstanceOf[Struct]).map(StructUtils.extractValues).toSet shouldBe
-        Set(Vector("mr", "ant"), Vector("miss", "tom"), Vector("ms", "stef"), Vector("ms", "laura"), Vector("mr", "andrew"), Vector("mr", "sam"))
+      val reader = new HiveSourceOffsetStorageReader(
+        new MockOffsetStorageReader(Map.empty)
+      )
+      val sourceConfig = HiveSourceConfig(
+        DatabaseName(dbname),
+        tableOptions = Set(
+          SourceTableOptions(
+            TableName(table),
+            Topic("mytopic"),
+            projection = Some(
+              NonEmptyList.of(
+                ProjectionField("title", "title"),
+                ProjectionField("name", "name")
+              )
+            )
+          )
+        ),
+        kerberos = None,
+        hadoopConfiguration = HadoopConfiguration.Empty
+      )
+      val source = new HiveSource(
+        DatabaseName(dbname),
+        TableName(table),
+        Topic("mytopic"),
+        reader,
+        sourceConfig
+      )
+      source
+        .map(_.value.asInstanceOf[Struct])
+        .map(StructUtils.extractValues)
+        .toSet shouldBe
+        Set(
+          Vector("mr", "ant"),
+          Vector("miss", "tom"),
+          Vector("ms", "stef"),
+          Vector("ms", "laura"),
+          Vector("mr", "andrew"),
+          Vector("mr", "sam")
+        )
     }
 
     "adhere to a LIMIT" in {
       val table = "employees"
       populateEmployees(table)
 
-      val reader = new HiveSourceOffsetStorageReader(new MockOffsetStorageReader(Map.empty))
-      val sourceConfig = HiveSourceConfig(DatabaseName(dbname), tableOptions = Set(
-        SourceTableOptions(TableName(table), Topic("mytopic"), limit = 3)
-      ))
+      val reader = new HiveSourceOffsetStorageReader(
+        new MockOffsetStorageReader(Map.empty)
+      )
+      val sourceConfig = HiveSourceConfig(
+        DatabaseName(dbname),
+        tableOptions = Set(
+          SourceTableOptions(TableName(table), Topic("mytopic"), limit = 3)
+        ),
+        kerberos = None,
+        hadoopConfiguration = HadoopConfiguration.Empty
+      )
 
-      val source = new HiveSource(DatabaseName(dbname), TableName(table), Topic("mytopic"), reader, sourceConfig)
-      source.toList.map(_.value.asInstanceOf[Struct]).map(StructUtils.extractValues) shouldBe
-        List(Vector("sam", "mr", 100.43), Vector("laura", "ms", 429.06), Vector("stef", "ms", 329.06))
+      val source = new HiveSource(
+        DatabaseName(dbname),
+        TableName(table),
+        Topic("mytopic"),
+        reader,
+        sourceConfig
+      )
+      source.toList
+        .map(_.value.asInstanceOf[Struct])
+        .map(StructUtils.extractValues) shouldBe
+        List(
+          Vector("sam", "mr", 100.43),
+          Vector("laura", "ms", 429.06),
+          Vector("stef", "ms", 329.06)
+        )
     }
 
     "set offset and partition on each record" in {
       val table = "employees"
       populateEmployees(table)
 
-      val reader = new HiveSourceOffsetStorageReader(new MockOffsetStorageReader(Map.empty))
-      val sourceConfig = HiveSourceConfig(DatabaseName(dbname), tableOptions = Set(
-        SourceTableOptions(TableName(table), Topic("mytopic"))
-      ))
+      val reader = new HiveSourceOffsetStorageReader(
+        new MockOffsetStorageReader(Map.empty)
+      )
+      val sourceConfig = HiveSourceConfig(
+        DatabaseName(dbname),
+        tableOptions =
+          Set(SourceTableOptions(TableName(table), Topic("mytopic"))),
+        kerberos = None,
+        hadoopConfiguration = HadoopConfiguration.Empty
+      )
 
-      val source = new HiveSource(DatabaseName(dbname), TableName(table), Topic("mytopic"), reader, sourceConfig)
+      val source = new HiveSource(
+        DatabaseName(dbname),
+        TableName(table),
+        Topic("mytopic"),
+        reader,
+        sourceConfig
+      )
       val list = source.toList
       list.head.sourcePartition() shouldBe
-        Map("db" -> dbname, "table" -> table, "topic" -> "mytopic", "path" -> s"hdfs://localhost:8020/user/hive/warehouse/$dbname/$table/streamreactor_mytopic_1_5").asJava
+        Map(
+          "db" -> dbname,
+          "table" -> table,
+          "topic" -> "mytopic",
+          "path" -> s"hdfs://localhost:8020/user/hive/warehouse/$dbname/$table/streamreactor_mytopic_1_5"
+        ).asJava
 
       list.head.sourceOffset() shouldBe
         Map("rownum" -> "0").asJava
 
       list.last.sourcePartition() shouldBe
-        Map("db" -> dbname, "table" -> table, "topic" -> "mytopic", "path" -> s"hdfs://localhost:8020/user/hive/warehouse/$dbname/$table/streamreactor_mytopic_1_5").asJava
+        Map(
+          "db" -> dbname,
+          "table" -> table,
+          "topic" -> "mytopic",
+          "path" -> s"hdfs://localhost:8020/user/hive/warehouse/$dbname/$table/streamreactor_mytopic_1_5"
+        ).asJava
 
       list.last.sourceOffset() shouldBe
         Map("rownum" -> "5").asJava
@@ -194,17 +420,38 @@ class HiveSourceTest extends WordSpec with Matchers with HiveTestConfig with Str
         DatabaseName(dbname),
         TableName(table),
         Topic("mytopic"),
-        new Path(s"hdfs://localhost:8020/user/hive/warehouse/$dbname/$table/streamreactor_mytopic_1_5")
+        new Path(
+          s"hdfs://localhost:8020/user/hive/warehouse/$dbname/$table/streamreactor_mytopic_1_5"
+        )
       )
       val sourceOffset = SourceOffset(2)
-      val reader = new HiveSourceOffsetStorageReader(new MockOffsetStorageReader(Map(sourcePartition -> sourceOffset)))
+      val reader = new HiveSourceOffsetStorageReader(
+        new MockOffsetStorageReader(Map(sourcePartition -> sourceOffset))
+      )
 
-      val sourceConfig = HiveSourceConfig(DatabaseName(dbname), tableOptions = Set(
-        SourceTableOptions(TableName(table), Topic("mytopic"))
-      ))
-      val source = new HiveSource(DatabaseName(dbname), TableName(table), Topic("mytopic"), reader, sourceConfig)
-      source.toList.map(_.value.asInstanceOf[Struct]).map(StructUtils.extractValues) shouldBe
-        List(Vector("stef", "ms", 329.06), Vector("andrew", "mr", 529.06), Vector("ant", "mr", 629.06), Vector("tom", "miss", 395.44))
+      val sourceConfig = HiveSourceConfig(
+        DatabaseName(dbname),
+        tableOptions =
+          Set(SourceTableOptions(TableName(table), Topic("mytopic"))),
+        kerberos = None,
+        hadoopConfiguration = HadoopConfiguration.Empty
+      )
+      val source = new HiveSource(
+        DatabaseName(dbname),
+        TableName(table),
+        Topic("mytopic"),
+        reader,
+        sourceConfig
+      )
+      source.toList
+        .map(_.value.asInstanceOf[Struct])
+        .map(StructUtils.extractValues) shouldBe
+        List(
+          Vector("stef", "ms", 329.06),
+          Vector("andrew", "mr", 529.06),
+          Vector("ant", "mr", 629.06),
+          Vector("tom", "miss", 395.44)
+        )
     }
 
     "skip records based on offset storage before applying limit" in {
@@ -215,16 +462,33 @@ class HiveSourceTest extends WordSpec with Matchers with HiveTestConfig with Str
         DatabaseName(dbname),
         TableName(table),
         Topic("mytopic"),
-        new Path(s"hdfs://localhost:8020/user/hive/warehouse/$dbname/$table/streamreactor_mytopic_1_5")
+        new Path(
+          s"hdfs://localhost:8020/user/hive/warehouse/$dbname/$table/streamreactor_mytopic_1_5"
+        )
       )
       val sourceOffset = SourceOffset(2)
-      val reader = new HiveSourceOffsetStorageReader(new MockOffsetStorageReader(Map(sourcePartition -> sourceOffset)))
+      val reader = new HiveSourceOffsetStorageReader(
+        new MockOffsetStorageReader(Map(sourcePartition -> sourceOffset))
+      )
 
-      val sourceConfig = HiveSourceConfig(DatabaseName(dbname), tableOptions = Set(
-        SourceTableOptions(TableName(table), Topic("mytopic"), limit = 2)
-      ))
-      val source = new HiveSource(DatabaseName(dbname), TableName(table), Topic("mytopic"), reader, sourceConfig)
-      source.toList.map(_.value.asInstanceOf[Struct]).map(StructUtils.extractValues) shouldBe
+      val sourceConfig = HiveSourceConfig(
+        DatabaseName(dbname),
+        tableOptions = Set(
+          SourceTableOptions(TableName(table), Topic("mytopic"), limit = 2)
+        ),
+        kerberos = None,
+        hadoopConfiguration = HadoopConfiguration.Empty
+      )
+      val source = new HiveSource(
+        DatabaseName(dbname),
+        TableName(table),
+        Topic("mytopic"),
+        reader,
+        sourceConfig
+      )
+      source.toList
+        .map(_.value.asInstanceOf[Struct])
+        .map(StructUtils.extractValues) shouldBe
         List(Vector("stef", "ms", 329.06), Vector("andrew", "mr", 529.06))
     }
 
@@ -236,15 +500,30 @@ class HiveSourceTest extends WordSpec with Matchers with HiveTestConfig with Str
         DatabaseName(dbname),
         TableName(table),
         Topic("mytopic"),
-        new Path(s"hdfs://localhost:8020/user/hive/warehouse/$dbname/$table/streamreactor_mytopic_1_5")
+        new Path(
+          s"hdfs://localhost:8020/user/hive/warehouse/$dbname/$table/streamreactor_mytopic_1_5"
+        )
       )
       val sourceOffset = SourceOffset(44)
-      val reader = new HiveSourceOffsetStorageReader(new MockOffsetStorageReader(Map(sourcePartition -> sourceOffset)))
+      val reader = new HiveSourceOffsetStorageReader(
+        new MockOffsetStorageReader(Map(sourcePartition -> sourceOffset))
+      )
 
-      val sourceConfig = HiveSourceConfig(DatabaseName(dbname), tableOptions = Set(
-        SourceTableOptions(TableName(table), Topic("mytopic"), limit = 2)
-      ))
-      val source = new HiveSource(DatabaseName(dbname), TableName(table), Topic("mytopic"), reader, sourceConfig)
+      val sourceConfig = HiveSourceConfig(
+        DatabaseName(dbname),
+        tableOptions = Set(
+          SourceTableOptions(TableName(table), Topic("mytopic"), limit = 2)
+        ),
+        kerberos = None,
+        hadoopConfiguration = HadoopConfiguration.Empty
+      )
+      val source = new HiveSource(
+        DatabaseName(dbname),
+        TableName(table),
+        Topic("mytopic"),
+        reader,
+        sourceConfig
+      )
       source.toList.isEmpty shouldBe true
     }
   }

--- a/kafka-connect-hive/src/main/scala/com/landoop/streamreactor/connect/hive/HadoopConfigurationExtension.scala
+++ b/kafka-connect-hive/src/main/scala/com/landoop/streamreactor/connect/hive/HadoopConfigurationExtension.scala
@@ -6,7 +6,6 @@ import com.landoop.streamreactor.connect.hive.kerberos.Kerberos
 import com.landoop.streamreactor.connect.hive.kerberos.KeytabSettings
 import com.landoop.streamreactor.connect.hive.kerberos.UserPasswordSettings
 import org.apache.hadoop.conf.Configuration
-import org.apache.hadoop.security.SecurityUtil
 
 object HadoopConfigurationExtension {
 

--- a/kafka-connect-hive/src/main/scala/com/landoop/streamreactor/connect/hive/source/HiveSourceTask.scala
+++ b/kafka-connect-hive/src/main/scala/com/landoop/streamreactor/connect/hive/source/HiveSourceTask.scala
@@ -6,25 +6,32 @@ import com.datamountaineer.streamreactor.connect.utils.JarManifest
 import com.landoop.streamreactor.connect.hive.sink.config.SinkConfigSettings
 import com.landoop.streamreactor.connect.hive.source.config.HiveSourceConfig
 import com.landoop.streamreactor.connect.hive.source.offset.HiveSourceOffsetStorageReader
+import com.landoop.streamreactor.connect.hive.ConfigurationBuilder
+import com.landoop.streamreactor.connect.hive.kerberos.KerberosLogin
+import com.landoop.streamreactor.connect.hive.HadoopConfigurationExtension._
 import com.typesafe.scalalogging.slf4j.StrictLogging
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.FileSystem
-import org.apache.hadoop.hive.conf.HiveConf
 import org.apache.hadoop.hive.metastore.HiveMetaStoreClient
+import org.apache.kafka.connect.errors.ConnectException
 import org.apache.kafka.connect.source.SourceRecord
 import org.apache.kafka.connect.source.SourceTask
 
 import scala.collection.JavaConverters._
+import scala.util.Try
 
 class HiveSourceTask extends SourceTask with StrictLogging {
 
-  private val manifest = JarManifest(getClass.getProtectionDomain.getCodeSource.getLocation)
+  private val manifest = JarManifest(
+    getClass.getProtectionDomain.getCodeSource.getLocation
+  )
   private var client: HiveMetaStoreClient = _
   private var fs: FileSystem = _
   private var config: HiveSourceConfig = _
 
   private var sources: Set[HiveSource] = Set.empty
   private var iterator: Iterator[SourceRecord] = Iterator.empty
+  private var kerberosLogin = Option.empty[KerberosLogin]
 
   def this(fs: FileSystem, client: HiveMetaStoreClient) {
     this()
@@ -35,21 +42,55 @@ class HiveSourceTask extends SourceTask with StrictLogging {
   override def start(props: util.Map[String, String]): Unit = {
     val configs = if (context.configs().isEmpty) props else context.configs()
 
-    if (client == null) {
-      val hiveConf = new HiveConf()
-      hiveConf.set("hive.metastore", configs.get(SinkConfigSettings.MetastoreTypeKey))
-      hiveConf.set("hive.metastore.uris", configs.get(SinkConfigSettings.MetastoreUrisKey))
-      client = new HiveMetaStoreClient(hiveConf)
-    }
-
-    if (fs == null) {
-      val conf = new Configuration()
-      conf.set("fs.defaultFS", configs.get(SinkConfigSettings.FsDefaultKey))
-      fs = FileSystem.get(conf)
-    }
-
     config = HiveSourceConfig.fromProps(configs.asScala.toMap)
 
+    Option(fs).foreach(fs => Try(fs.close()))
+    Option(client).foreach(c => Try(c.close()))
+
+    val conf: Configuration =
+      ConfigurationBuilder.buildHdfsConfiguration(config.hadoopConfiguration)
+    conf.set("fs.defaultFS", configs.get(SinkConfigSettings.FsDefaultKey))
+
+    kerberosLogin = config.kerberos.map { kerberos =>
+      conf.withKerberos(kerberos)
+      KerberosLogin.from(kerberos, conf)
+    }
+
+    val hiveConf =
+      ConfigurationBuilder.buildHiveConfig(config.hadoopConfiguration)
+    hiveConf.set("hive.metastore.local", "false")
+    hiveConf.set(
+      "hive.metastore",
+      configs.get(SinkConfigSettings.MetastoreTypeKey)
+    )
+    hiveConf.set(
+      "hive.metastore.uris",
+      configs.get(SinkConfigSettings.MetastoreUrisKey)
+    )
+    config.kerberos.foreach { _ =>
+      val principal =
+        Option(configs.get(SinkConfigSettings.HiveMetastorePrincipalKey))
+          .getOrElse {
+            throw new ConnectException(
+              s"Missing configuration for [${SinkConfigSettings.HiveMetastorePrincipalKey}]. When using Kerberos it is required to set the configuration."
+            )
+          }
+
+      hiveConf.set("hive.metastore.kerberos.principal", principal)
+    }
+
+    def initialize(): Unit = {
+      fs = FileSystem.get(conf)
+      client = new HiveMetaStoreClient(hiveConf)
+    }
+    kerberosLogin.fold(initialize())(_.run(initialize()))
+
+    val databases = execute(client.getAllDatabases)
+    if (!databases.contains(config.dbName.value)) {
+      throw new ConnectException(
+        s"Cannot find database [${config.dbName.value}]. Current database(-s): ${databases.asScala.mkString(",")}. Please make sure the database is created before sinking to it."
+      )
+    }
     sources = config.tableOptions.map { options =>
       new HiveSource(
         config.dbName,
@@ -60,14 +101,27 @@ class HiveSourceTask extends SourceTask with StrictLogging {
       )(client, fs)
     }
 
-    iterator = sources.reduce((a: Iterator[SourceRecord], b: Iterator[SourceRecord]) => a ++ b)
+    iterator = sources.reduce(
+      (a: Iterator[SourceRecord], b: Iterator[SourceRecord]) => a ++ b
+    )
   }
 
   override def poll(): util.List[SourceRecord] = {
     iterator.take(config.pollSize).toList.asJava
   }
 
-  override def stop(): Unit = sources.foreach(_.close)
+  override def stop(): Unit = {
+    sources.foreach(_.close())
+    kerberosLogin.foreach(_.close())
+    kerberosLogin = None
+  }
 
   override def version(): String = manifest.version()
+
+  private def execute[T](thunk: => T): T = {
+    kerberosLogin match {
+      case None        => thunk
+      case Some(login) => login.run(thunk)
+    }
+  }
 }

--- a/kafka-connect-hive/src/main/scala/com/landoop/streamreactor/connect/hive/source/config/HiveSourceConfig.scala
+++ b/kafka-connect-hive/src/main/scala/com/landoop/streamreactor/connect/hive/source/config/HiveSourceConfig.scala
@@ -3,20 +3,28 @@ package com.landoop.streamreactor.connect.hive.source.config
 import java.util.Collections
 
 import cats.data.NonEmptyList
-import com.landoop.streamreactor.connect.hive.{DatabaseName, TableName, Topic}
+import com.landoop.streamreactor.connect.hive.DatabaseName
+import com.landoop.streamreactor.connect.hive.HadoopConfiguration
+import com.landoop.streamreactor.connect.hive.TableName
+import com.landoop.streamreactor.connect.hive.Topic
+import com.landoop.streamreactor.connect.hive.kerberos.Kerberos
 
 import scala.collection.JavaConverters._
 
 case class ProjectionField(name: String, alias: String)
 
 case class HiveSourceConfig(dbName: DatabaseName,
+                            kerberos: Option[Kerberos],
+                            hadoopConfiguration: HadoopConfiguration,
                             tableOptions: Set[SourceTableOptions] = Set.empty,
                             pollSize: Int = 1024)
 
-case class SourceTableOptions(tableName: TableName,
-                              topic: Topic,
-                              projection: Option[NonEmptyList[ProjectionField]] = None,
-                              limit: Int = Int.MaxValue)
+case class SourceTableOptions(
+  tableName: TableName,
+  topic: Topic,
+  projection: Option[NonEmptyList[ProjectionField]] = None,
+  limit: Int = Int.MaxValue
+)
 
 object HiveSourceConfig {
 
@@ -24,15 +32,18 @@ object HiveSourceConfig {
 
     val config = HiveSourceConfigDefBuilder(props.asJava)
     val tables = config.getKCQL.map { kcql =>
-
-      val fields = Option(kcql.getFields).getOrElse(Collections.emptyList).asScala.toList.map { field =>
-        ProjectionField(field.getName, field.getAlias)
-      }
+      val fields = Option(kcql.getFields)
+        .getOrElse(Collections.emptyList)
+        .asScala
+        .toList
+        .map { field =>
+          ProjectionField(field.getName, field.getAlias)
+        }
 
       val projection = fields match {
-        case Nil => None
+        case Nil                              => None
         case ProjectionField("*", "*") :: Nil => None
-        case _ => NonEmptyList.fromList(fields)
+        case _                                => NonEmptyList.fromList(fields)
       }
 
       SourceTableOptions(
@@ -46,7 +57,13 @@ object HiveSourceConfig {
     HiveSourceConfig(
       dbName = DatabaseName(props(HiveSourceConfigConstants.DatabaseNameKey)),
       tableOptions = tables,
-      props.getOrElse(HiveSourceConfigConstants.PollSizeKey, 1024).toString.toInt
+      kerberos = Kerberos.from(config, HiveSourceConfigConstants),
+      hadoopConfiguration =
+        HadoopConfiguration.from(config, HiveSourceConfigConstants),
+      pollSize = props
+        .getOrElse(HiveSourceConfigConstants.PollSizeKey, 1024)
+        .toString
+        .toInt
     )
   }
 }

--- a/kafka-connect-hive/src/main/scala/com/landoop/streamreactor/connect/hive/source/config/HiveSourceConfigConstants.scala
+++ b/kafka-connect-hive/src/main/scala/com/landoop/streamreactor/connect/hive/source/config/HiveSourceConfigConstants.scala
@@ -1,18 +1,25 @@
 package com.landoop.streamreactor.connect.hive.source.config
 
-import com.datamountaineer.streamreactor.connect.config.base.const.TraitConfigConst.{KCQL_PROP_SUFFIX, PROGRESS_ENABLED_CONST}
+import com.datamountaineer.streamreactor.connect.config.base.const.TraitConfigConst.KCQL_PROP_SUFFIX
+import com.datamountaineer.streamreactor.connect.config.base.const.TraitConfigConst.PROGRESS_ENABLED_CONST
+import com.landoop.streamreactor.connect.hive.HadoopConfigurationConstants
+import com.landoop.streamreactor.connect.hive.kerberos.KerberosSettings
 
-object HiveSourceConfigConstants {
+object HiveSourceConfigConstants
+    extends KerberosSettings
+    with HadoopConfigurationConstants {
 
   val CONNECTOR_PREFIX = "connect.hive"
 
   val KcqlKey = s"$CONNECTOR_PREFIX.$KCQL_PROP_SUFFIX"
   val KCQL_CONFIG = s"$CONNECTOR_PREFIX.$KCQL_PROP_SUFFIX"
-  val KCQL_DOC = "Contains the Kafka Connect Query Language describing the flow from Apache Hive tables to Apache Kafka topics"
+  val KCQL_DOC =
+    "Contains the Kafka Connect Query Language describing the flow from Apache Hive tables to Apache Kafka topics"
   val KCQL_DISPLAY = "KCQL commands"
 
   val PROGRESS_COUNTER_ENABLED = PROGRESS_ENABLED_CONST
-  val PROGRESS_COUNTER_ENABLED_DOC = "Enables the output for how many records have been processed"
+  val PROGRESS_COUNTER_ENABLED_DOC =
+    "Enables the output for how many records have been processed"
   val PROGRESS_COUNTER_ENABLED_DEFAULT = false
   val PROGRESS_COUNTER_ENABLED_DISPLAY = "Enable progress counter"
 

--- a/kafka-connect-hive/src/test/scala/com/landoop/streamreactor/connect/hive/source/HiveSourceTest.scala
+++ b/kafka-connect-hive/src/test/scala/com/landoop/streamreactor/connect/hive/source/HiveSourceTest.scala
@@ -82,7 +82,8 @@ class HiveSourceTest extends WordSpec with Matchers with HiveTestConfig with Str
       val reader = new HiveSourceOffsetStorageReader(new MockOffsetStorageReader(Map.empty))
       val sourceConfig = HiveSourceConfig(DatabaseName(dbname), tableOptions = Set(
         SourceTableOptions(TableName(table), Topic("mytopic"))
-      ))
+      ), kerberos = None,
+        hadoopConfiguration = HadoopConfiguration.Empty)
       val source = new HiveSource(DatabaseName(dbname), TableName(table), Topic("mytopic"), reader, sourceConfig)
       source.toList.map(_.value.asInstanceOf[Struct]).map(StructUtils.extractValues) shouldBe
         List(Vector("sam", "mr", 100.43), Vector("laura", "ms", 429.06), Vector("stef", "ms", 329.06), Vector("andrew", "mr", 529.06), Vector("ant", "mr", 629.06), Vector("tom", "miss", 395.44))
@@ -96,7 +97,8 @@ class HiveSourceTest extends WordSpec with Matchers with HiveTestConfig with Str
       val reader = new HiveSourceOffsetStorageReader(new MockOffsetStorageReader(Map.empty))
       val sourceConfig = HiveSourceConfig(DatabaseName(dbname), tableOptions = Set(
         SourceTableOptions(TableName(table), Topic("mytopic"), projection = Some(NonEmptyList.of(ProjectionField("title", "title"), ProjectionField("name", "name"))))
-      ))
+      ), kerberos = None,
+        hadoopConfiguration = HadoopConfiguration.Empty)
       val source = new HiveSource(DatabaseName(dbname), TableName(table), Topic("mytopic"), reader, sourceConfig)
       val records = source.toList
       records.head.valueSchema.fields().asScala.map(_.name) shouldBe Seq("title", "name")
@@ -112,7 +114,8 @@ class HiveSourceTest extends WordSpec with Matchers with HiveTestConfig with Str
       val reader = new HiveSourceOffsetStorageReader(new MockOffsetStorageReader(Map.empty))
       val sourceConfig = HiveSourceConfig(DatabaseName(dbname), tableOptions = Set(
         SourceTableOptions(TableName(table), Topic("mytopic"), projection = Some(NonEmptyList.of(ProjectionField("title", "salutation"), ProjectionField("name", "name"))))
-      ))
+      ), kerberos = None,
+        hadoopConfiguration = HadoopConfiguration.Empty)
       val source = new HiveSource(DatabaseName(dbname), TableName(table), Topic("mytopic"), reader, sourceConfig)
       val records = source.toList
       records.head.valueSchema.fields().asScala.map(_.name) shouldBe Seq("salutation", "name")
@@ -128,7 +131,8 @@ class HiveSourceTest extends WordSpec with Matchers with HiveTestConfig with Str
       val reader = new HiveSourceOffsetStorageReader(new MockOffsetStorageReader(Map.empty))
       val sourceConfig = HiveSourceConfig(DatabaseName(dbname), tableOptions = Set(
         SourceTableOptions(TableName(table), Topic("mytopic"))
-      ))
+      ), kerberos = None,
+        hadoopConfiguration = HadoopConfiguration.Empty)
       val source = new HiveSource(DatabaseName(dbname), TableName(table), Topic("mytopic"), reader, sourceConfig)
       source.map(_.value.asInstanceOf[Struct]).map(StructUtils.extractValues).toSet shouldBe
         Set(Vector("tom", 395.44, "miss"), Vector("sam", 100.43, "mr"), Vector("andrew", 529.06, "mr"), Vector("ant", 629.06, "mr"), Vector("laura", 429.06, "ms"), Vector("stef", 329.06, "ms"))
@@ -142,7 +146,8 @@ class HiveSourceTest extends WordSpec with Matchers with HiveTestConfig with Str
       val reader = new HiveSourceOffsetStorageReader(new MockOffsetStorageReader(Map.empty))
       val sourceConfig = HiveSourceConfig(DatabaseName(dbname), tableOptions = Set(
         SourceTableOptions(TableName(table), Topic("mytopic"), projection = Some(NonEmptyList.of(ProjectionField("title", "title"), ProjectionField("name", "name"))))
-      ))
+      ), kerberos = None,
+        hadoopConfiguration = HadoopConfiguration.Empty)
       val source = new HiveSource(DatabaseName(dbname), TableName(table), Topic("mytopic"), reader, sourceConfig)
       source.map(_.value.asInstanceOf[Struct]).map(StructUtils.extractValues).toSet shouldBe
         Set(Vector("mr", "ant"), Vector("miss", "tom"), Vector("ms", "stef"), Vector("ms", "laura"), Vector("mr", "andrew"), Vector("mr", "sam"))
@@ -155,7 +160,8 @@ class HiveSourceTest extends WordSpec with Matchers with HiveTestConfig with Str
       val reader = new HiveSourceOffsetStorageReader(new MockOffsetStorageReader(Map.empty))
       val sourceConfig = HiveSourceConfig(DatabaseName(dbname), tableOptions = Set(
         SourceTableOptions(TableName(table), Topic("mytopic"), limit = 3)
-      ))
+      ), kerberos = None,
+        hadoopConfiguration = HadoopConfiguration.Empty)
 
       val source = new HiveSource(DatabaseName(dbname), TableName(table), Topic("mytopic"), reader, sourceConfig)
       source.toList.map(_.value.asInstanceOf[Struct]).map(StructUtils.extractValues) shouldBe
@@ -169,7 +175,8 @@ class HiveSourceTest extends WordSpec with Matchers with HiveTestConfig with Str
       val reader = new HiveSourceOffsetStorageReader(new MockOffsetStorageReader(Map.empty))
       val sourceConfig = HiveSourceConfig(DatabaseName(dbname), tableOptions = Set(
         SourceTableOptions(TableName(table), Topic("mytopic"))
-      ))
+      ), kerberos = None,
+        hadoopConfiguration = HadoopConfiguration.Empty)
 
       val source = new HiveSource(DatabaseName(dbname), TableName(table), Topic("mytopic"), reader, sourceConfig)
       val list = source.toList
@@ -201,7 +208,8 @@ class HiveSourceTest extends WordSpec with Matchers with HiveTestConfig with Str
 
       val sourceConfig = HiveSourceConfig(DatabaseName(dbname), tableOptions = Set(
         SourceTableOptions(TableName(table), Topic("mytopic"))
-      ))
+      ), kerberos = None,
+        hadoopConfiguration = HadoopConfiguration.Empty)
       val source = new HiveSource(DatabaseName(dbname), TableName(table), Topic("mytopic"), reader, sourceConfig)
       source.toList.map(_.value.asInstanceOf[Struct]).map(StructUtils.extractValues) shouldBe
         List(Vector("stef", "ms", 329.06), Vector("andrew", "mr", 529.06), Vector("ant", "mr", 629.06), Vector("tom", "miss", 395.44))
@@ -222,7 +230,8 @@ class HiveSourceTest extends WordSpec with Matchers with HiveTestConfig with Str
 
       val sourceConfig = HiveSourceConfig(DatabaseName(dbname), tableOptions = Set(
         SourceTableOptions(TableName(table), Topic("mytopic"), limit = 2)
-      ))
+      ), kerberos = None,
+        hadoopConfiguration = HadoopConfiguration.Empty)
       val source = new HiveSource(DatabaseName(dbname), TableName(table), Topic("mytopic"), reader, sourceConfig)
       source.toList.map(_.value.asInstanceOf[Struct]).map(StructUtils.extractValues) shouldBe
         List(Vector("stef", "ms", 329.06), Vector("andrew", "mr", 529.06))
@@ -243,7 +252,8 @@ class HiveSourceTest extends WordSpec with Matchers with HiveTestConfig with Str
 
       val sourceConfig = HiveSourceConfig(DatabaseName(dbname), tableOptions = Set(
         SourceTableOptions(TableName(table), Topic("mytopic"), limit = 2)
-      ))
+      ), kerberos = None,
+        hadoopConfiguration = HadoopConfiguration.Empty)
       val source = new HiveSource(DatabaseName(dbname), TableName(table), Topic("mytopic"), reader, sourceConfig)
       source.toList.isEmpty shouldBe true
     }


### PR DESCRIPTION
The hive source was missing secured connection support. This has been raised by a few users of it.

The PRs brings the Kerberos support in the Hive sink to the source.