### PR TITLE
CLOUD-1340 - Using scala source instead of Scanner

### DIFF
--- a/kafka-connect-aws-s3/src/main/scala/io/lenses/streamreactor/connect/aws/s3/formats/CsvFormatStreamReader.scala
+++ b/kafka-connect-aws-s3/src/main/scala/io/lenses/streamreactor/connect/aws/s3/formats/CsvFormatStreamReader.scala
@@ -29,8 +29,8 @@ class CsvFormatStreamReader(inputStreamFn: () => InputStream, bucketAndPath: Buc
   override def next(): StringSourceData = {
     if(firstRun) {
       if(hasHeaders) {
-        if(scanner.hasNextLine) {
-          scanner.nextLine()
+        if(sourceLines.hasNext) {
+          sourceLines.next()
           lineNumber += 1
         } else {
           throw new IllegalStateException("No column headers are available")


### PR DESCRIPTION
Resolution for inability of connector to determine line breaks when the connector is run on certain docker images.