### PR TITLE
Replacing the expensive bucket list on startup with a lightweight operation

### DIFF
--- a/kafka-connect-aws-s3/src/main/scala/io/lenses/streamreactor/connect/aws/s3/sink/S3SinkTask.scala
+++ b/kafka-connect-aws-s3/src/main/scala/io/lenses/streamreactor/connect/aws/s3/sink/S3SinkTask.scala
@@ -54,8 +54,7 @@ class S3SinkTask extends SinkTask {
   def validateBuckets(storageInterface: StorageInterface, config: S3SinkConfig) = {
     config.bucketOptions.foreach(
       bucketOption => {
-        val bucketAndPrefix = bucketOption.bucketAndPrefix
-        storageInterface.list(bucketAndPrefix)
+        storageInterface.checkBucket(bucketOption.bucketAndPrefix).fold()(e => throw new IllegalStateException(e))
       }
     )
   }

--- a/kafka-connect-aws-s3/src/main/scala/io/lenses/streamreactor/connect/aws/s3/storage/MultipartBlobStoreStorageInterface.scala
+++ b/kafka-connect-aws-s3/src/main/scala/io/lenses/streamreactor/connect/aws/s3/storage/MultipartBlobStoreStorageInterface.scala
@@ -34,7 +34,7 @@ import java.io.ByteArrayInputStream
 import java.io.InputStream
 import java.util.UUID
 import scala.collection.JavaConverters._
-import scala.util.Try
+import scala.util.{Failure, Success, Try}
 
 class MultipartBlobStoreStorageInterface(sinkName: String, blobStoreContext: BlobStoreContext) extends StorageInterface with LazyLogging {
 
@@ -169,6 +169,25 @@ class MultipartBlobStoreStorageInterface(sinkName: String, blobStoreContext: Blo
 
     } while (nextMarker.nonEmpty)
     pageSetStrings
+
+  }
+
+  override def checkBucket(bucketAndPrefix: BucketAndPrefix): Option[Throwable] = {
+    val options = bucketAndPrefix
+      .prefix
+      .fold(
+        ListContainerOptions.Builder.recursive()
+      )(
+        ListContainerOptions.Builder.recursive().prefix
+      )
+      .maxResults(1)
+
+    Try(blobStore.list(bucketAndPrefix.bucket, options)) match {
+      case Failure(ex) => Some(ex)
+      case Success(_) => None
+    }
+
+
 
   }
 

--- a/kafka-connect-aws-s3/src/main/scala/io/lenses/streamreactor/connect/aws/s3/storage/StorageInterface.scala
+++ b/kafka-connect-aws-s3/src/main/scala/io/lenses/streamreactor/connect/aws/s3/storage/StorageInterface.scala
@@ -51,5 +51,6 @@ trait StorageInterface {
 
   def getBlobSize(bucketAndPath: BucketAndPath): Long
 
+  def checkBucket(bucketAndPrefix: BucketAndPrefix): Option[Throwable]
 }
 

--- a/kafka-connect-aws-s3/src/test/scala/io/lenses/streamreactor/connect/aws/s3/sink/S3SinkTaskTest.scala
+++ b/kafka-connect-aws-s3/src/test/scala/io/lenses/streamreactor/connect/aws/s3/sink/S3SinkTaskTest.scala
@@ -89,6 +89,20 @@ class S3SinkTaskTest extends AnyFlatSpec with Matchers with S3TestConfig with Mo
     new SinkRecord(TopicName, 1, null, createKey(keySchema, ("phonePrefix", "+49"), ("region", 5)), null, users(2), 2, null, null)
   )
 
+  "S3SinkTask" should "validate connection on startup" in {
+
+    val task = new S3SinkTask()
+
+    val props = DefaultProps
+      .combine(
+        Map("connect.s3.kcql" -> s"insert into incorrectbucket:$PrefixName select * from $TopicName WITH_FLUSH_INTERVAL = 1")
+      ).asJava
+
+    assertThrows[IllegalStateException] {
+      task.start(props)
+    }
+  }
+
   "S3SinkTask" should "flush on configured flush time intervals" in {
 
     val task = new S3SinkTask()

--- a/kafka-connect-aws-s3/src/test/scala/io/lenses/streamreactor/connect/aws/s3/storage/MultipartBlobStoreStorageInterfaceTest.scala
+++ b/kafka-connect-aws-s3/src/test/scala/io/lenses/streamreactor/connect/aws/s3/storage/MultipartBlobStoreStorageInterfaceTest.scala
@@ -128,6 +128,16 @@ class MultipartBlobStoreStorageInterfaceTest extends AnyFlatSpec with MockitoSug
       be(List("only"))
   }
 
+  "checkBucket" should "return None on success" in {
+    multipartBlobStoreStorageInterface.checkBucket(BucketAndPrefix(testBucketAndPath.bucket, Some("prefix"))) should be (None)
+  }
+
+  "checkBucket" should "return Some(exception) on failure" in {
+    val ex = new IllegalArgumentException("Error listing bucket")
+    when(blobStore.list(anyString(), any(classOf[ListContainerOptions]))).thenThrow(ex)
+    multipartBlobStoreStorageInterface.checkBucket(BucketAndPrefix(testBucketAndPath.bucket, Some("incorrectPrefix"))) should be (Some(ex))
+  }
+
   private def createUploadState(
                                  existingParts: Vector[MultipartPart] = Vector(),
                                  existingBufferBytes: Array[Byte] = Array()


### PR DESCRIPTION
On startup the s3 connector lists the files in order to check the validity of the connection.  Unfortunately the listFiles call is expensive as it sends multiple requests to AWS to build a whole picture of the directory so it is not appropriate for this purpose.

This PR replaces the call on startup with a faster one-request call to list files via the client, requesting only a single result.