### PR TITLE
S3 Connector Error Handling and Retry Logic

### DIFF
--- a/kafka-connect-aws-s3/src/main/scala/io/lenses/streamreactor/connect/aws/s3/auth/AwsContextCreator.scala
+++ b/kafka-connect-aws-s3/src/main/scala/io/lenses/streamreactor/connect/aws/s3/auth/AwsContextCreator.scala
@@ -47,9 +47,7 @@ class AwsContextCreator(credentialsProviderFn: () => AWSCredentialsProvider) {
 
     awsConfig.customEndpoint.foreach(contextBuilder.endpoint)
 
-    if (awsConfig.enableVirtualHostBuckets) {
-      contextBuilder.overrides(createOverride())
-    }
+      contextBuilder.overrides(createOverride(awsConfig))
 
     contextBuilder.buildView(classOf[BlobStoreContext])
 
@@ -77,9 +75,13 @@ class AwsContextCreator(credentialsProviderFn: () => AWSCredentialsProvider) {
     }
   }
 
-  private def createOverride() = {
+  private def createOverride(awsConfig: S3Config) = {
     val overrides = new Properties()
-    overrides.put(org.jclouds.s3.reference.S3Constants.PROPERTY_S3_VIRTUAL_HOST_BUCKETS, "false")
+    if (awsConfig.enableVirtualHostBuckets) {
+      overrides.put(org.jclouds.s3.reference.S3Constants.PROPERTY_S3_VIRTUAL_HOST_BUCKETS, "false")
+    }
+    overrides.put(org.jclouds.Constants.PROPERTY_MAX_RETRIES, awsConfig.httpRetryConfig.numberOfRetries.toString)
+    overrides.put(org.jclouds.Constants.PROPERTY_RETRY_DELAY_START, awsConfig.httpRetryConfig.errorRetryInterval.toString)
     overrides
   }
 

--- a/kafka-connect-aws-s3/src/main/scala/io/lenses/streamreactor/connect/aws/s3/config/S3ConfigDef.scala
+++ b/kafka-connect-aws-s3/src/main/scala/io/lenses/streamreactor/connect/aws/s3/config/S3ConfigDef.scala
@@ -64,6 +64,55 @@ object S3ConfigDef {
       "Enable virtual host buckets"
     )
     .define(KcqlKey, Type.STRING, Importance.HIGH, KCQL_DOC)
+    .define(ERROR_POLICY,
+      Type.STRING,
+      ERROR_POLICY_DEFAULT,
+      Importance.HIGH,
+      ERROR_POLICY_DOC,
+      "Error",
+      1,
+      ConfigDef.Width.LONG,
+      ERROR_POLICY)
+
+    .define(NBR_OF_RETRIES,
+      Type.INT,
+      NBR_OF_RETIRES_DEFAULT,
+      Importance.MEDIUM,
+      NBR_OF_RETRIES_DOC,
+      "Error",
+      2,
+      ConfigDef.Width.LONG,
+      NBR_OF_RETRIES)
+
+    .define(ERROR_RETRY_INTERVAL,
+      Type.LONG,
+      ERROR_RETRY_INTERVAL_DEFAULT,
+      Importance.MEDIUM,
+      ERROR_RETRY_INTERVAL_DOC,
+      "Error",
+      3,
+      ConfigDef.Width.LONG,
+      ERROR_RETRY_INTERVAL)
+
+    .define(HTTP_NBR_OF_RETRIES,
+      Type.INT,
+      HTTP_NBR_OF_RETIRES_DEFAULT,
+      Importance.MEDIUM,
+      HTTP_NBR_OF_RETRIES_DOC,
+      "Error",
+      2,
+      ConfigDef.Width.LONG,
+      HTTP_NBR_OF_RETRIES)
+
+    .define(HTTP_ERROR_RETRY_INTERVAL,
+      Type.LONG,
+      HTTP_ERROR_RETRY_INTERVAL_DEFAULT,
+      Importance.MEDIUM,
+      HTTP_ERROR_RETRY_INTERVAL_DOC,
+      "Error",
+      3,
+      ConfigDef.Width.LONG,
+      HTTP_ERROR_RETRY_INTERVAL)
 
 }
 

