### PR TITLE
Enabling simpler management of default flush values in S3 Sink connector

### DIFF
--- a/kafka-connect-aws-s3/src/main/scala/io/lenses/streamreactor/connect/aws/s3/config/S3ConfigDef.scala
+++ b/kafka-connect-aws-s3/src/main/scala/io/lenses/streamreactor/connect/aws/s3/config/S3ConfigDef.scala
@@ -63,6 +63,13 @@ object S3ConfigDef {
       Importance.LOW,
       "Enable virtual host buckets"
     )
+    .define(
+      DISABLE_FLUSH_COUNT,
+      Type.BOOLEAN,
+      false,
+      Importance.LOW,
+      "Disable flush on reaching count"
+    )
     .define(KcqlKey, Type.STRING, Importance.HIGH, KCQL_DOC)
     .define(ERROR_POLICY,
       Type.STRING,
@@ -123,3 +130,5 @@ case class S3ConfigDefBuilder(props: util.Map[String, String])
     with NumberRetriesSettings
     with UserSettings
     with ConnectionSettings
+    with S3FlushSettings
+

--- a/kafka-connect-aws-s3/src/main/scala/io/lenses/streamreactor/connect/aws/s3/config/S3ConfigSettings.scala
+++ b/kafka-connect-aws-s3/src/main/scala/io/lenses/streamreactor/connect/aws/s3/config/S3ConfigSettings.scala
@@ -28,6 +28,7 @@ object S3ConfigSettings {
   val AUTH_MODE: String = "aws.auth.mode"
   val CUSTOM_ENDPOINT: String = "aws.custom.endpoint"
   val ENABLE_VIRTUAL_HOST_BUCKETS: String = "aws.vhost.bucket"
+  val DISABLE_FLUSH_COUNT: String = s"$CONNECTOR_PREFIX.disable.flush.count"
 
   val KcqlKey = s"$CONNECTOR_PREFIX.$KCQL_PROP_SUFFIX"
   val KCQL_CONFIG = s"$CONNECTOR_PREFIX.$KCQL_PROP_SUFFIX"

--- a/kafka-connect-aws-s3/src/main/scala/io/lenses/streamreactor/connect/aws/s3/config/S3FlushSettings.scala
+++ b/kafka-connect-aws-s3/src/main/scala/io/lenses/streamreactor/connect/aws/s3/config/S3FlushSettings.scala
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2021 Lenses.io
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.lenses.streamreactor.connect.aws.s3.config
+
+import com.datamountaineer.kcql.Kcql
+import com.datamountaineer.streamreactor.common.config.base.traits.BaseSettings
+import io.lenses.streamreactor.connect.aws.s3.config.S3ConfigSettings.DISABLE_FLUSH_COUNT
+import io.lenses.streamreactor.connect.aws.s3.sink.DefaultCommitPolicy
+
+import scala.concurrent.duration.{DurationInt, DurationLong, FiniteDuration}
+object S3FlushSettings {
+
+  val defaultFlushSize = 500000000
+  val defaultFlushInterval = 3600.seconds
+  val defaultFlushCount = 50000L
+
+}
+
+trait S3FlushSettings extends BaseSettings {
+
+  import S3FlushSettings._
+
+  private def isFlushCountDisabled : Boolean = {
+    getBoolean(s"$DISABLE_FLUSH_COUNT")
+  }
+
+  private def isFlushCountEnabled : Boolean = {
+    !isFlushCountDisabled
+  }
+
+  def commitPolicy(kcql: Kcql) = DefaultCommitPolicy(
+    fileSize = flushSize(kcql),
+    interval = Option(flushInterval(kcql)),
+    recordCount = flushCount(kcql)
+  )
+
+  private def flushInterval(kcql: Kcql): FiniteDuration = {
+    Option(kcql.getWithFlushInterval).filter(_ > 0).map(_.seconds).getOrElse(defaultFlushInterval)
+  }
+
+  private def flushSize(kcql: Kcql): Option[Long] = {
+    Option(kcql.getWithFlushSize).filter(_ > 0).orElse(Some(defaultFlushSize))
+  }
+
+  private def flushCount(kcql: Kcql): Option[Long] = {
+    if (isFlushCountEnabled) {
+      Option(kcql.getWithFlushCount).filter(_ > 0).orElse(Some(defaultFlushCount))
+    } else {
+      None
+    }
+  }
+}
+


### PR DESCRIPTION
This PR amends the default values for the AWS S3 Sink Flush (Size, Count and Interval).

The new default values are
```
WITH_FLUSH_SIZE = 500000000
WITH_FLUSH_INTERVAL = 3600
WITH_FLUSH_COUNT = 50000
```

In addition the new property has been introduced
`connect.s3.disable.flush.count=true`

So that, if necessary, the flush count can be disabled to revert to the previous behaviour.