### PR TITLE
ORC Sink Failure

### DIFF
--- a/kafka-connect-hive/src/main/scala/com/landoop/streamreactor/connect/hive/formats/OrcHiveFormat.scala
+++ b/kafka-connect-hive/src/main/scala/com/landoop/streamreactor/connect/hive/formats/OrcHiveFormat.scala
@@ -26,7 +26,7 @@ object OrcHiveFormat extends HiveFormat {
     Try(fs.setPermission(path, FsPermission.valueOf("-rwxrwxrwx")))
 
     val cretedTimestamp: Long = System.currentTimeMillis()
-    var lastKnownFileSize:Long = fs.getFileStatus(path).getLen
+    var lastKnownFileSize:Long = if(fs.exists(path)) fs.getFileStatus(path).getLen else 0L
     var readFileSize = false
     var count = 0
 


### PR DESCRIPTION
When sinking with ORC the file is not created automatically. Therefore getting the file status to get the file size should check for the file presence. The code changes the approach to return 0 if the file does not exists. This fixes the unit tests and the prospect issue.