--- a/kafka-connect-aws-s3/src/main/scala/io/lenses/streamreactor/connect/aws/s3/config/S3ConfigSettings.scala
+++ b/kafka-connect-aws-s3/src/main/scala/io/lenses/streamreactor/connect/aws/s3/config/S3ConfigSettings.scala
@@ -17,7 +17,7 @@
 
 package io.lenses.streamreactor.connect.aws.s3.config
 
-import com.datamountaineer.streamreactor.common.config.base.const.TraitConfigConst.{KCQL_PROP_SUFFIX, PROGRESS_ENABLED_CONST}
+import com.datamountaineer.streamreactor.common.config.base.const.TraitConfigConst.{ERROR_POLICY_PROP_SUFFIX, KCQL_PROP_SUFFIX, MAX_RETRIES_PROP_SUFFIX, PROGRESS_ENABLED_CONST, RETRY_INTERVAL_PROP_SUFFIX}
 
 object S3ConfigSettings {
 
@@ -39,4 +39,31 @@ object S3ConfigSettings {
   val PROGRESS_COUNTER_ENABLED_DEFAULT = false
   val PROGRESS_COUNTER_ENABLED_DISPLAY = "Enable progress counter"
 
+  val ERROR_POLICY = s"$CONNECTOR_PREFIX.$ERROR_POLICY_PROP_SUFFIX"
+  val ERROR_POLICY_DOC =
+    """
+      |Specifies the action to be taken if an error occurs while inserting the data.
+      | There are three available options:
+      |    NOOP - the error is swallowed
+      |    THROW - the error is allowed to propagate.
+      |    RETRY - The exception causes the Connect framework to retry the message. The number of retries is set by connect.s3.max.retries.
+      |All errors will be logged automatically, even if the code swallows them.
+    """.stripMargin
+  val ERROR_POLICY_DEFAULT = "THROW"
+
+  val ERROR_RETRY_INTERVAL = s"$CONNECTOR_PREFIX.$RETRY_INTERVAL_PROP_SUFFIX"
+  val ERROR_RETRY_INTERVAL_DOC = "The time in milliseconds between retries."
+  val ERROR_RETRY_INTERVAL_DEFAULT: Long = 60000L
+
+  val NBR_OF_RETRIES = s"$CONNECTOR_PREFIX.$MAX_RETRIES_PROP_SUFFIX"
+  val NBR_OF_RETRIES_DOC = "The maximum number of times to try the write again."
+  val NBR_OF_RETIRES_DEFAULT: Int = 20
+
+  val HTTP_ERROR_RETRY_INTERVAL = s"$CONNECTOR_PREFIX.HTTP.$RETRY_INTERVAL_PROP_SUFFIX"
+  val HTTP_ERROR_RETRY_INTERVAL_DOC = "If greater than zero, used to determine the delay after which to retry the http request in milliseconds.  Based on an exponential backoff algorithm."
+  val HTTP_ERROR_RETRY_INTERVAL_DEFAULT: Long = 50L
+
+  val HTTP_NBR_OF_RETRIES = s"$CONNECTOR_PREFIX.HTTP.$MAX_RETRIES_PROP_SUFFIX"
+  val HTTP_NBR_OF_RETRIES_DOC = "Number of times to retry the http request, in the case of a resolvable error on the server side."
+  val HTTP_NBR_OF_RETIRES_DEFAULT: Int = 5
 }

--- a/kafka-connect-aws-s3/src/main/scala/io/lenses/streamreactor/connect/aws/s3/sink/S3SinkTask.scala
+++ b/kafka-connect-aws-s3/src/main/scala/io/lenses/streamreactor/connect/aws/s3/sink/S3SinkTask.scala
@@ -17,6 +17,7 @@
 
 package io.lenses.streamreactor.connect.aws.s3.sink
 
+import com.datamountaineer.streamreactor.common.errors.RetryErrorPolicy
 import com.datamountaineer.streamreactor.common.utils.JarManifest
 import io.lenses.streamreactor.connect.aws.s3.auth.AwsContextCreator
 import io.lenses.streamreactor.connect.aws.s3.model._
@@ -75,7 +76,17 @@ class S3SinkTask extends SinkTask {
 
     validateBuckets(storageInterface, config)
 
+    setErrorRetryInterval
+
     writerManager = S3WriterManager.from(config, sinkName)(storageInterface)
+  }
+
+  private def setErrorRetryInterval = {
+    //if error policy is retry set retry interval
+    config.s3Config.errorPolicy match {
+      case RetryErrorPolicy() => context.timeout(config.s3Config.connectorRetryConfig.errorRetryInterval)
+      case _ =>
+    }
   }
 
   case class TopicAndPartition(topic: String, partition: Int) {

--- a/kafka-connect-aws-s3/src/test/scala/io/lenses/streamreactor/connect/aws/s3/sink/S3SinkTaskTest.scala
+++ b/kafka-connect-aws-s3/src/test/scala/io/lenses/streamreactor/connect/aws/s3/sink/S3SinkTaskTest.scala
@@ -30,6 +30,7 @@ import org.apache.avro.util.Utf8
 import org.apache.commons.io.IOUtils
 import org.apache.kafka.common.TopicPartition
 import org.apache.kafka.connect.data.{Schema, SchemaBuilder, Struct}
+import org.apache.kafka.connect.errors.ConnectException
 import org.apache.kafka.connect.header.{ConnectHeaders, Header}
 import org.apache.kafka.connect.sink.{SinkRecord, SinkTaskContext}
 import org.jclouds.blobstore.options.ListContainerOptions
@@ -284,7 +285,7 @@ class S3SinkTaskTest extends AnyFlatSpec with Matchers with S3TestConfig with Mo
     task.start(props)
     task.open(Seq(new TopicPartition(TopicName, 1)).asJava)
 
-    assertThrows[IllegalStateException] {
+    assertThrows[ConnectException] {
       task.put(records.asJava)
     }
 
@@ -610,11 +611,11 @@ class S3SinkTaskTest extends AnyFlatSpec with Matchers with S3TestConfig with Mo
 
     task.start(props)
     task.open(Seq(new TopicPartition(TopicName, 1)).asJava)
-    val caught = intercept[IllegalArgumentException] {
+    val caught = intercept[ConnectException] {
       task.put(textRecords.asJava)
     }
 
-    assert(caught.getMessage.equalsIgnoreCase("Header 'hair' not found in message"))
+    assert(caught.getMessage.endsWith("Header 'hair' not found in message"))
 
     task.close(Seq(new TopicPartition(TopicName, 1)).asJava)
     task.stop()
@@ -764,10 +765,10 @@ class S3SinkTaskTest extends AnyFlatSpec with Matchers with S3TestConfig with Mo
 
     task.start(props)
     task.open(Seq(new TopicPartition(TopicName, 1)).asJava)
-    val intercepted = intercept[IllegalStateException] {
+    val intercepted = intercept[ConnectException] {
       task.put(keyPartitionedRecords.asJava)
     }
-    intercepted.getMessage should be("Non primitive struct provided, PARTITIONBY _key requested in KCQL")
+    intercepted.getMessage should endWith("Non primitive struct provided, PARTITIONBY _key requested in KCQL")
 
     task.close(Seq(new TopicPartition(TopicName, 1)).asJava)
     task.stop()


### PR DESCRIPTION
This PR introduces multiple properties for error handling and retry.

``connect.s3.error.policy``
Specifies the action to be taken if an error occurs while inserting the data.
 There are three available options:
    NOOP - the error is swallowed
    THROW - the error is allowed to propagate.
    RETRY - The exception causes the Connect framework to retry the message. The number of retries is set by connect.s3.max.retries.
All errors will be logged automatically, even if the code swallows them.

``connect.s3.max.retries``
The maximum number of times to try the write again.

``connect.s3.retry.interval``
The time in milliseconds between retries.

``connect.s3.http.max.retries``
Number of times to retry the http request, in the case of a resolvable error on the server side.

``connect.s3.http.retry.interval``
If greater than zero, used to determine the delay after which to retry the http request in milliseconds.  Based on an exponential backoff algorithm.



Note: This is a work in progress.