### PR TITLE
FTP: respect "connect.ftp.max.poll.records" when reading slices.

### DIFF
--- a/kafka-connect-ftp/build.gradle
+++ b/kafka-connect-ftp/build.gradle
@@ -13,21 +13,25 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 project(":kafka-connect-ftp") {
+  ext {
+    pathikritVersion = '2.16.0'
+    ftpserverVersion = '1.0.6'
+    commonsnetVersion = '3.5'
+    commonsCodecVersion = '1.10'
+  }
 
-    ext {
-        pathikritVersion = '2.16.0'
-        ftpserverVersion = '1.0.6'
-        commonsnetVersion = '3.5'
-        commonsCodecVersion = '1.10'
-    }
+  test {
+    // detect memory leaks by constraining the Heap size
+    maxHeapSize = "200m"
+    jvmArgs "-Xms100m"
+  }
 
-    dependencies {
-        compile "commons-net:commons-net:${commonsnetVersion}"
-        compile "commons-codec:commons-codec:${commonsCodecVersion}"
-        testCompile "com.github.pathikrit:better-files_2.11:${pathikritVersion}"
-        testCompile "org.apache.ftpserver:ftpserver-core:${ftpserverVersion}"
-    }
+  dependencies {
+    compile "commons-net:commons-net:${commonsnetVersion}"
+    compile "commons-codec:commons-codec:${commonsCodecVersion}"
+    testCompile "com.github.pathikrit:better-files_2.11:${pathikritVersion}"
+    testCompile "org.apache.ftpserver:ftpserver-core:${ftpserverVersion}"
+  }
 }
 

--- a/kafka-connect-ftp/src/main/scala/com/datamountaineer/streamreactor/connect/ftp/source/ConnectFileMetaDataStore.scala
+++ b/kafka-connect-ftp/src/main/scala/com/datamountaineer/streamreactor/connect/ftp/source/ConnectFileMetaDataStore.scala
@@ -38,8 +38,7 @@ class ConnectFileMetaDataStore(offsetStorage: OffsetStorageReader) extends FileM
     })
 
   override def set(path: String, fileMetaData: FileMetaData): Unit = {
-    logger.info(s"ConnectFileMetaDataStore set ${path}")
-    logger.info(s"path = ${path}, fileMetaData.offset = ${fileMetaData.offset}, fileMetaData.attribs.size = ${fileMetaData.attribs.size}")
+    logger.debug(s"ConnectFileMetaDataStore path = ${path}, fileMetaData.offset = ${fileMetaData.offset}, fileMetaData.attribs.size = ${fileMetaData.attribs.size}")
     cache.put(path, fileMetaData)
   }
 

--- a/kafka-connect-ftp/src/test/resources/log4j.properties
+++ b/kafka-connect-ftp/src/test/resources/log4j.properties
@@ -1,0 +1,12 @@
+# suppress inspection "UnusedProperty" for whole file
+log4j.rootLogger=INFO,stdout
+
+#stdout
+log4j.appender.stdout=org.apache.log4j.ConsoleAppender
+log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
+log4j.appender.stdout.layout.conversionPattern=%d{ISO8601} %-5p [%t] [%c] [%M:%L] %m%n
+
+log4j.logger.com.jcabi.manifests=ERROR
+log4j.logger.org.apache.ftpserver.listener.nio.FtpLoggingFilter=WARN
+log4j.logger.com.datamountaineer.streamreactor.connect.ftp.source=DEBUG
+log4j.logger.com.datamountaineer.streamreactor.connect.ftp.source.ConnectFileMetaDataStore=INFO

--- a/kafka-connect-ftp/src/test/scala/com/datamountaineer/streamreactor/connect/ftp/source/ManyFilesTest.scala
+++ b/kafka-connect-ftp/src/test/scala/com/datamountaineer/streamreactor/connect/ftp/source/ManyFilesTest.scala
@@ -1,0 +1,49 @@
+package com.datamountaineer.streamreactor.connect.ftp.source
+
+import com.typesafe.scalalogging.slf4j.StrictLogging
+import org.scalatest.{BeforeAndAfter, FunSuite, Matchers}
+
+import scala.collection.JavaConverters._
+
+
+class ManyFilesTest extends FunSuite with Matchers with BeforeAndAfter with StrictLogging {
+  val ftpServer = new EmbeddedFtpServer(3333)
+
+  val fileCount = 132
+  val sliceSize = 1024
+  val maxPollRecords = 74
+
+  val lineSep = System.getProperty("line.separator")
+  val fileContent = (1 to 12000).map(index => s"line_${"%010d".format(index)}${lineSep}").mkString.getBytes
+
+  val fileName = "the_file_name"
+  val filePath = s"/folder/${fileName}"
+
+  val sourceConfig = Map(
+    FtpSourceConfig.Address -> s"${ftpServer.host}:${ftpServer.port}",
+    FtpSourceConfig.User -> ftpServer.username,
+    FtpSourceConfig.Password -> ftpServer.password,
+    FtpSourceConfig.RefreshRate -> "PT0S",
+    FtpSourceConfig.MonitorTail -> "/folder/:output_topic",
+    FtpSourceConfig.MonitorSliceSize -> sliceSize.toString,
+    FtpSourceConfig.FileMaxAge -> "P7D",
+    FtpSourceConfig.KeyStyle -> "string",
+    FtpSourceConfig.fileFilter -> ".*",
+    FtpSourceConfig.FtpMaxPollRecords -> s"${maxPollRecords}",
+    FtpSourceConfig.KeyStyle -> "struct"
+  )
+
+
+  test("Read only FtpMaxPollRecords even if using MonitorSliceSize") {
+    val fs = new FileSystem(ftpServer.rootDir).clear()
+    val cfg = new FtpSourceConfig(sourceConfig.asJava)
+    val offsets = new DummyOffsetStorage
+    (0 to fileCount).map(index => fs.applyChanges(Seq(s"${filePath}_${index}" -> Append(fileContent))))
+
+    val poller = new FtpSourcePoller(cfg, offsets)
+    ftpServer.start()
+    val slices = poller.poll()
+    (slices.size) shouldBe (maxPollRecords)
+    ftpServer.stop()
+  }
+}


### PR DESCRIPTION
Closes #672 