### PR TITLE
Local Write Mode - Build Locally, then Ship

### DIFF
--- a/kafka-connect-aws-s3/src/main/scala/io/lenses/streamreactor/connect/aws/s3/config/S3ConfigDef.scala
+++ b/kafka-connect-aws-s3/src/main/scala/io/lenses/streamreactor/connect/aws/s3/config/S3ConfigDef.scala
@@ -18,7 +18,7 @@
 package io.lenses.streamreactor.connect.aws.s3.config
 
 import com.datamountaineer.streamreactor.common.config.base.traits.{BaseConfig, ConnectionSettings, ErrorPolicySettings, KcqlSettings, NumberRetriesSettings, UserSettings}
-import io.lenses.streamreactor.connect.aws.s3.model.S3WriteMode
+import io.lenses.streamreactor.connect.aws.s3.model.S3WriteMode.{BuildLocal, Streamed}
 
 import java.util
 import org.apache.kafka.common.config.ConfigDef
@@ -74,16 +74,16 @@ object S3ConfigDef {
     .define(
       WRITE_MODE,
       Type.STRING,
-      S3WriteModeSettings.defaultWriteMode.toString,
+      Streamed.entryName,
       Importance.HIGH,
-      s"Write mode, '${S3WriteMode.Streamed.toString}' or '${S3WriteMode.BuildLocal.toString}'"
+      s"Write mode, '${Streamed.entryName}' or '${BuildLocal.entryName}'"
     )
     .define(
       LOCAL_TMP_DIRECTORY,
       Type.STRING,
       "",
       Importance.LOW,
-      s"Local tmp directory for use with ${S3WriteMode.BuildLocal} write mode"
+      s"Local tmp directory for use with ${BuildLocal.entryName} write mode"
     )
     .define(KcqlKey, Type.STRING, Importance.HIGH, KCQL_DOC)
     .define(ERROR_POLICY,

--- a/kafka-connect-aws-s3/src/main/scala/io/lenses/streamreactor/connect/aws/s3/config/S3ConfigDef.scala
+++ b/kafka-connect-aws-s3/src/main/scala/io/lenses/streamreactor/connect/aws/s3/config/S3ConfigDef.scala
@@ -18,6 +18,7 @@
 package io.lenses.streamreactor.connect.aws.s3.config
 
 import com.datamountaineer.streamreactor.common.config.base.traits.{BaseConfig, ConnectionSettings, ErrorPolicySettings, KcqlSettings, NumberRetriesSettings, UserSettings}
+import io.lenses.streamreactor.connect.aws.s3.model.S3WriteMode
 
 import java.util
 import org.apache.kafka.common.config.ConfigDef
@@ -69,6 +70,20 @@ object S3ConfigDef {
       false,
       Importance.LOW,
       "Disable flush on reaching count"
+    )
+    .define(
+      WRITE_MODE,
+      Type.STRING,
+      S3WriteModeSettings.defaultWriteMode.toString,
+      Importance.HIGH,
+      s"Write mode, '${S3WriteMode.Streamed.toString}' or '${S3WriteMode.BuildLocal.toString}'"
+    )
+    .define(
+      LOCAL_TMP_DIRECTORY,
+      Type.STRING,
+      "",
+      Importance.LOW,
+      s"Local tmp directory for use with ${S3WriteMode.BuildLocal} write mode"
     )
     .define(KcqlKey, Type.STRING, Importance.HIGH, KCQL_DOC)
     .define(ERROR_POLICY,
@@ -131,4 +146,6 @@ case class S3ConfigDefBuilder(props: util.Map[String, String])
     with UserSettings
     with ConnectionSettings
     with S3FlushSettings
+    with S3WriteModeSettings
+
 

--- a/kafka-connect-aws-s3/src/main/scala/io/lenses/streamreactor/connect/aws/s3/config/S3ConfigSettings.scala
+++ b/kafka-connect-aws-s3/src/main/scala/io/lenses/streamreactor/connect/aws/s3/config/S3ConfigSettings.scala
@@ -29,6 +29,8 @@ object S3ConfigSettings {
   val CUSTOM_ENDPOINT: String = "aws.custom.endpoint"
   val ENABLE_VIRTUAL_HOST_BUCKETS: String = "aws.vhost.bucket"
   val DISABLE_FLUSH_COUNT: String = s"$CONNECTOR_PREFIX.disable.flush.count"
+  val WRITE_MODE: String = s"$CONNECTOR_PREFIX.write.mode"
+  val LOCAL_TMP_DIRECTORY: String = s"$CONNECTOR_PREFIX.local.tmp.directory"
 
   val KcqlKey = s"$CONNECTOR_PREFIX.$KCQL_PROP_SUFFIX"
   val KCQL_CONFIG = s"$CONNECTOR_PREFIX.$KCQL_PROP_SUFFIX"

--- a/kafka-connect-aws-s3/src/main/scala/io/lenses/streamreactor/connect/aws/s3/config/S3WriteModeSettings.scala
+++ b/kafka-connect-aws-s3/src/main/scala/io/lenses/streamreactor/connect/aws/s3/config/S3WriteModeSettings.scala
@@ -22,11 +22,8 @@ import io.lenses.streamreactor.connect.aws.s3.model.S3OutputStreamOptions
 
 trait S3WriteModeSettings extends BaseSettings {
 
-  def s3WriteOptions(props: Map[String,String]) : S3OutputStreamOptions = {
-    S3OutputStreamOptions(getString(WRITE_MODE), props) match {
-      case Left(exception) => throw exception
-      case Right(value) => value
-    }
+  def s3WriteOptions(props: Map[String,String]) : Either[Exception,S3OutputStreamOptions] = {
+    S3OutputStreamOptions(getString(WRITE_MODE), props)
   }
 
 }

--- a/kafka-connect-aws-s3/src/main/scala/io/lenses/streamreactor/connect/aws/s3/config/S3WriteModeSettings.scala
+++ b/kafka-connect-aws-s3/src/main/scala/io/lenses/streamreactor/connect/aws/s3/config/S3WriteModeSettings.scala
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2021 Lenses.io
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.lenses.streamreactor.connect.aws.s3.config
+
+import com.datamountaineer.streamreactor.common.config.base.traits.BaseSettings
+import io.lenses.streamreactor.connect.aws.s3.config.S3ConfigSettings.{LOCAL_TMP_DIRECTORY, WRITE_MODE}
+import io.lenses.streamreactor.connect.aws.s3.config.S3WriteModeSettings.defaultWriteMode
+import io.lenses.streamreactor.connect.aws.s3.model.{LocalLocation, S3WriteMode}
+import io.lenses.streamreactor.connect.aws.s3.model.S3WriteMode.{BuildLocal, Streamed}
+
+import java.nio.file.Files
+import java.util.UUID
+
+object S3WriteModeSettings {
+
+  val defaultWriteMode: S3WriteMode = Streamed
+
+}
+
+trait S3WriteModeSettings extends BaseSettings {
+
+  def s3WriteMode() : S3WriteMode = {
+    S3WriteMode
+      .withNameInsensitiveOption(getString(WRITE_MODE))
+      .getOrElse(defaultWriteMode)
+  }
+
+  def s3LocalBuildDirectory(sinkName: Option[String]) : Option[LocalLocation] = {
+    s3WriteMode() match {
+      case S3WriteMode.Streamed => Option.empty[LocalLocation]
+      case S3WriteMode.BuildLocal => Option(getString(LOCAL_TMP_DIRECTORY))
+        .filter(_.trim.nonEmpty)
+        .orElse(createTmpDir(sinkName))
+        .map(LocalLocation(_))
+    }
+  }
+
+  private def createTmpDir(sinkName: Option[String]): Option[String] = {
+    val sinkIdent = sinkName.getOrElse("MissingSinkName")
+    val uuid = UUID.randomUUID().toString
+    Some(Files.createTempDirectory(s"$sinkIdent.$uuid").toAbsolutePath.toString)
+  }
+}

--- a/kafka-connect-aws-s3/src/main/scala/io/lenses/streamreactor/connect/aws/s3/formats/AvroFormatStreamReader.scala
+++ b/kafka-connect-aws-s3/src/main/scala/io/lenses/streamreactor/connect/aws/s3/formats/AvroFormatStreamReader.scala
@@ -19,13 +19,13 @@ package io.lenses.streamreactor.connect.aws.s3.formats
 import java.io.InputStream
 
 import io.confluent.connect.avro.AvroData
-import io.lenses.streamreactor.connect.aws.s3.model.{BucketAndPath, SchemaAndValueSourceData}
+import io.lenses.streamreactor.connect.aws.s3.model.{RemotePathLocation, SchemaAndValueSourceData}
 import org.apache.avro.file.DataFileStream
 import org.apache.avro.generic.{GenericDatumReader, GenericRecord}
 
 import scala.util.Try
 
-class AvroFormatStreamReader(inputStreamFn: () => InputStream, bucketAndPath: BucketAndPath) extends S3FormatStreamReader[SchemaAndValueSourceData] {
+class AvroFormatStreamReader(inputStreamFn: () => InputStream, bucketAndPath: RemotePathLocation) extends S3FormatStreamReader[SchemaAndValueSourceData] {
   private val avroDataConverter = new AvroData(100)
 
   private val datumReader = new GenericDatumReader[GenericRecord]()
@@ -50,7 +50,7 @@ class AvroFormatStreamReader(inputStreamFn: () => InputStream, bucketAndPath: Bu
     SchemaAndValueSourceData(schemaAndValue, lineNumber)
   }
 
-  override def getBucketAndPath: BucketAndPath = bucketAndPath
+  override def getBucketAndPath: RemotePathLocation = bucketAndPath
 
   override def getLineNumber: Long = lineNumber
 }

--- a/kafka-connect-aws-s3/src/main/scala/io/lenses/streamreactor/connect/aws/s3/formats/AvroFormatWriter.scala
+++ b/kafka-connect-aws-s3/src/main/scala/io/lenses/streamreactor/connect/aws/s3/formats/AvroFormatWriter.scala
@@ -31,8 +31,6 @@ class AvroFormatWriter(outputStreamFn: () => S3OutputStream) extends S3FormatWri
 
   private var avroWriterState: Option[AvroWriterState] = None
 
-  private var outstandingRename: Boolean = false
-
   override def rolloverFileOnSchemaChange() = true
 
   override def write(keySinkData: Option[SinkData], valueSinkData: SinkData, topic: Topic): Unit = {
@@ -49,11 +47,9 @@ class AvroFormatWriter(outputStreamFn: () => S3OutputStream) extends S3FormatWri
 
   }
 
-  override def close(): Unit = {
-    avroWriterState.fold(logger.debug("Requesting close when there's nothing to close"))(_.close())
+  override def close(newName: BucketAndPath): Unit = {
+    avroWriterState.fold(logger.debug("Requesting close when there's nothing to close"))(_.close(newName))
   }
-
-  override def getOutstandingRename: Boolean = outstandingRename
 
   override def getPointer: Long = avroWriterState.fold(0L)(_.pointer)
 
@@ -72,10 +68,10 @@ class AvroFormatWriter(outputStreamFn: () => S3OutputStream) extends S3FormatWri
 
     }
 
-    def close(): Unit = {
-      Try(fileWriter.flush())
-      Try(outstandingRename = outputStream.complete)
 
+    def close(newName: BucketAndPath) = {
+      Try(fileWriter.flush())
+      Try(outputStream.complete(newName))
       Try(fileWriter.close())
       Try(outputStream.close())
     }

--- a/kafka-connect-aws-s3/src/main/scala/io/lenses/streamreactor/connect/aws/s3/formats/AvroFormatWriter.scala
+++ b/kafka-connect-aws-s3/src/main/scala/io/lenses/streamreactor/connect/aws/s3/formats/AvroFormatWriter.scala
@@ -47,7 +47,7 @@ class AvroFormatWriter(outputStreamFn: () => S3OutputStream) extends S3FormatWri
 
   }
 
-  override def close(newName: BucketAndPath): Unit = {
+  override def close(newName: RemotePathLocation): Unit = {
     avroWriterState.fold(logger.debug("Requesting close when there's nothing to close"))(_.close(newName))
   }
 
@@ -69,7 +69,7 @@ class AvroFormatWriter(outputStreamFn: () => S3OutputStream) extends S3FormatWri
     }
 
 
-    def close(newName: BucketAndPath) = {
+    def close(newName: RemotePathLocation) = {
       Try(fileWriter.flush())
       Try(outputStream.complete(newName))
       Try(fileWriter.close())

--- a/kafka-connect-aws-s3/src/main/scala/io/lenses/streamreactor/connect/aws/s3/formats/BytesFormatStreamFileReader.scala
+++ b/kafka-connect-aws-s3/src/main/scala/io/lenses/streamreactor/connect/aws/s3/formats/BytesFormatStreamFileReader.scala
@@ -19,11 +19,11 @@ package io.lenses.streamreactor.connect.aws.s3.formats
 import java.io.InputStream
 
 import com.google.common.io.ByteStreams
-import io.lenses.streamreactor.connect.aws.s3.model.{BucketAndPath, ByteArraySourceData, BytesWriteMode}
+import io.lenses.streamreactor.connect.aws.s3.model.{RemotePathLocation, ByteArraySourceData, BytesWriteMode}
 
 import scala.util.Try
 
-class BytesFormatStreamFileReader(inputStreamFn: () => InputStream, fileSizeFn: () => Long, bucketAndPath: BucketAndPath, bytesWriteMode: BytesWriteMode) extends S3FormatStreamReader[ByteArraySourceData] {
+class BytesFormatStreamFileReader(inputStreamFn: () => InputStream, fileSizeFn: () => Long, bucketAndPath: RemotePathLocation, bytesWriteMode: BytesWriteMode) extends S3FormatStreamReader[ByteArraySourceData] {
 
   private var consumed : Boolean = false
   private val inputStream = inputStreamFn()
@@ -45,6 +45,6 @@ class BytesFormatStreamFileReader(inputStreamFn: () => InputStream, fileSizeFn: 
     }
   }
 
-  override def getBucketAndPath: BucketAndPath = bucketAndPath
+  override def getBucketAndPath: RemotePathLocation = bucketAndPath
 
 }

--- a/kafka-connect-aws-s3/src/main/scala/io/lenses/streamreactor/connect/aws/s3/formats/BytesFormatWithSizesStreamReader.scala
+++ b/kafka-connect-aws-s3/src/main/scala/io/lenses/streamreactor/connect/aws/s3/formats/BytesFormatWithSizesStreamReader.scala
@@ -19,11 +19,11 @@ package io.lenses.streamreactor.connect.aws.s3.formats
 import java.io.{DataInputStream, InputStream}
 import java.util.concurrent.atomic.AtomicLong
 
-import io.lenses.streamreactor.connect.aws.s3.model.{BucketAndPath, ByteArraySourceData, BytesWriteMode}
+import io.lenses.streamreactor.connect.aws.s3.model.{RemotePathLocation, ByteArraySourceData, BytesWriteMode}
 
 import scala.util.Try
 
-class BytesFormatWithSizesStreamReader(inputStreamFn: () => InputStream, fileSizeFn: () => Long, bucketAndPath: BucketAndPath, bytesWriteMode: BytesWriteMode) extends S3FormatStreamReader[ByteArraySourceData] {
+class BytesFormatWithSizesStreamReader(inputStreamFn: () => InputStream, fileSizeFn: () => Long, bucketAndPath: RemotePathLocation, bytesWriteMode: BytesWriteMode) extends S3FormatStreamReader[ByteArraySourceData] {
 
   private val inputStream = new DataInputStream(inputStreamFn())
 
@@ -48,6 +48,6 @@ class BytesFormatWithSizesStreamReader(inputStreamFn: () => InputStream, fileSiz
     }
   }
 
-  override def getBucketAndPath: BucketAndPath = bucketAndPath
+  override def getBucketAndPath: RemotePathLocation = bucketAndPath
 
 }

--- a/kafka-connect-aws-s3/src/main/scala/io/lenses/streamreactor/connect/aws/s3/formats/BytesFormatWriter.scala
+++ b/kafka-connect-aws-s3/src/main/scala/io/lenses/streamreactor/connect/aws/s3/formats/BytesFormatWriter.scala
@@ -17,7 +17,7 @@
 package io.lenses.streamreactor.connect.aws.s3.formats
 
 import com.typesafe.scalalogging.LazyLogging
-import io.lenses.streamreactor.connect.aws.s3.model.{BucketAndPath, ByteArraySinkData, BytesOutputRow, BytesWriteMode, SinkData, Topic}
+import io.lenses.streamreactor.connect.aws.s3.model.{RemotePathLocation, ByteArraySinkData, BytesOutputRow, BytesWriteMode, SinkData, Topic}
 import io.lenses.streamreactor.connect.aws.s3.storage.S3OutputStream
 
 import scala.util.Try
@@ -70,7 +70,7 @@ class BytesFormatWriter(outputStreamFn: () => S3OutputStream, bytesWriteMode: By
 
   override def rolloverFileOnSchemaChange(): Boolean = false
 
-  override def close(newName: BucketAndPath) = {
+  override def close(newName: RemotePathLocation) = {
     Try(outputStream.complete(newName))
 
     Try(outputStream.flush())

--- a/kafka-connect-aws-s3/src/main/scala/io/lenses/streamreactor/connect/aws/s3/formats/CsvFormatStreamReader.scala
+++ b/kafka-connect-aws-s3/src/main/scala/io/lenses/streamreactor/connect/aws/s3/formats/CsvFormatStreamReader.scala
@@ -18,10 +18,10 @@ package io.lenses.streamreactor.connect.aws.s3.formats
 
 import java.io.InputStream
 
-import io.lenses.streamreactor.connect.aws.s3.model.{BucketAndPath, StringSourceData}
+import io.lenses.streamreactor.connect.aws.s3.model.{RemotePathLocation, StringSourceData}
 
 
-class CsvFormatStreamReader(inputStreamFn: () => InputStream, bucketAndPath: BucketAndPath, hasHeaders: Boolean)
+class CsvFormatStreamReader(inputStreamFn: () => InputStream, bucketAndPath: RemotePathLocation, hasHeaders: Boolean)
   extends TextFormatStreamReader(inputStreamFn, bucketAndPath) {
 
   private var firstRun : Boolean = true;

--- a/kafka-connect-aws-s3/src/main/scala/io/lenses/streamreactor/connect/aws/s3/formats/CsvFormatWriter.scala
+++ b/kafka-connect-aws-s3/src/main/scala/io/lenses/streamreactor/connect/aws/s3/formats/CsvFormatWriter.scala
@@ -19,7 +19,7 @@ package io.lenses.streamreactor.connect.aws.s3.formats
 
 import au.com.bytecode.opencsv.CSVWriter
 import com.typesafe.scalalogging.LazyLogging
-import io.lenses.streamreactor.connect.aws.s3.model.{BucketAndPath, PartitionNamePath, SinkData, Topic}
+import io.lenses.streamreactor.connect.aws.s3.model.{RemotePathLocation, PartitionNamePath, SinkData, Topic}
 import io.lenses.streamreactor.connect.aws.s3.sink.extractors.ExtractorErrorAdaptor.adaptErrorResponse
 import io.lenses.streamreactor.connect.aws.s3.sink.extractors.SinkDataExtractor
 import io.lenses.streamreactor.connect.aws.s3.storage.S3OutputStream
@@ -51,7 +51,7 @@ class CsvFormatWriter(outputStreamFn: () => S3OutputStream, writeHeaders: Boolea
 
   override def rolloverFileOnSchemaChange(): Boolean = true
 
-  def close(newName: BucketAndPath) = {
+  def close(newName: RemotePathLocation) = {
     Try(outputStream.complete(newName))
 
     Try(csvWriter.flush())

--- a/kafka-connect-aws-s3/src/main/scala/io/lenses/streamreactor/connect/aws/s3/formats/CsvFormatWriter.scala
+++ b/kafka-connect-aws-s3/src/main/scala/io/lenses/streamreactor/connect/aws/s3/formats/CsvFormatWriter.scala
@@ -19,7 +19,7 @@ package io.lenses.streamreactor.connect.aws.s3.formats
 
 import au.com.bytecode.opencsv.CSVWriter
 import com.typesafe.scalalogging.LazyLogging
-import io.lenses.streamreactor.connect.aws.s3.model.{PartitionNamePath, SinkData, Topic}
+import io.lenses.streamreactor.connect.aws.s3.model.{BucketAndPath, PartitionNamePath, SinkData, Topic}
 import io.lenses.streamreactor.connect.aws.s3.sink.extractors.ExtractorErrorAdaptor.adaptErrorResponse
 import io.lenses.streamreactor.connect.aws.s3.sink.extractors.SinkDataExtractor
 import io.lenses.streamreactor.connect.aws.s3.storage.S3OutputStream
@@ -34,8 +34,6 @@ class CsvFormatWriter(outputStreamFn: () => S3OutputStream, writeHeaders: Boolea
   private val outputStream: S3OutputStream = outputStreamFn()
   private val outputStreamWriter = new OutputStreamWriter(outputStream)
   private val csvWriter = new CSVWriter(outputStreamWriter)
-
-  private var outstandingRename: Boolean = false
 
   private var fieldsWritten = false
 
@@ -53,8 +51,8 @@ class CsvFormatWriter(outputStreamFn: () => S3OutputStream, writeHeaders: Boolea
 
   override def rolloverFileOnSchemaChange(): Boolean = true
 
-  override def close(): Unit = {
-    Try(outstandingRename = outputStream.complete)
+  def close(newName: BucketAndPath) = {
+    Try(outputStream.complete(newName))
 
     Try(csvWriter.flush())
     Try(outputStream.flush())
@@ -62,8 +60,6 @@ class CsvFormatWriter(outputStreamFn: () => S3OutputStream, writeHeaders: Boolea
     Try(outputStreamWriter.close())
     Try(outputStream.close())
   }
-
-  override def getOutstandingRename: Boolean = outstandingRename
 
   override def getPointer: Long = outputStream.getPointer
 

--- a/kafka-connect-aws-s3/src/main/scala/io/lenses/streamreactor/connect/aws/s3/formats/JsonFormatWriter.scala
+++ b/kafka-connect-aws-s3/src/main/scala/io/lenses/streamreactor/connect/aws/s3/formats/JsonFormatWriter.scala
@@ -33,7 +33,6 @@ class JsonFormatWriter(outputStreamFn: () => S3OutputStream) extends S3FormatWri
 
   private val outputStream: S3OutputStream = outputStreamFn()
   private val jsonConverter = new JsonConverter
-  private var outstandingRename: Boolean = false
 
   jsonConverter.configure(
     Map("schemas.enable" -> false).asJava, false
@@ -58,14 +57,12 @@ class JsonFormatWriter(outputStreamFn: () => S3OutputStream) extends S3FormatWri
 
   override def rolloverFileOnSchemaChange(): Boolean = false
 
-  override def close(): Unit = {
-    Try(outstandingRename = outputStream.complete)
+  override def close(newName: BucketAndPath): Unit = {
+    Try(outputStream.complete(newName))
 
     Try(outputStream.flush())
     Try(outputStream.close())
   }
-
-  override def getOutstandingRename: Boolean = outstandingRename
 
   override def getPointer: Long = outputStream.getPointer
 }

--- a/kafka-connect-aws-s3/src/main/scala/io/lenses/streamreactor/connect/aws/s3/formats/JsonFormatWriter.scala
+++ b/kafka-connect-aws-s3/src/main/scala/io/lenses/streamreactor/connect/aws/s3/formats/JsonFormatWriter.scala
@@ -57,7 +57,7 @@ class JsonFormatWriter(outputStreamFn: () => S3OutputStream) extends S3FormatWri
 
   override def rolloverFileOnSchemaChange(): Boolean = false
 
-  override def close(newName: BucketAndPath): Unit = {
+  override def close(newName: RemotePathLocation): Unit = {
     Try(outputStream.complete(newName))
 
     Try(outputStream.flush())

--- a/kafka-connect-aws-s3/src/main/scala/io/lenses/streamreactor/connect/aws/s3/formats/ParquetFormatStreamReader.scala
+++ b/kafka-connect-aws-s3/src/main/scala/io/lenses/streamreactor/connect/aws/s3/formats/ParquetFormatStreamReader.scala
@@ -20,14 +20,14 @@ import java.io.InputStream
 
 import io.confluent.connect.avro.AvroData
 import io.lenses.streamreactor.connect.aws.s3.formats.parquet.ParquetStreamingInputFile
-import io.lenses.streamreactor.connect.aws.s3.model.{BucketAndPath, SchemaAndValueSourceData}
+import io.lenses.streamreactor.connect.aws.s3.model.{RemotePathLocation, SchemaAndValueSourceData}
 import org.apache.avro.generic.GenericRecord
 import org.apache.parquet.avro.AvroParquetReader
 import org.apache.parquet.hadoop.ParquetReader
 
 import scala.util.Try
 
-class ParquetFormatStreamReader(inputStreamFn: () => InputStream, fileSizeFn: () => Long, bucketAndPath: BucketAndPath)
+class ParquetFormatStreamReader(inputStreamFn: () => InputStream, fileSizeFn: () => Long, bucketAndPath: RemotePathLocation)
   extends S3FormatStreamReader[SchemaAndValueSourceData] with Using {
 
   private val inputFile = new ParquetStreamingInputFile(inputStreamFn, fileSizeFn)
@@ -36,7 +36,7 @@ class ParquetFormatStreamReader(inputStreamFn: () => InputStream, fileSizeFn: ()
   private var lineNumber: Long = -1
   private val avroDataConverter = new AvroData(100)
 
-  override def getBucketAndPath: BucketAndPath = bucketAndPath
+  override def getBucketAndPath: RemotePathLocation = bucketAndPath
 
   override def getLineNumber: Long = lineNumber
 

--- a/kafka-connect-aws-s3/src/main/scala/io/lenses/streamreactor/connect/aws/s3/formats/ParquetFormatWriter.scala
+++ b/kafka-connect-aws-s3/src/main/scala/io/lenses/streamreactor/connect/aws/s3/formats/ParquetFormatWriter.scala
@@ -19,7 +19,7 @@ package io.lenses.streamreactor.connect.aws.s3.formats
 
 import com.typesafe.scalalogging.LazyLogging
 import io.lenses.streamreactor.connect.aws.s3.formats.parquet.ParquetOutputFile
-import io.lenses.streamreactor.connect.aws.s3.model.{BucketAndPath, SinkData, Topic}
+import io.lenses.streamreactor.connect.aws.s3.model.{RemotePathLocation, SinkData, Topic}
 import io.lenses.streamreactor.connect.aws.s3.sink.conversion.ToAvroDataConverter
 import io.lenses.streamreactor.connect.aws.s3.storage.S3OutputStream
 import org.apache.avro.Schema
@@ -66,7 +66,7 @@ class ParquetFormatWriter(outputStreamFn: () => S3OutputStream) extends S3Format
 
   override def rolloverFileOnSchemaChange() = true
 
-  override def close(newName: BucketAndPath) = {
+  override def close(newName: RemotePathLocation) = {
     Try(writer.close())
     Try(outputStream.flush())
     Try(outputStream.complete(newName))

--- a/kafka-connect-aws-s3/src/main/scala/io/lenses/streamreactor/connect/aws/s3/formats/ParquetFormatWriter.scala
+++ b/kafka-connect-aws-s3/src/main/scala/io/lenses/streamreactor/connect/aws/s3/formats/ParquetFormatWriter.scala
@@ -19,7 +19,7 @@ package io.lenses.streamreactor.connect.aws.s3.formats
 
 import com.typesafe.scalalogging.LazyLogging
 import io.lenses.streamreactor.connect.aws.s3.formats.parquet.ParquetOutputFile
-import io.lenses.streamreactor.connect.aws.s3.model.{SinkData, Topic}
+import io.lenses.streamreactor.connect.aws.s3.model.{BucketAndPath, SinkData, Topic}
 import io.lenses.streamreactor.connect.aws.s3.sink.conversion.ToAvroDataConverter
 import io.lenses.streamreactor.connect.aws.s3.storage.S3OutputStream
 import org.apache.avro.Schema
@@ -31,7 +31,6 @@ import org.apache.parquet.hadoop.ParquetWriter.{DEFAULT_BLOCK_SIZE, DEFAULT_PAGE
 import scala.util.Try
 
 class ParquetFormatWriter(outputStreamFn: () => S3OutputStream) extends S3FormatWriter with LazyLogging {
-  private var outstandingRename: Boolean = false
 
   private var outputStream: S3OutputStream = _
 
@@ -67,14 +66,12 @@ class ParquetFormatWriter(outputStreamFn: () => S3OutputStream) extends S3Format
 
   override def rolloverFileOnSchemaChange() = true
 
-  override def close(): Unit = {
+  override def close(newName: BucketAndPath) = {
     Try(writer.close())
     Try(outputStream.flush())
-    Try(outstandingRename = outputStream.complete)
+    Try(outputStream.complete(newName))
     Try(outputStream.close())
   }
-
-  override def getOutstandingRename: Boolean = outstandingRename
 
   override def getPointer: Long = outputStream.getPointer
 }

--- a/kafka-connect-aws-s3/src/main/scala/io/lenses/streamreactor/connect/aws/s3/formats/S3FormatReader.scala
+++ b/kafka-connect-aws-s3/src/main/scala/io/lenses/streamreactor/connect/aws/s3/formats/S3FormatReader.scala
@@ -26,8 +26,6 @@ trait S3FormatReader extends AutoCloseable {
 
   def write(struct: Struct, topic: Topic): Unit
 
-  def getOutstandingRename: Boolean
-
   def getPointer: Long
 }
 

--- a/kafka-connect-aws-s3/src/main/scala/io/lenses/streamreactor/connect/aws/s3/formats/S3FormatStreamReader.scala
+++ b/kafka-connect-aws-s3/src/main/scala/io/lenses/streamreactor/connect/aws/s3/formats/S3FormatStreamReader.scala
@@ -20,7 +20,7 @@ import java.io.InputStream
 
 import io.lenses.streamreactor.connect.aws.s3.config.Format
 import io.lenses.streamreactor.connect.aws.s3.config.FormatOptions.WithHeaders
-import io.lenses.streamreactor.connect.aws.s3.model.{BucketAndPath, SourceData}
+import io.lenses.streamreactor.connect.aws.s3.model.{RemotePathLocation, SourceData}
 import io.lenses.streamreactor.connect.aws.s3.source.config.SourceBucketOptions
 
 object S3FormatStreamReader {
@@ -29,7 +29,7 @@ object S3FormatStreamReader {
              inputStreamFn: () => InputStream,
              fileSizeFn: () => Long,
              options: SourceBucketOptions,
-             bucketAndPath: BucketAndPath
+             bucketAndPath: RemotePathLocation
            ): S3FormatStreamReader[_ <: SourceData] =
     options.format.format match {
       case Format.Avro => new AvroFormatStreamReader(inputStreamFn, bucketAndPath)
@@ -49,7 +49,7 @@ object S3FormatStreamReader {
 
 trait S3FormatStreamReader[R <: SourceData] extends AutoCloseable with Iterator[R] {
 
-  def getBucketAndPath: BucketAndPath
+  def getBucketAndPath: RemotePathLocation
 
   def getLineNumber: Long
 

--- a/kafka-connect-aws-s3/src/main/scala/io/lenses/streamreactor/connect/aws/s3/formats/S3FormatWriter.scala
+++ b/kafka-connect-aws-s3/src/main/scala/io/lenses/streamreactor/connect/aws/s3/formats/S3FormatWriter.scala
@@ -20,8 +20,8 @@ package io.lenses.streamreactor.connect.aws.s3.formats
 import io.lenses.streamreactor.connect.aws.s3.config.Format._
 import io.lenses.streamreactor.connect.aws.s3.config.FormatOptions.WithHeaders
 import io.lenses.streamreactor.connect.aws.s3.config.{FormatOptions, FormatSelection}
-import io.lenses.streamreactor.connect.aws.s3.model.{BytesWriteMode, SinkData, Topic}
-import io.lenses.streamreactor.connect.aws.s3.storage.MultipartBlobStoreOutputStream
+import io.lenses.streamreactor.connect.aws.s3.model.{BucketAndPath, BytesWriteMode, SinkData, Topic}
+import io.lenses.streamreactor.connect.aws.s3.storage.{MultipartBlobStoreOutputStream, S3OutputStream}
 import org.apache.kafka.connect.errors.ConnectException
 
 object S3FormatWriter {
@@ -35,7 +35,7 @@ object S3FormatWriter {
 
   def apply(
              formatInfo: FormatSelection,
-             outputStreamFn: () => MultipartBlobStoreOutputStream
+             outputStreamFn: () => S3OutputStream
            ): S3FormatWriter = {
 
     formatInfo.format match {
@@ -51,15 +51,15 @@ object S3FormatWriter {
 
 }
 
-trait S3FormatWriter extends AutoCloseable {
+trait S3FormatWriter {
 
   def rolloverFileOnSchemaChange(): Boolean
 
   def write(keySinkData: Option[SinkData], valueSinkData: SinkData, topic: Topic): Unit
 
-  def getOutstandingRename: Boolean
-
   def getPointer: Long
+
+  def close(newName: BucketAndPath)
 }
 
 

--- a/kafka-connect-aws-s3/src/main/scala/io/lenses/streamreactor/connect/aws/s3/formats/S3FormatWriter.scala
+++ b/kafka-connect-aws-s3/src/main/scala/io/lenses/streamreactor/connect/aws/s3/formats/S3FormatWriter.scala
@@ -20,7 +20,7 @@ package io.lenses.streamreactor.connect.aws.s3.formats
 import io.lenses.streamreactor.connect.aws.s3.config.Format._
 import io.lenses.streamreactor.connect.aws.s3.config.FormatOptions.WithHeaders
 import io.lenses.streamreactor.connect.aws.s3.config.{FormatOptions, FormatSelection}
-import io.lenses.streamreactor.connect.aws.s3.model.{BucketAndPath, BytesWriteMode, SinkData, Topic}
+import io.lenses.streamreactor.connect.aws.s3.model.{RemotePathLocation, BytesWriteMode, SinkData, Topic}
 import io.lenses.streamreactor.connect.aws.s3.storage.{MultipartBlobStoreOutputStream, S3OutputStream}
 import org.apache.kafka.connect.errors.ConnectException
 
@@ -59,7 +59,7 @@ trait S3FormatWriter {
 
   def getPointer: Long
 
-  def close(newName: BucketAndPath)
+  def close(newName: RemotePathLocation)
 }
 
 

--- a/kafka-connect-aws-s3/src/main/scala/io/lenses/streamreactor/connect/aws/s3/formats/TextFormatStreamReader.scala
+++ b/kafka-connect-aws-s3/src/main/scala/io/lenses/streamreactor/connect/aws/s3/formats/TextFormatStreamReader.scala
@@ -18,12 +18,12 @@ package io.lenses.streamreactor.connect.aws.s3.formats
 
 import java.io.InputStream
 
-import io.lenses.streamreactor.connect.aws.s3.model.{BucketAndPath, StringSourceData}
+import io.lenses.streamreactor.connect.aws.s3.model.{RemotePathLocation, StringSourceData}
 
 import scala.io.Source
 import scala.util.Try
 
-class TextFormatStreamReader(inputStreamFn: () => InputStream, bucketAndPath: BucketAndPath) extends S3FormatStreamReader[StringSourceData] {
+class TextFormatStreamReader(inputStreamFn: () => InputStream, bucketAndPath: RemotePathLocation) extends S3FormatStreamReader[StringSourceData] {
 
   private val inputStream: InputStream = inputStreamFn()
   private val source = Source.fromInputStream(inputStream, "UTF-8")
@@ -42,7 +42,7 @@ class TextFormatStreamReader(inputStreamFn: () => InputStream, bucketAndPath: Bu
     StringSourceData(sourceLines.next(), lineNumber)
   }
 
-  override def getBucketAndPath: BucketAndPath = bucketAndPath
+  override def getBucketAndPath: RemotePathLocation = bucketAndPath
 
   override def getLineNumber: Long = lineNumber
 }

--- a/kafka-connect-aws-s3/src/main/scala/io/lenses/streamreactor/connect/aws/s3/formats/TextFormatWriter.scala
+++ b/kafka-connect-aws-s3/src/main/scala/io/lenses/streamreactor/connect/aws/s3/formats/TextFormatWriter.scala
@@ -18,8 +18,7 @@
 package io.lenses.streamreactor.connect.aws.s3.formats
 
 import java.nio.charset.StandardCharsets
-
-import io.lenses.streamreactor.connect.aws.s3.model.{PrimitiveSinkData, SinkData, Topic}
+import io.lenses.streamreactor.connect.aws.s3.model.{BucketAndPath, PrimitiveSinkData, SinkData, Topic}
 import io.lenses.streamreactor.connect.aws.s3.storage.S3OutputStream
 
 import scala.util.{Failure, Success, Try}
@@ -29,7 +28,6 @@ class TextFormatWriter(outputStreamFn: () => S3OutputStream) extends S3FormatWri
   private val LineSeparatorBytes: Array[Byte] = System.lineSeparator.getBytes(StandardCharsets.UTF_8)
 
   private val outputStream: S3OutputStream = outputStreamFn()
-  private var outstandingRename: Boolean = false
 
   override def write(keySinkData: Option[SinkData], valueSinkData: SinkData, topic: Topic): Unit = {
 
@@ -50,14 +48,12 @@ class TextFormatWriter(outputStreamFn: () => S3OutputStream) extends S3FormatWri
 
   override def rolloverFileOnSchemaChange(): Boolean = false
 
-  override def close(): Unit = {
-    Try(outstandingRename = outputStream.complete)
+  override def close(newName: BucketAndPath): Unit = {
+    Try(outputStream.complete(newName))
 
     Try(outputStream.flush())
     Try(outputStream.close())
   }
-
-  override def getOutstandingRename: Boolean = outstandingRename
 
   override def getPointer: Long = outputStream.getPointer
 }

--- a/kafka-connect-aws-s3/src/main/scala/io/lenses/streamreactor/connect/aws/s3/formats/TextFormatWriter.scala
+++ b/kafka-connect-aws-s3/src/main/scala/io/lenses/streamreactor/connect/aws/s3/formats/TextFormatWriter.scala
@@ -18,7 +18,7 @@
 package io.lenses.streamreactor.connect.aws.s3.formats
 
 import java.nio.charset.StandardCharsets
-import io.lenses.streamreactor.connect.aws.s3.model.{BucketAndPath, PrimitiveSinkData, SinkData, Topic}
+import io.lenses.streamreactor.connect.aws.s3.model.{RemotePathLocation, PrimitiveSinkData, SinkData, Topic}
 import io.lenses.streamreactor.connect.aws.s3.storage.S3OutputStream
 
 import scala.util.{Failure, Success, Try}
@@ -48,7 +48,7 @@ class TextFormatWriter(outputStreamFn: () => S3OutputStream) extends S3FormatWri
 
   override def rolloverFileOnSchemaChange(): Boolean = false
 
-  override def close(newName: BucketAndPath): Unit = {
+  override def close(newName: RemotePathLocation): Unit = {
     Try(outputStream.complete(newName))
 
     Try(outputStream.flush())

--- a/kafka-connect-aws-s3/src/main/scala/io/lenses/streamreactor/connect/aws/s3/model/BytesWriteMode.scala
+++ b/kafka-connect-aws-s3/src/main/scala/io/lenses/streamreactor/connect/aws/s3/model/BytesWriteMode.scala
@@ -30,7 +30,7 @@ sealed trait BytesWriteMode extends EnumEntry {
 }
 
 object BytesWriteMode extends Enum[BytesWriteMode] {
-  val values: immutable.IndexedSeq[BytesWriteMode] = findValues
+  override val values: immutable.IndexedSeq[BytesWriteMode] = findValues
 
   case object KeyAndValueWithSizes extends BytesWriteMode {
     override def read(storedByteArray: Array[Byte]): BytesOutputRow = throw new IllegalArgumentException(s"Invalid apply function for bytesWriteMode key/value only $this")

--- a/kafka-connect-aws-s3/src/main/scala/io/lenses/streamreactor/connect/aws/s3/model/PartitionDisplay.scala
+++ b/kafka-connect-aws-s3/src/main/scala/io/lenses/streamreactor/connect/aws/s3/model/PartitionDisplay.scala
@@ -26,7 +26,7 @@ sealed trait PartitionDisplay extends EnumEntry
 
 object PartitionDisplay extends Enum[PartitionDisplay] {
 
-  val values: immutable.IndexedSeq[PartitionDisplay] = findValues
+  override val values: immutable.IndexedSeq[PartitionDisplay] = findValues
 
   case object KeysAndValues extends PartitionDisplay
 

--- a/kafka-connect-aws-s3/src/main/scala/io/lenses/streamreactor/connect/aws/s3/model/S3OutputStreamOptions.scala
+++ b/kafka-connect-aws-s3/src/main/scala/io/lenses/streamreactor/connect/aws/s3/model/S3OutputStreamOptions.scala
@@ -1,0 +1,104 @@
+/*
+ * Copyright 2021 Lenses.io
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.lenses.streamreactor.connect.aws.s3.model
+
+import cats.syntax.all._
+import com.typesafe.scalalogging.LazyLogging
+import io.lenses.streamreactor.connect.aws.s3.config.FormatSelection
+import io.lenses.streamreactor.connect.aws.s3.config.S3ConfigSettings.LOCAL_TMP_DIRECTORY
+import io.lenses.streamreactor.connect.aws.s3.formats.S3FormatWriter
+import io.lenses.streamreactor.connect.aws.s3.model.S3WriteMode.{BuildLocal, Streamed}
+import io.lenses.streamreactor.connect.aws.s3.storage.{BuildLocalOutputStream, MultipartBlobStoreOutputStream, S3OutputStream, StorageInterface}
+
+import java.nio.file.Files
+import java.util.UUID
+
+
+sealed trait S3OutputStreamOptions {
+  def createFormatWriter(formatSelection: FormatSelection, path: RemotePathLocation)(implicit storageInterface: StorageInterface): S3FormatWriter
+}
+
+object S3OutputStreamOptions extends LazyLogging{
+
+  def apply(writeMode: String, props: Map[String, String]) : Either[Exception, S3OutputStreamOptions] = {
+    S3WriteMode.withNameInsensitiveOption(writeMode) match {
+      case Some(BuildLocal) => BuildLocalOutputStreamOptions(props)
+      case Some(Streamed) => StreamedWriteOutputStreamOptions().asRight[Exception]
+      case None => logger.warn(s"Unknown write mode ('$writeMode') requested, defaulting to 'Streamed'")
+        StreamedWriteOutputStreamOptions().asRight[Exception]
+    }
+  }
+
+}
+
+case class StreamedWriteOutputStreamOptions() extends S3OutputStreamOptions {
+
+  val MinAllowedMultipartSize: Int = 5242880
+
+  override def createFormatWriter(formatSelection: FormatSelection, path: RemotePathLocation)(implicit storageInterface: StorageInterface): S3FormatWriter = {
+    val streamFn = createOutputStreamFn(storageInterface, path)
+    S3FormatWriter(formatSelection, streamFn)
+  }
+
+  private def createOutputStreamFn(storageInterface: StorageInterface, location: RemotePathLocation): () => S3OutputStream = {
+    () => new MultipartBlobStoreOutputStream(location, MinAllowedMultipartSize)(storageInterface)
+  }
+
+}
+
+
+
+object BuildLocalOutputStreamOptions {
+
+  val PROPERTY_SINK_NAME = "name"
+
+  def apply(props: Map[String, String]): Either[Exception, BuildLocalOutputStreamOptions]  = {
+
+    def fetchFromProps(propertyToFetch: String) : Option[String] = {
+      props
+        .get(propertyToFetch)
+        .filter(_.trim.nonEmpty)
+    }
+
+    fetchFromProps(LOCAL_TMP_DIRECTORY)
+      .orElse(
+        fetchFromProps(PROPERTY_SINK_NAME)
+          .map(
+            sinkName =>
+              Option(Files.createTempDirectory(s"$sinkName.${UUID.randomUUID().toString}.").toAbsolutePath.toString)
+          ).getOrElse(Option.empty[String])
+      )
+    match {
+      case Some(value) => BuildLocalOutputStreamOptions(LocalLocation(value)).asRight[Exception]
+      case None => new IllegalStateException(s"Either a local temporary directory ($LOCAL_TMP_DIRECTORY) or a Sink Name ($PROPERTY_SINK_NAME) must be configured to use '${BuildLocal.entryName}' write mode.").asLeft[BuildLocalOutputStreamOptions]
+    }
+  }
+}
+
+case class BuildLocalOutputStreamOptions(localLocation: LocalLocation) extends S3OutputStreamOptions {
+
+  override def createFormatWriter(formatSelection: FormatSelection, path: RemotePathLocation)(implicit storageInterface: StorageInterface): S3FormatWriter = {
+    val streamFn = createOutputStreamFn(storageInterface, LocalLocation(localLocation, path))
+    S3FormatWriter(formatSelection, streamFn)
+  }
+
+  private def createOutputStreamFn(storageInterface: StorageInterface, location: LocalLocation): () => S3OutputStream = {
+    () => new BuildLocalOutputStream(location)(storageInterface)
+  }
+
+}
+

--- a/kafka-connect-aws-s3/src/main/scala/io/lenses/streamreactor/connect/aws/s3/model/S3WriteMode.scala
+++ b/kafka-connect-aws-s3/src/main/scala/io/lenses/streamreactor/connect/aws/s3/model/S3WriteMode.scala
@@ -1,6 +1,5 @@
-
 /*
- * Copyright 2020 Lenses.io
+ * Copyright 2021 Lenses.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,16 +14,21 @@
  * limitations under the License.
  */
 
-package io.lenses.streamreactor.connect.aws.s3.storage
+package io.lenses.streamreactor.connect.aws.s3.model
 
-import io.lenses.streamreactor.connect.aws.s3.model.BucketAndPath
+import enumeratum.{Enum, EnumEntry}
 
-import java.io.OutputStream
+import scala.collection.immutable
 
-trait S3OutputStream extends OutputStream {
+sealed trait S3WriteMode extends EnumEntry
 
-  def complete(finalDestination: BucketAndPath): Unit
+object S3WriteMode extends Enum[S3WriteMode] {
 
-  def getPointer: Long
+  override val values: immutable.IndexedSeq[S3WriteMode] = findValues
+
+  case object Streamed extends S3WriteMode
+
+  case object BuildLocal extends S3WriteMode
+
 
 }

--- a/kafka-connect-aws-s3/src/main/scala/io/lenses/streamreactor/connect/aws/s3/model/S3WriteMode.scala
+++ b/kafka-connect-aws-s3/src/main/scala/io/lenses/streamreactor/connect/aws/s3/model/S3WriteMode.scala
@@ -18,17 +18,11 @@ package io.lenses.streamreactor.connect.aws.s3.model
 
 import enumeratum.{Enum, EnumEntry}
 
-import scala.collection.immutable
-
 sealed trait S3WriteMode extends EnumEntry
 
 object S3WriteMode extends Enum[S3WriteMode] {
-
-  override val values: immutable.IndexedSeq[S3WriteMode] = findValues
-
-  case object Streamed extends S3WriteMode
+  override val values = findValues
 
   case object BuildLocal extends S3WriteMode
-
-
+  case object Streamed extends S3WriteMode
 }

--- a/kafka-connect-aws-s3/src/main/scala/io/lenses/streamreactor/connect/aws/s3/model/TopicPartitionOffset.scala
+++ b/kafka-connect-aws-s3/src/main/scala/io/lenses/streamreactor/connect/aws/s3/model/TopicPartitionOffset.scala
@@ -22,7 +22,7 @@ case class OffsetReaderResult(path: String, line: String)
 
 case class PollResults(
                         resultList: Vector[_ <: SourceData],
-                        bucketAndPath: BucketAndPath,
+                        bucketAndPath: RemotePathLocation,
                         prefix: String,
                         targetTopic: String
                       )

--- a/kafka-connect-aws-s3/src/main/scala/io/lenses/streamreactor/connect/aws/s3/sink/OffsetSeeker.scala
+++ b/kafka-connect-aws-s3/src/main/scala/io/lenses/streamreactor/connect/aws/s3/sink/OffsetSeeker.scala
@@ -17,7 +17,7 @@
 
 package io.lenses.streamreactor.connect.aws.s3.sink
 
-import io.lenses.streamreactor.connect.aws.s3.model.{BucketAndPath, TopicPartitionOffset}
+import io.lenses.streamreactor.connect.aws.s3.model.{RemotePathLocation, TopicPartitionOffset}
 import io.lenses.streamreactor.connect.aws.s3.storage.StorageInterface
 
 import scala.util.control.NonFatal
@@ -31,7 +31,7 @@ import scala.util.control.NonFatal
 class OffsetSeeker(fileNamingStrategy: S3FileNamingStrategy) {
   private val logger = org.slf4j.LoggerFactory.getLogger(getClass.getName)
 
-  def seek(bucketAndPath: BucketAndPath)(implicit storageInterface: StorageInterface): Set[TopicPartitionOffset] = {
+  def seek(bucketAndPath: RemotePathLocation)(implicit storageInterface: StorageInterface): Set[TopicPartitionOffset] = {
     try {
 
       // the path may not have been created, in which case we have no offsets defined

--- a/kafka-connect-aws-s3/src/main/scala/io/lenses/streamreactor/connect/aws/s3/sink/config/S3SinkConfig.scala
+++ b/kafka-connect-aws-s3/src/main/scala/io/lenses/streamreactor/connect/aws/s3/sink/config/S3SinkConfig.scala
@@ -17,21 +17,25 @@
 
 package io.lenses.streamreactor.connect.aws.s3.sink.config
 
+import cats.syntax.all._
 import com.datamountaineer.kcql.Kcql
 import io.lenses.streamreactor.connect.aws.s3.config.Format.Json
 import io.lenses.streamreactor.connect.aws.s3.config.S3FlushSettings.{defaultFlushCount, defaultFlushInterval, defaultFlushSize}
 import io.lenses.streamreactor.connect.aws.s3.config.{FormatSelection, S3Config, S3ConfigDefBuilder}
-import io.lenses.streamreactor.connect.aws.s3.model.{RemoteRootLocation, PartitionSelection, S3OutputStreamOptions, StreamedWriteOutputStreamOptions}
+import io.lenses.streamreactor.connect.aws.s3.model.{PartitionSelection, RemoteRootLocation, S3OutputStreamOptions, StreamedWriteOutputStreamOptions}
 import io.lenses.streamreactor.connect.aws.s3.sink._
 
 import scala.collection.JavaConverters._
 
 object S3SinkConfig {
 
-  def apply(props: Map[String, String]): S3SinkConfig = S3SinkConfig(
-    S3Config(props),
-    SinkBucketOptions(props)
-  )
+  def apply(props: Map[String, String]): Either[Exception, S3SinkConfig] = {
+    SinkBucketOptions(props) match {
+      case Left(ex) => ex.asLeft[S3SinkConfig]
+      case Right(value) => S3SinkConfig(S3Config(props), value).asRight[Exception]
+    }
+
+  }
 
 }
 
@@ -42,7 +46,7 @@ case class S3SinkConfig(
 
 object SinkBucketOptions {
 
-  def apply(props: Map[String, String]): Set[SinkBucketOptions] = {
+  def apply(props: Map[String, String]): Either[Exception, Set[SinkBucketOptions]] = {
 
     val config = S3ConfigDefBuilder(props.asJava)
 
@@ -59,16 +63,20 @@ object SinkBucketOptions {
         case None => new HierarchicalS3FileNamingStrategy(formatSelection)
       }
 
-      SinkBucketOptions(
-        kcql.getSource,
-        RemoteRootLocation(kcql.getTarget),
-        formatSelection = formatSelection,
-        fileNamingStrategy = namingStrategy,
-        partitionSelection = partitionSelection,
-        commitPolicy = config.commitPolicy(kcql),
-        writeMode = config.s3WriteOptions(props),
-      )
-    }
+      val s3WriteOptions = config.s3WriteOptions(props)
+      s3WriteOptions match {
+        case Right(value) => SinkBucketOptions(
+          kcql.getSource,
+          RemoteRootLocation(kcql.getTarget),
+          formatSelection = formatSelection,
+          fileNamingStrategy = namingStrategy,
+          partitionSelection = partitionSelection,
+          commitPolicy = config.commitPolicy(kcql),
+          writeMode = value,
+        )
+        case Left(exception) => return exception.asLeft[Set[SinkBucketOptions]]
+      }
+    }.asRight[Exception]
 
   }
 

--- a/kafka-connect-aws-s3/src/main/scala/io/lenses/streamreactor/connect/aws/s3/sink/config/S3SinkConfig.scala
+++ b/kafka-connect-aws-s3/src/main/scala/io/lenses/streamreactor/connect/aws/s3/sink/config/S3SinkConfig.scala
@@ -18,17 +18,13 @@
 package io.lenses.streamreactor.connect.aws.s3.sink.config
 
 import com.datamountaineer.kcql.Kcql
-import io.lenses.streamreactor.connect.aws.s3.config.FormatSelection
-import io.lenses.streamreactor.connect.aws.s3.config.S3Config
-import io.lenses.streamreactor.connect.aws.s3.config.S3ConfigDefBuilder
 import io.lenses.streamreactor.connect.aws.s3.config.Format.Json
-import io.lenses.streamreactor.connect.aws.s3.model.BucketAndPrefix
-import io.lenses.streamreactor.connect.aws.s3.model.PartitionSelection
-import io.lenses.streamreactor.connect.aws.s3.sink._
 import io.lenses.streamreactor.connect.aws.s3.config.S3FlushSettings.{defaultFlushCount, defaultFlushInterval, defaultFlushSize}
+import io.lenses.streamreactor.connect.aws.s3.config.{FormatSelection, S3Config, S3ConfigDefBuilder, S3WriteModeSettings}
+import io.lenses.streamreactor.connect.aws.s3.model.{BucketAndPrefix, LocalLocation, PartitionSelection, S3WriteMode}
+import io.lenses.streamreactor.connect.aws.s3.sink._
 
 import scala.collection.JavaConverters._
-import scala.concurrent.duration._
 
 object S3SinkConfig {
 
@@ -69,7 +65,9 @@ object SinkBucketOptions {
         formatSelection = formatSelection,
         fileNamingStrategy = namingStrategy,
         partitionSelection = partitionSelection,
-        commitPolicy = config.commitPolicy(kcql)
+        commitPolicy = config.commitPolicy(kcql),
+        writeMode = config.s3WriteMode(),
+        localBuildDirectory = config.s3LocalBuildDirectory(props.get("name"))
       )
     }
 
@@ -84,4 +82,6 @@ case class SinkBucketOptions(
                               fileNamingStrategy: S3FileNamingStrategy,
                               partitionSelection: Option[PartitionSelection] = None,
                               commitPolicy: CommitPolicy = DefaultCommitPolicy(Some(defaultFlushSize), Some(defaultFlushInterval), Some(defaultFlushCount)),
+                              writeMode: S3WriteMode = S3WriteModeSettings.defaultWriteMode,
+                              localBuildDirectory: Option[LocalLocation] = None
                             )

--- a/kafka-connect-aws-s3/src/main/scala/io/lenses/streamreactor/connect/aws/s3/sink/config/S3SinkConfig.scala
+++ b/kafka-connect-aws-s3/src/main/scala/io/lenses/streamreactor/connect/aws/s3/sink/config/S3SinkConfig.scala
@@ -20,8 +20,8 @@ package io.lenses.streamreactor.connect.aws.s3.sink.config
 import com.datamountaineer.kcql.Kcql
 import io.lenses.streamreactor.connect.aws.s3.config.Format.Json
 import io.lenses.streamreactor.connect.aws.s3.config.S3FlushSettings.{defaultFlushCount, defaultFlushInterval, defaultFlushSize}
-import io.lenses.streamreactor.connect.aws.s3.config.{FormatSelection, S3Config, S3ConfigDefBuilder, S3WriteModeSettings}
-import io.lenses.streamreactor.connect.aws.s3.model.{BucketAndPrefix, LocalLocation, PartitionSelection, S3WriteMode}
+import io.lenses.streamreactor.connect.aws.s3.config.{FormatSelection, S3Config, S3ConfigDefBuilder}
+import io.lenses.streamreactor.connect.aws.s3.model.{RemoteRootLocation, PartitionSelection, S3OutputStreamOptions, StreamedWriteOutputStreamOptions}
 import io.lenses.streamreactor.connect.aws.s3.sink._
 
 import scala.collection.JavaConverters._
@@ -61,13 +61,12 @@ object SinkBucketOptions {
 
       SinkBucketOptions(
         kcql.getSource,
-        BucketAndPrefix(kcql.getTarget),
+        RemoteRootLocation(kcql.getTarget),
         formatSelection = formatSelection,
         fileNamingStrategy = namingStrategy,
         partitionSelection = partitionSelection,
         commitPolicy = config.commitPolicy(kcql),
-        writeMode = config.s3WriteMode(),
-        localBuildDirectory = config.s3LocalBuildDirectory(props.get("name"))
+        writeMode = config.s3WriteOptions(props),
       )
     }
 
@@ -77,11 +76,10 @@ object SinkBucketOptions {
 
 case class SinkBucketOptions(
                               sourceTopic: String,
-                              bucketAndPrefix: BucketAndPrefix,
+                              bucketAndPrefix: RemoteRootLocation,
                               formatSelection: FormatSelection,
                               fileNamingStrategy: S3FileNamingStrategy,
                               partitionSelection: Option[PartitionSelection] = None,
                               commitPolicy: CommitPolicy = DefaultCommitPolicy(Some(defaultFlushSize), Some(defaultFlushInterval), Some(defaultFlushCount)),
-                              writeMode: S3WriteMode = S3WriteModeSettings.defaultWriteMode,
-                              localBuildDirectory: Option[LocalLocation] = None
+                              writeMode: S3OutputStreamOptions = StreamedWriteOutputStreamOptions(),
                             )

--- a/kafka-connect-aws-s3/src/main/scala/io/lenses/streamreactor/connect/aws/s3/source/S3BucketReaderManager.scala
+++ b/kafka-connect-aws-s3/src/main/scala/io/lenses/streamreactor/connect/aws/s3/source/S3BucketReaderManager.scala
@@ -107,7 +107,7 @@ class S3BucketReaderManager(
   }
 
   private def setUpReader(s3StoredFile: S3StoredFile): Option[S3FormatStreamReader[_ <: SourceData]] = {
-    val bucketAndPath = BucketAndPath(sourceBucketOptions.sourceBucketAndPrefix.bucket, s3StoredFile.path)
+    val bucketAndPath = RemotePathLocation(sourceBucketOptions.sourceBucketAndPrefix.bucket, s3StoredFile.path)
     val inputStreamFn = () => storageInterface.getBlob(bucketAndPath)
     val fileSizeFn = () => storageInterface.getBlobSize(bucketAndPath)
     logger.info(s"Reading next file: $s3StoredFile")

--- a/kafka-connect-aws-s3/src/main/scala/io/lenses/streamreactor/connect/aws/s3/source/S3SourceLister.scala
+++ b/kafka-connect-aws-s3/src/main/scala/io/lenses/streamreactor/connect/aws/s3/source/S3SourceLister.scala
@@ -18,7 +18,7 @@
 package io.lenses.streamreactor.connect.aws.s3.source
 
 import com.typesafe.scalalogging.LazyLogging
-import io.lenses.streamreactor.connect.aws.s3.model.{BucketAndPrefix, S3StoredFile, S3StoredFileSorter}
+import io.lenses.streamreactor.connect.aws.s3.model.{RemoteRootLocation, S3StoredFile, S3StoredFileSorter}
 import io.lenses.streamreactor.connect.aws.s3.sink.S3FileNamingStrategy
 import io.lenses.streamreactor.connect.aws.s3.storage.StorageInterface
 
@@ -30,7 +30,7 @@ import scala.util.control.NonFatal
   */
 class S3SourceLister(implicit storageInterface: StorageInterface) extends LazyLogging {
 
-  def list(implicit fileNamingStrategy: S3FileNamingStrategy, bucketAndPrefix: BucketAndPrefix): List[S3StoredFile] = {
+  def list(implicit fileNamingStrategy: S3FileNamingStrategy, bucketAndPrefix: RemoteRootLocation): List[S3StoredFile] = {
 
     def bucketLocationExists: Boolean = storageInterface.pathExists(bucketAndPrefix)
 
@@ -51,7 +51,7 @@ class S3SourceLister(implicit storageInterface: StorageInterface) extends LazyLo
 
   }
 
-  def next(fileNamingStrategy: S3FileNamingStrategy, bucketAndPrefix: BucketAndPrefix, lastResult: Option[S3StoredFile], resumeFrom: Option[S3StoredFile]): Option[S3StoredFile] = {
+  def next(fileNamingStrategy: S3FileNamingStrategy, bucketAndPrefix: RemoteRootLocation, lastResult: Option[S3StoredFile], resumeFrom: Option[S3StoredFile]): Option[S3StoredFile] = {
     val names = list(fileNamingStrategy, bucketAndPrefix)
 
     val position = if (resumeFrom.nonEmpty) {

--- a/kafka-connect-aws-s3/src/main/scala/io/lenses/streamreactor/connect/aws/s3/source/S3SourceTask.scala
+++ b/kafka-connect-aws-s3/src/main/scala/io/lenses/streamreactor/connect/aws/s3/source/S3SourceTask.scala
@@ -97,7 +97,7 @@ class S3SourceTask extends SourceTask {
       "prefix" -> prefix
     )
 
-  private def fromSourceOffset(bucketAndPath: BucketAndPath, offset: Long): Map[String, AnyRef] =
+  private def fromSourceOffset(bucketAndPath: RemotePathLocation, offset: Long): Map[String, AnyRef] =
     Map(
       "path" -> bucketAndPath.path,
       "line" -> offset.toString

--- a/kafka-connect-aws-s3/src/main/scala/io/lenses/streamreactor/connect/aws/s3/source/config/S3SourceConfig.scala
+++ b/kafka-connect-aws-s3/src/main/scala/io/lenses/streamreactor/connect/aws/s3/source/config/S3SourceConfig.scala
@@ -19,7 +19,7 @@ package io.lenses.streamreactor.connect.aws.s3.source.config
 import com.datamountaineer.kcql.Kcql
 import io.lenses.streamreactor.connect.aws.s3.config.Format.Json
 import io.lenses.streamreactor.connect.aws.s3.config.{FormatSelection, S3Config, S3ConfigDefBuilder}
-import io.lenses.streamreactor.connect.aws.s3.model.{BucketAndPrefix, PartitionSelection}
+import io.lenses.streamreactor.connect.aws.s3.model.{RemoteRootLocation, PartitionSelection}
 import io.lenses.streamreactor.connect.aws.s3.sink.{HierarchicalS3FileNamingStrategy, PartitionedS3FileNamingStrategy, S3FileNamingStrategy}
 
 import scala.collection.JavaConverters._
@@ -39,7 +39,7 @@ case class S3SourceConfig(
                          )
 
 case class SourceBucketOptions(
-                                sourceBucketAndPrefix: BucketAndPrefix,
+                                sourceBucketAndPrefix: RemoteRootLocation,
                                 targetTopic: String,
                                 format: FormatSelection,
                                 fileNamingStrategy: S3FileNamingStrategy,
@@ -70,7 +70,7 @@ object SourceBucketOptions {
           case None => new HierarchicalS3FileNamingStrategy(formatSelection)
         }
         SourceBucketOptions(
-          BucketAndPrefix(kcql.getSource),
+          RemoteRootLocation(kcql.getSource),
           kcql.getTarget,
           format = formatSelection,
           fileNamingStrategy = namingStrategy,

--- a/kafka-connect-aws-s3/src/main/scala/io/lenses/streamreactor/connect/aws/s3/storage/BuildLocalOutputStream.scala
+++ b/kafka-connect-aws-s3/src/main/scala/io/lenses/streamreactor/connect/aws/s3/storage/BuildLocalOutputStream.scala
@@ -18,19 +18,17 @@
 package io.lenses.streamreactor.connect.aws.s3.storage
 
 import com.typesafe.scalalogging.LazyLogging
-import io.lenses.streamreactor.connect.aws.s3.model.{RemotePathLocation, LocalLocation}
-import org.jclouds.blobstore.domain.{MultipartPart, MultipartUpload}
+import io.lenses.streamreactor.connect.aws.s3.model.{LocalLocation, RemotePathLocation}
 
 import java.io.{BufferedOutputStream, File, FileOutputStream, OutputStream}
-import java.nio.ByteBuffer
 
 
 class BuildLocalOutputStream(
-                                      initialName: LocalLocation,
-                                      cleanUp: Boolean = true,
-                                    )(
-                                      implicit storageInterface: StorageInterface
-                                    ) extends OutputStream with LazyLogging with S3OutputStream {
+                              initialName: LocalLocation,
+                              cleanUp: Boolean = true,
+                            )(
+                              implicit storageInterface: StorageInterface
+                            ) extends OutputStream with LazyLogging with S3OutputStream {
 
   private val file = new File(initialName.path)
 

--- a/kafka-connect-aws-s3/src/main/scala/io/lenses/streamreactor/connect/aws/s3/storage/BuildLocalOutputStream.scala
+++ b/kafka-connect-aws-s3/src/main/scala/io/lenses/streamreactor/connect/aws/s3/storage/BuildLocalOutputStream.scala
@@ -18,7 +18,7 @@
 package io.lenses.streamreactor.connect.aws.s3.storage
 
 import com.typesafe.scalalogging.LazyLogging
-import io.lenses.streamreactor.connect.aws.s3.model.{BucketAndPath, LocalLocation}
+import io.lenses.streamreactor.connect.aws.s3.model.{RemotePathLocation, LocalLocation}
 import org.jclouds.blobstore.domain.{MultipartPart, MultipartUpload}
 
 import java.io.{BufferedOutputStream, File, FileOutputStream, OutputStream}
@@ -57,7 +57,7 @@ class BuildLocalOutputStream(
     pointer += 1
   }
 
-  override def complete(finalDestination: BucketAndPath): Unit = {
+  override def complete(finalDestination: RemotePathLocation): Unit = {
     outputStream.close()
     storageInterface.uploadFile(initialName, finalDestination)
     if (cleanUp) file.delete()

--- a/kafka-connect-aws-s3/src/main/scala/io/lenses/streamreactor/connect/aws/s3/storage/BuildLocalOutputStream.scala
+++ b/kafka-connect-aws-s3/src/main/scala/io/lenses/streamreactor/connect/aws/s3/storage/BuildLocalOutputStream.scala
@@ -1,0 +1,69 @@
+
+/*
+ * Copyright 2020 Lenses.io
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.lenses.streamreactor.connect.aws.s3.storage
+
+import com.typesafe.scalalogging.LazyLogging
+import io.lenses.streamreactor.connect.aws.s3.model.{BucketAndPath, LocalLocation}
+import org.jclouds.blobstore.domain.{MultipartPart, MultipartUpload}
+
+import java.io.{BufferedOutputStream, File, FileOutputStream, OutputStream}
+import java.nio.ByteBuffer
+
+
+class BuildLocalOutputStream(
+                                      initialName: LocalLocation,
+                                      cleanUp: Boolean = true,
+                                    )(
+                                      implicit storageInterface: StorageInterface
+                                    ) extends OutputStream with LazyLogging with S3OutputStream {
+
+  private val file = new File(initialName.path)
+
+  private val outputStream = new BufferedOutputStream(new FileOutputStream(file))
+
+  private var pointer = 0
+
+  override def write(bytes: Array[Byte], startOffset: Int, numberOfBytes: Int): Unit = {
+
+    require(bytes != null && bytes.nonEmpty, "Bytes must be provided")
+    val endOffset = startOffset + numberOfBytes
+    require(
+      validateRange(startOffset, bytes.length) &&
+        numberOfBytes > 0 &&
+        validateRange(endOffset, bytes.length)
+    )
+
+    outputStream.write(bytes.slice(startOffset, endOffset))
+    pointer += endOffset - startOffset
+  }
+
+  override def write(b: Int): Unit = {
+    outputStream.write(b)
+    pointer += 1
+  }
+
+  override def complete(finalDestination: BucketAndPath): Unit = {
+    outputStream.close()
+    storageInterface.uploadFile(initialName, finalDestination)
+    if (cleanUp) file.delete()
+  }
+
+  private def validateRange(startOffset: Int, numberOfBytes: Int) = startOffset >= 0 && startOffset <= numberOfBytes
+
+  override def getPointer: Long = pointer
+}

--- a/kafka-connect-aws-s3/src/main/scala/io/lenses/streamreactor/connect/aws/s3/storage/MultipartBlobStoreOutputStream.scala
+++ b/kafka-connect-aws-s3/src/main/scala/io/lenses/streamreactor/connect/aws/s3/storage/MultipartBlobStoreOutputStream.scala
@@ -20,10 +20,10 @@ package io.lenses.streamreactor.connect.aws.s3.storage
 import java.io.OutputStream
 import java.nio.ByteBuffer
 import com.typesafe.scalalogging.LazyLogging
-import io.lenses.streamreactor.connect.aws.s3.model.{BucketAndPath, Location}
+import io.lenses.streamreactor.connect.aws.s3.model.{RemotePathLocation, Location}
 
 class MultipartBlobStoreOutputStream(
-                                      initialName: BucketAndPath,
+                                      initialName: RemotePathLocation,
                                       minAllowedMultipartSize: Int
                                     )(
                                       implicit storageInterface: StorageInterface
@@ -82,7 +82,7 @@ class MultipartBlobStoreOutputStream(
     pointer += numberOfBytes
   }
 
-  override def complete(finalDestination: BucketAndPath): Unit = {
+  override def complete(finalDestination: RemotePathLocation): Unit = {
 
     if (buffer.position() > 0)
       uploadState = storageInterface.uploadPart(uploadState, buffer.array(), buffer.position)

--- a/kafka-connect-aws-s3/src/main/scala/io/lenses/streamreactor/connect/aws/s3/storage/MultipartBlobStoreOutputStream.scala
+++ b/kafka-connect-aws-s3/src/main/scala/io/lenses/streamreactor/connect/aws/s3/storage/MultipartBlobStoreOutputStream.scala
@@ -19,18 +19,17 @@ package io.lenses.streamreactor.connect.aws.s3.storage
 
 import java.io.OutputStream
 import java.nio.ByteBuffer
-
 import com.typesafe.scalalogging.LazyLogging
-import io.lenses.streamreactor.connect.aws.s3.model.BucketAndPath
+import io.lenses.streamreactor.connect.aws.s3.model.{BucketAndPath, Location}
 
 class MultipartBlobStoreOutputStream(
-                                      bucketAndPath: BucketAndPath,
+                                      initialName: BucketAndPath,
                                       minAllowedMultipartSize: Int
                                     )(
                                       implicit storageInterface: StorageInterface
                                     ) extends OutputStream with LazyLogging with S3OutputStream {
 
-  private var uploadState: MultiPartUploadState = storageInterface.initUpload(bucketAndPath)
+  private var uploadState: MultiPartUploadState = storageInterface.initUpload(initialName)
   private val buffer: ByteBuffer = ByteBuffer.allocate(minAllowedMultipartSize)
   private var pointer = 0
   private var uploadedBytes: Long = 0
@@ -83,7 +82,7 @@ class MultipartBlobStoreOutputStream(
     pointer += numberOfBytes
   }
 
-  def complete: Boolean = {
+  override def complete(finalDestination: BucketAndPath): Unit = {
 
     if (buffer.position() > 0)
       uploadState = storageInterface.uploadPart(uploadState, buffer.array(), buffer.position)
@@ -92,9 +91,10 @@ class MultipartBlobStoreOutputStream(
       case state if state.parts.nonEmpty =>
         storageInterface.completeUpload(state)
         buffer.clear()
-        true
-
-      case _ => false
+        if(initialName != finalDestination) {
+          storageInterface.rename(initialName, finalDestination)
+        }
+      case _ =>
     }
 
   }

--- a/kafka-connect-aws-s3/src/main/scala/io/lenses/streamreactor/connect/aws/s3/storage/S3OutputStream.scala
+++ b/kafka-connect-aws-s3/src/main/scala/io/lenses/streamreactor/connect/aws/s3/storage/S3OutputStream.scala
@@ -17,13 +17,13 @@
 
 package io.lenses.streamreactor.connect.aws.s3.storage
 
-import io.lenses.streamreactor.connect.aws.s3.model.BucketAndPath
+import io.lenses.streamreactor.connect.aws.s3.model.RemotePathLocation
 
 import java.io.OutputStream
 
 trait S3OutputStream extends OutputStream {
 
-  def complete(finalDestination: BucketAndPath): Unit
+  def complete(finalDestination: RemotePathLocation): Unit
 
   def getPointer: Long
 

--- a/kafka-connect-aws-s3/src/main/scala/io/lenses/streamreactor/connect/aws/s3/storage/S3Writer.scala
+++ b/kafka-connect-aws-s3/src/main/scala/io/lenses/streamreactor/connect/aws/s3/storage/S3Writer.scala
@@ -56,7 +56,7 @@ case class S3WriterState(topicPartition: TopicPartition,
 }
 
 class S3WriterImpl(sinkName: String,
-                   bucketAndPrefix: BucketAndPrefix,
+                   bucketAndPrefix: RemoteRootLocation,
                    commitPolicy: CommitPolicy,
                    formatWriterFn: (TopicPartition, Map[PartitionField, String]) => S3FormatWriter,
                    fileNamingStrategy: S3FileNamingStrategy,

--- a/kafka-connect-aws-s3/src/main/scala/io/lenses/streamreactor/connect/aws/s3/storage/StorageInterface.scala
+++ b/kafka-connect-aws-s3/src/main/scala/io/lenses/streamreactor/connect/aws/s3/storage/StorageInterface.scala
@@ -18,8 +18,7 @@
 package io.lenses.streamreactor.connect.aws.s3.storage
 
 import java.io.InputStream
-
-import io.lenses.streamreactor.connect.aws.s3.model.{BucketAndPath, BucketAndPrefix}
+import io.lenses.streamreactor.connect.aws.s3.model.{BucketAndPath, BucketAndPrefix, LocalLocation}
 import org.jclouds.blobstore.domain.{MultipartPart, MultipartUpload}
 
 case class MultiPartUploadState(
@@ -34,6 +33,8 @@ trait StorageInterface {
   def completeUpload(state: MultiPartUploadState): Unit
 
   def uploadPart(state: MultiPartUploadState, bytes: Array[Byte], size: Long): MultiPartUploadState
+
+  def uploadFile(initialName: LocalLocation, finalDestination: BucketAndPath): Unit
 
   def rename(originalFilename: BucketAndPath, newFilename: BucketAndPath): Unit
 

--- a/kafka-connect-aws-s3/src/main/scala/io/lenses/streamreactor/connect/aws/s3/storage/StorageInterface.scala
+++ b/kafka-connect-aws-s3/src/main/scala/io/lenses/streamreactor/connect/aws/s3/storage/StorageInterface.scala
@@ -18,7 +18,7 @@
 package io.lenses.streamreactor.connect.aws.s3.storage
 
 import java.io.InputStream
-import io.lenses.streamreactor.connect.aws.s3.model.{BucketAndPath, BucketAndPrefix, LocalLocation}
+import io.lenses.streamreactor.connect.aws.s3.model.{RemotePathLocation, RemoteRootLocation, LocalLocation}
 import org.jclouds.blobstore.domain.{MultipartPart, MultipartUpload}
 
 case class MultiPartUploadState(
@@ -28,29 +28,29 @@ case class MultiPartUploadState(
 
 trait StorageInterface {
 
-  def initUpload(bucketAndPath: BucketAndPath): MultiPartUploadState
+  def initUpload(bucketAndPath: RemotePathLocation): MultiPartUploadState
 
   def completeUpload(state: MultiPartUploadState): Unit
 
   def uploadPart(state: MultiPartUploadState, bytes: Array[Byte], size: Long): MultiPartUploadState
 
-  def uploadFile(initialName: LocalLocation, finalDestination: BucketAndPath): Unit
+  def uploadFile(initialName: LocalLocation, finalDestination: RemotePathLocation): Unit
 
-  def rename(originalFilename: BucketAndPath, newFilename: BucketAndPath): Unit
+  def rename(originalFilename: RemotePathLocation, newFilename: RemotePathLocation): Unit
 
   def close(): Unit
 
-  def pathExists(bucketAndPrefix: BucketAndPrefix): Boolean
+  def pathExists(bucketAndPrefix: RemoteRootLocation): Boolean
 
-  def pathExists(bucketAndPath: BucketAndPath): Boolean
+  def pathExists(bucketAndPath: RemotePathLocation): Boolean
 
-  def list(bucketAndPrefix: BucketAndPath): List[String]
+  def list(bucketAndPrefix: RemotePathLocation): List[String]
 
-  def list(bucketAndPrefix: BucketAndPrefix): List[String]
+  def list(bucketAndPrefix: RemoteRootLocation): List[String]
 
-  def getBlob(bucketAndPath: BucketAndPath): InputStream
+  def getBlob(bucketAndPath: RemotePathLocation): InputStream
 
-  def getBlobSize(bucketAndPath: BucketAndPath): Long
+  def getBlobSize(bucketAndPath: RemotePathLocation): Long
 
 }
 

--- a/kafka-connect-aws-s3/src/test/scala/io/lenses/streamreactor/connect/aws/s3/formats/AvroFormatStreamReaderTest.scala
+++ b/kafka-connect-aws-s3/src/test/scala/io/lenses/streamreactor/connect/aws/s3/formats/AvroFormatStreamReaderTest.scala
@@ -46,7 +46,7 @@ class AvroFormatStreamReaderTest extends AnyFlatSpec with Matchers {
     val outputStream = new S3ByteArrayOutputStream()
     val avroFormatWriter = new AvroFormatWriter(() => outputStream)
     firstUsers.foreach(str => avroFormatWriter.write(None, StructSinkData(str), topic))
-    avroFormatWriter.close()
+    avroFormatWriter.close(BucketAndPath("my-bucket", "my-path"))
 
     new ByteArrayInputStream(outputStream.toByteArray)
   }

--- a/kafka-connect-aws-s3/src/test/scala/io/lenses/streamreactor/connect/aws/s3/formats/AvroFormatStreamReaderTest.scala
+++ b/kafka-connect-aws-s3/src/test/scala/io/lenses/streamreactor/connect/aws/s3/formats/AvroFormatStreamReaderTest.scala
@@ -18,7 +18,7 @@ package io.lenses.streamreactor.connect.aws.s3.formats
 
 import java.io.ByteArrayInputStream
 
-import io.lenses.streamreactor.connect.aws.s3.model.{BucketAndPath, StructSinkData}
+import io.lenses.streamreactor.connect.aws.s3.model.{RemotePathLocation, StructSinkData}
 import io.lenses.streamreactor.connect.aws.s3.sink.utils.TestSampleSchemaAndData.{checkRecord, firstUsers, topic}
 import io.lenses.streamreactor.connect.aws.s3.storage.S3ByteArrayOutputStream
 import org.scalatest.flatspec.AnyFlatSpec
@@ -30,7 +30,7 @@ class AvroFormatStreamReaderTest extends AnyFlatSpec with Matchers {
   "read" should "read through all records" in {
 
     val byteArrayInputStream: ByteArrayInputStream = writeRecordsToOutputStream
-    val avroFormatStreamReader = new AvroFormatStreamReader(() => byteArrayInputStream, BucketAndPath("test-bucket", "test-path"))
+    val avroFormatStreamReader = new AvroFormatStreamReader(() => byteArrayInputStream, RemotePathLocation("test-bucket", "test-path"))
 
     avroFormatStreamReader.hasNext should be(true)
     checkRecord(avroFormatStreamReader.next().data, "sam", Some("mr"), 100.43)
@@ -46,7 +46,7 @@ class AvroFormatStreamReaderTest extends AnyFlatSpec with Matchers {
     val outputStream = new S3ByteArrayOutputStream()
     val avroFormatWriter = new AvroFormatWriter(() => outputStream)
     firstUsers.foreach(str => avroFormatWriter.write(None, StructSinkData(str), topic))
-    avroFormatWriter.close(BucketAndPath("my-bucket", "my-path"))
+    avroFormatWriter.close(RemotePathLocation("my-bucket", "my-path"))
 
     new ByteArrayInputStream(outputStream.toByteArray)
   }

--- a/kafka-connect-aws-s3/src/test/scala/io/lenses/streamreactor/connect/aws/s3/formats/AvroFormatWriterStreamTest.scala
+++ b/kafka-connect-aws-s3/src/test/scala/io/lenses/streamreactor/connect/aws/s3/formats/AvroFormatWriterStreamTest.scala
@@ -33,7 +33,7 @@ class AvroFormatWriterStreamTest extends AnyFlatSpec with Matchers with S3TestCo
 
     val avroFormatWriter = new AvroFormatWriter(() => blobStream)
     avroFormatWriter.write(None, StructSinkData(users.head), topic)
-    avroFormatWriter.close()
+    avroFormatWriter.close(BucketAndPath("my-bucket", "my-path"))
 
     val bytes = S3TestPayloadReader.readPayload(BucketName, "myPrefix", blobStoreContext)
 
@@ -48,7 +48,7 @@ class AvroFormatWriterStreamTest extends AnyFlatSpec with Matchers with S3TestCo
 
     val avroFormatWriter = new AvroFormatWriter(() => blobStream)
     firstUsers.foreach(u => avroFormatWriter.write(None, StructSinkData(u), topic))
-    avroFormatWriter.close()
+    avroFormatWriter.close(BucketAndPath("my-bucket", "my-path"))
 
     val bytes = S3TestPayloadReader.readPayload(BucketName, "myPrefix", blobStoreContext)
     val genericRecords = avroFormatReader.read(bytes)

--- a/kafka-connect-aws-s3/src/test/scala/io/lenses/streamreactor/connect/aws/s3/formats/AvroFormatWriterStreamTest.scala
+++ b/kafka-connect-aws-s3/src/test/scala/io/lenses/streamreactor/connect/aws/s3/formats/AvroFormatWriterStreamTest.scala
@@ -17,7 +17,7 @@
 
 package io.lenses.streamreactor.connect.aws.s3.formats
 
-import io.lenses.streamreactor.connect.aws.s3.model.{BucketAndPath, StructSinkData}
+import io.lenses.streamreactor.connect.aws.s3.model.{RemotePathLocation, StructSinkData}
 import io.lenses.streamreactor.connect.aws.s3.sink.utils.TestSampleSchemaAndData._
 import io.lenses.streamreactor.connect.aws.s3.sink.utils.{S3TestConfig, S3TestPayloadReader}
 import io.lenses.streamreactor.connect.aws.s3.storage.MultipartBlobStoreOutputStream
@@ -29,11 +29,11 @@ class AvroFormatWriterStreamTest extends AnyFlatSpec with Matchers with S3TestCo
   val avroFormatReader = new AvroFormatReader()
 
   "convert" should "write byte output stream with json for a single record" in {
-    val blobStream = new MultipartBlobStoreOutputStream(BucketAndPath(BucketName, "myPrefix"), 20000)(storageInterface)
+    val blobStream = new MultipartBlobStoreOutputStream(RemotePathLocation(BucketName, "myPrefix"), 20000)(storageInterface)
 
     val avroFormatWriter = new AvroFormatWriter(() => blobStream)
     avroFormatWriter.write(None, StructSinkData(users.head), topic)
-    avroFormatWriter.close(BucketAndPath("my-bucket", "my-path"))
+    avroFormatWriter.close(RemotePathLocation("my-bucket", "my-path"))
 
     val bytes = S3TestPayloadReader.readPayload(BucketName, "myPrefix", blobStoreContext)
 
@@ -44,11 +44,11 @@ class AvroFormatWriterStreamTest extends AnyFlatSpec with Matchers with S3TestCo
   }
 
   "convert" should "write byte output stream with json for multiple records" in {
-    val blobStream = new MultipartBlobStoreOutputStream(BucketAndPath(BucketName, "myPrefix"), 100)(storageInterface)
+    val blobStream = new MultipartBlobStoreOutputStream(RemotePathLocation(BucketName, "myPrefix"), 100)(storageInterface)
 
     val avroFormatWriter = new AvroFormatWriter(() => blobStream)
     firstUsers.foreach(u => avroFormatWriter.write(None, StructSinkData(u), topic))
-    avroFormatWriter.close(BucketAndPath("my-bucket", "my-path"))
+    avroFormatWriter.close(RemotePathLocation("my-bucket", "my-path"))
 
     val bytes = S3TestPayloadReader.readPayload(BucketName, "myPrefix", blobStoreContext)
     val genericRecords = avroFormatReader.read(bytes)

--- a/kafka-connect-aws-s3/src/test/scala/io/lenses/streamreactor/connect/aws/s3/formats/AvroFormatWriterTest.scala
+++ b/kafka-connect-aws-s3/src/test/scala/io/lenses/streamreactor/connect/aws/s3/formats/AvroFormatWriterTest.scala
@@ -39,7 +39,7 @@ class AvroFormatWriterTest extends AnyFlatSpec with Matchers {
     val outputStream = new S3ByteArrayOutputStream()
     val avroFormatWriter = new AvroFormatWriter(() => outputStream)
     avroFormatWriter.write(None, StructSinkData(users.head), topic)
-    avroFormatWriter.close()
+    avroFormatWriter.close(BucketAndPath("my-bucket", "my-path"))
 
     val genericRecords = avroFormatReader.read(outputStream.toByteArray)
 
@@ -52,7 +52,7 @@ class AvroFormatWriterTest extends AnyFlatSpec with Matchers {
     val outputStream = new S3ByteArrayOutputStream()
     val avroFormatWriter = new AvroFormatWriter(() => outputStream)
     firstUsers.foreach(u => avroFormatWriter.write(None, StructSinkData(u), topic))
-    avroFormatWriter.close()
+    avroFormatWriter.close(BucketAndPath("my-bucket", "my-path"))
 
     val genericRecords = avroFormatReader.read(outputStream.toByteArray)
     genericRecords.size should be(3)
@@ -64,7 +64,7 @@ class AvroFormatWriterTest extends AnyFlatSpec with Matchers {
     val outputStream = new S3ByteArrayOutputStream()
     val avroFormatWriter = new AvroFormatWriter(() => outputStream)
     avroFormatWriter.write(None, IntSinkData(100, Some(Schema.OPTIONAL_INT32_SCHEMA)), topic)
-    avroFormatWriter.close()
+    avroFormatWriter.close(BucketAndPath("my-bucket", "my-path"))
 
     val genericRecords = avroFormatReader.read(outputStream.toByteArray)
 
@@ -78,7 +78,7 @@ class AvroFormatWriterTest extends AnyFlatSpec with Matchers {
     val avroFormatWriter = new AvroFormatWriter(() => outputStream)
     avroFormatWriter.write(None, IntSinkData(100, Some(Schema.OPTIONAL_INT32_SCHEMA)), topic)
     avroFormatWriter.write(None, IntSinkData(200, Some(Schema.OPTIONAL_INT32_SCHEMA)), topic)
-    avroFormatWriter.close()
+    avroFormatWriter.close(BucketAndPath("my-bucket", "my-path"))
 
     val genericRecords = avroFormatReader.read(outputStream.toByteArray)
 
@@ -101,7 +101,7 @@ class AvroFormatWriterTest extends AnyFlatSpec with Matchers {
           StringSinkData("alfred")
         ), Some(arraySchema)),
       topic)
-    avroFormatWriter.close()
+    avroFormatWriter.close(BucketAndPath("my-bucket", "my-path"))
 
     val genericRecords = avroFormatReader.read(outputStream.toByteArray)
     genericRecords.size should be(1)
@@ -131,7 +131,7 @@ class AvroFormatWriterTest extends AnyFlatSpec with Matchers {
           StringSinkData("lois lane")
         ), Some(arraySchema)),
       topic)
-    avroFormatWriter.close()
+    avroFormatWriter.close(BucketAndPath("my-bucket", "my-path"))
 
     val genericRecords = avroFormatReader.read(outputStream.toByteArray)
     genericRecords.size should be(2)
@@ -180,7 +180,7 @@ class AvroFormatWriterTest extends AnyFlatSpec with Matchers {
           StringSinkData("lois lane") -> IntSinkData(5)
         ), Some(mapSchema)),
       topic)
-    avroFormatWriter.close()
+    avroFormatWriter.close(BucketAndPath("my-bucket", "my-path"))
 
     val genericRecords = avroFormatReader.read(outputStream.toByteArray)
     genericRecords.size should be(2)
@@ -205,7 +205,7 @@ class AvroFormatWriterTest extends AnyFlatSpec with Matchers {
     val avroFormatWriter = new AvroFormatWriter(() => outputStream)
     avroFormatWriter.write(None, ByteArraySinkData("Sausages".getBytes(), Some(byteSchema)), topic)
     avroFormatWriter.write(None, ByteArraySinkData("Mash".getBytes(), Some(byteSchema)), topic)
-    avroFormatWriter.close()
+    avroFormatWriter.close(BucketAndPath("my-bucket", "my-path"))
 
     val genericRecords = avroFormatReader.read(outputStream.toByteArray)
     genericRecords.size should be(2)

--- a/kafka-connect-aws-s3/src/test/scala/io/lenses/streamreactor/connect/aws/s3/formats/AvroFormatWriterTest.scala
+++ b/kafka-connect-aws-s3/src/test/scala/io/lenses/streamreactor/connect/aws/s3/formats/AvroFormatWriterTest.scala
@@ -39,7 +39,7 @@ class AvroFormatWriterTest extends AnyFlatSpec with Matchers {
     val outputStream = new S3ByteArrayOutputStream()
     val avroFormatWriter = new AvroFormatWriter(() => outputStream)
     avroFormatWriter.write(None, StructSinkData(users.head), topic)
-    avroFormatWriter.close(BucketAndPath("my-bucket", "my-path"))
+    avroFormatWriter.close(RemotePathLocation("my-bucket", "my-path"))
 
     val genericRecords = avroFormatReader.read(outputStream.toByteArray)
 
@@ -52,7 +52,7 @@ class AvroFormatWriterTest extends AnyFlatSpec with Matchers {
     val outputStream = new S3ByteArrayOutputStream()
     val avroFormatWriter = new AvroFormatWriter(() => outputStream)
     firstUsers.foreach(u => avroFormatWriter.write(None, StructSinkData(u), topic))
-    avroFormatWriter.close(BucketAndPath("my-bucket", "my-path"))
+    avroFormatWriter.close(RemotePathLocation("my-bucket", "my-path"))
 
     val genericRecords = avroFormatReader.read(outputStream.toByteArray)
     genericRecords.size should be(3)
@@ -64,7 +64,7 @@ class AvroFormatWriterTest extends AnyFlatSpec with Matchers {
     val outputStream = new S3ByteArrayOutputStream()
     val avroFormatWriter = new AvroFormatWriter(() => outputStream)
     avroFormatWriter.write(None, IntSinkData(100, Some(Schema.OPTIONAL_INT32_SCHEMA)), topic)
-    avroFormatWriter.close(BucketAndPath("my-bucket", "my-path"))
+    avroFormatWriter.close(RemotePathLocation("my-bucket", "my-path"))
 
     val genericRecords = avroFormatReader.read(outputStream.toByteArray)
 
@@ -78,7 +78,7 @@ class AvroFormatWriterTest extends AnyFlatSpec with Matchers {
     val avroFormatWriter = new AvroFormatWriter(() => outputStream)
     avroFormatWriter.write(None, IntSinkData(100, Some(Schema.OPTIONAL_INT32_SCHEMA)), topic)
     avroFormatWriter.write(None, IntSinkData(200, Some(Schema.OPTIONAL_INT32_SCHEMA)), topic)
-    avroFormatWriter.close(BucketAndPath("my-bucket", "my-path"))
+    avroFormatWriter.close(RemotePathLocation("my-bucket", "my-path"))
 
     val genericRecords = avroFormatReader.read(outputStream.toByteArray)
 
@@ -101,7 +101,7 @@ class AvroFormatWriterTest extends AnyFlatSpec with Matchers {
           StringSinkData("alfred")
         ), Some(arraySchema)),
       topic)
-    avroFormatWriter.close(BucketAndPath("my-bucket", "my-path"))
+    avroFormatWriter.close(RemotePathLocation("my-bucket", "my-path"))
 
     val genericRecords = avroFormatReader.read(outputStream.toByteArray)
     genericRecords.size should be(1)
@@ -131,7 +131,7 @@ class AvroFormatWriterTest extends AnyFlatSpec with Matchers {
           StringSinkData("lois lane")
         ), Some(arraySchema)),
       topic)
-    avroFormatWriter.close(BucketAndPath("my-bucket", "my-path"))
+    avroFormatWriter.close(RemotePathLocation("my-bucket", "my-path"))
 
     val genericRecords = avroFormatReader.read(outputStream.toByteArray)
     genericRecords.size should be(2)
@@ -180,7 +180,7 @@ class AvroFormatWriterTest extends AnyFlatSpec with Matchers {
           StringSinkData("lois lane") -> IntSinkData(5)
         ), Some(mapSchema)),
       topic)
-    avroFormatWriter.close(BucketAndPath("my-bucket", "my-path"))
+    avroFormatWriter.close(RemotePathLocation("my-bucket", "my-path"))
 
     val genericRecords = avroFormatReader.read(outputStream.toByteArray)
     genericRecords.size should be(2)
@@ -205,7 +205,7 @@ class AvroFormatWriterTest extends AnyFlatSpec with Matchers {
     val avroFormatWriter = new AvroFormatWriter(() => outputStream)
     avroFormatWriter.write(None, ByteArraySinkData("Sausages".getBytes(), Some(byteSchema)), topic)
     avroFormatWriter.write(None, ByteArraySinkData("Mash".getBytes(), Some(byteSchema)), topic)
-    avroFormatWriter.close(BucketAndPath("my-bucket", "my-path"))
+    avroFormatWriter.close(RemotePathLocation("my-bucket", "my-path"))
 
     val genericRecords = avroFormatReader.read(outputStream.toByteArray)
     genericRecords.size should be(2)

--- a/kafka-connect-aws-s3/src/test/scala/io/lenses/streamreactor/connect/aws/s3/formats/BytesFormatStreamFileReaderTest.scala
+++ b/kafka-connect-aws-s3/src/test/scala/io/lenses/streamreactor/connect/aws/s3/formats/BytesFormatStreamFileReaderTest.scala
@@ -18,7 +18,7 @@ package io.lenses.streamreactor.connect.aws.s3.formats
 
 import java.io.ByteArrayInputStream
 
-import io.lenses.streamreactor.connect.aws.s3.model.{BucketAndPath, BytesOutputRow, BytesOutputRowTest, BytesWriteMode}
+import io.lenses.streamreactor.connect.aws.s3.model.{RemotePathLocation, BytesOutputRow, BytesOutputRowTest, BytesWriteMode}
 import org.mockito.MockitoSugar
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
@@ -27,7 +27,7 @@ class BytesFormatStreamFileReaderTest extends AnyFlatSpec with MockitoSugar with
 
   import BytesOutputRowTest._
 
-  val bucketAndPath: BucketAndPath = mock[BucketAndPath]
+  val bucketAndPath: RemotePathLocation = mock[RemotePathLocation]
   val fileContents = "lemonOlivelemonOlive".getBytes
 
   "read" should "read entire file at once" in {

--- a/kafka-connect-aws-s3/src/test/scala/io/lenses/streamreactor/connect/aws/s3/formats/BytesFormatWithSizesStreamReaderTest.scala
+++ b/kafka-connect-aws-s3/src/test/scala/io/lenses/streamreactor/connect/aws/s3/formats/BytesFormatWithSizesStreamReaderTest.scala
@@ -19,7 +19,7 @@ package io.lenses.streamreactor.connect.aws.s3.formats
 import java.io.ByteArrayInputStream
 
 import io.lenses.streamreactor.connect.aws.s3.formats.bytes.{ByteArrayUtils, WithSizesBytesOutputRowReader}
-import io.lenses.streamreactor.connect.aws.s3.model.{BucketAndPath, BytesOutputRow, BytesOutputRowTest, BytesWriteMode}
+import io.lenses.streamreactor.connect.aws.s3.model.{RemotePathLocation, BytesOutputRow, BytesOutputRowTest, BytesWriteMode}
 import org.mockito.MockitoSugar
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
@@ -28,7 +28,7 @@ class BytesFormatWithSizesStreamReaderTest extends AnyFlatSpec with MockitoSugar
 
   import BytesOutputRowTest._
 
-  private val bucketAndPath: BucketAndPath = mock[BucketAndPath]
+  private val bucketAndPath: RemotePathLocation = mock[RemotePathLocation]
 
   private val bytesKeyAndValueWithSizes2: Array[Byte] = ByteArrayUtils.longToByteArray(4L) ++ ByteArrayUtils.longToByteArray(3L) ++ "caketea".getBytes
 

--- a/kafka-connect-aws-s3/src/test/scala/io/lenses/streamreactor/connect/aws/s3/formats/BytesFormatWriterTest.scala
+++ b/kafka-connect-aws-s3/src/test/scala/io/lenses/streamreactor/connect/aws/s3/formats/BytesFormatWriterTest.scala
@@ -18,7 +18,7 @@
 package io.lenses.streamreactor.connect.aws.s3.formats
 
 import io.lenses.streamreactor.connect.aws.s3.formats.bytes.ByteArrayUtils
-import io.lenses.streamreactor.connect.aws.s3.model.{ByteArraySinkData, BytesWriteMode, StructSinkData}
+import io.lenses.streamreactor.connect.aws.s3.model.{BucketAndPath, ByteArraySinkData, BytesWriteMode, StructSinkData}
 import io.lenses.streamreactor.connect.aws.s3.sink.utils.TestSampleSchemaAndData._
 import io.lenses.streamreactor.connect.aws.s3.storage.S3ByteArrayOutputStream
 import org.apache.commons.io.IOUtils
@@ -40,7 +40,7 @@ class BytesFormatWriterTest extends AnyFlatSpec with Matchers {
 
     outputStream.toString should be("Sausages")
 
-    bytesFormatWriter.close()
+    bytesFormatWriter.close(BucketAndPath("my-bucket", "my-path"))
   }
 
   "convert" should "write binary with ValueOnly" in {
@@ -52,7 +52,7 @@ class BytesFormatWriterTest extends AnyFlatSpec with Matchers {
 
     outputStream.toByteArray should be(bytes)
 
-    bytesFormatWriter.close()
+    bytesFormatWriter.close(BucketAndPath("my-bucket", "my-path"))
 
   }
 
@@ -64,7 +64,7 @@ class BytesFormatWriterTest extends AnyFlatSpec with Matchers {
 
     outputStream.toByteArray should be(bytes)
 
-    bytesFormatWriter.close()
+    bytesFormatWriter.close(BucketAndPath("my-bucket", "my-path"))
 
   }
 
@@ -77,7 +77,7 @@ class BytesFormatWriterTest extends AnyFlatSpec with Matchers {
 
     outputStream.toByteArray should be(pixelLengthBytes ++ pixelLengthBytes ++ bytes ++ bytes)
 
-    bytesFormatWriter.close()
+    bytesFormatWriter.close(BucketAndPath("my-bucket", "my-path"))
 
   }
 
@@ -90,7 +90,7 @@ class BytesFormatWriterTest extends AnyFlatSpec with Matchers {
 
     outputStream.toByteArray should be(pixelLengthBytes ++ bytes)
 
-    bytesFormatWriter.close()
+    bytesFormatWriter.close(BucketAndPath("my-bucket", "my-path"))
 
   }
 
@@ -103,7 +103,7 @@ class BytesFormatWriterTest extends AnyFlatSpec with Matchers {
 
     outputStream.toByteArray should be(pixelLengthBytes ++ bytes)
 
-    bytesFormatWriter.close()
+    bytesFormatWriter.close(BucketAndPath("my-bucket", "my-path"))
 
   }
 
@@ -120,7 +120,7 @@ class BytesFormatWriterTest extends AnyFlatSpec with Matchers {
 
     outputStream.toByteArray should be(bytes)
 
-    bytesFormatWriter.close()
+    bytesFormatWriter.close(BucketAndPath("my-bucket", "my-path"))
   }
 
   "convert" should "throw error when avro value is supplied" in {
@@ -130,7 +130,7 @@ class BytesFormatWriterTest extends AnyFlatSpec with Matchers {
     assertThrows[IllegalStateException] {
       bytesFormatWriter.write(None, StructSinkData(users.head), topic)
     }
-    bytesFormatWriter.close()
+    bytesFormatWriter.close(BucketAndPath("my-bucket", "my-path"))
   }
 
   private def getPixelBytes = {

--- a/kafka-connect-aws-s3/src/test/scala/io/lenses/streamreactor/connect/aws/s3/formats/BytesFormatWriterTest.scala
+++ b/kafka-connect-aws-s3/src/test/scala/io/lenses/streamreactor/connect/aws/s3/formats/BytesFormatWriterTest.scala
@@ -18,7 +18,7 @@
 package io.lenses.streamreactor.connect.aws.s3.formats
 
 import io.lenses.streamreactor.connect.aws.s3.formats.bytes.ByteArrayUtils
-import io.lenses.streamreactor.connect.aws.s3.model.{BucketAndPath, ByteArraySinkData, BytesWriteMode, StructSinkData}
+import io.lenses.streamreactor.connect.aws.s3.model.{RemotePathLocation, ByteArraySinkData, BytesWriteMode, StructSinkData}
 import io.lenses.streamreactor.connect.aws.s3.sink.utils.TestSampleSchemaAndData._
 import io.lenses.streamreactor.connect.aws.s3.storage.S3ByteArrayOutputStream
 import org.apache.commons.io.IOUtils
@@ -40,7 +40,7 @@ class BytesFormatWriterTest extends AnyFlatSpec with Matchers {
 
     outputStream.toString should be("Sausages")
 
-    bytesFormatWriter.close(BucketAndPath("my-bucket", "my-path"))
+    bytesFormatWriter.close(RemotePathLocation("my-bucket", "my-path"))
   }
 
   "convert" should "write binary with ValueOnly" in {
@@ -52,7 +52,7 @@ class BytesFormatWriterTest extends AnyFlatSpec with Matchers {
 
     outputStream.toByteArray should be(bytes)
 
-    bytesFormatWriter.close(BucketAndPath("my-bucket", "my-path"))
+    bytesFormatWriter.close(RemotePathLocation("my-bucket", "my-path"))
 
   }
 
@@ -64,7 +64,7 @@ class BytesFormatWriterTest extends AnyFlatSpec with Matchers {
 
     outputStream.toByteArray should be(bytes)
 
-    bytesFormatWriter.close(BucketAndPath("my-bucket", "my-path"))
+    bytesFormatWriter.close(RemotePathLocation("my-bucket", "my-path"))
 
   }
 
@@ -77,7 +77,7 @@ class BytesFormatWriterTest extends AnyFlatSpec with Matchers {
 
     outputStream.toByteArray should be(pixelLengthBytes ++ pixelLengthBytes ++ bytes ++ bytes)
 
-    bytesFormatWriter.close(BucketAndPath("my-bucket", "my-path"))
+    bytesFormatWriter.close(RemotePathLocation("my-bucket", "my-path"))
 
   }
 
@@ -90,7 +90,7 @@ class BytesFormatWriterTest extends AnyFlatSpec with Matchers {
 
     outputStream.toByteArray should be(pixelLengthBytes ++ bytes)
 
-    bytesFormatWriter.close(BucketAndPath("my-bucket", "my-path"))
+    bytesFormatWriter.close(RemotePathLocation("my-bucket", "my-path"))
 
   }
 
@@ -103,7 +103,7 @@ class BytesFormatWriterTest extends AnyFlatSpec with Matchers {
 
     outputStream.toByteArray should be(pixelLengthBytes ++ bytes)
 
-    bytesFormatWriter.close(BucketAndPath("my-bucket", "my-path"))
+    bytesFormatWriter.close(RemotePathLocation("my-bucket", "my-path"))
 
   }
 
@@ -120,7 +120,7 @@ class BytesFormatWriterTest extends AnyFlatSpec with Matchers {
 
     outputStream.toByteArray should be(bytes)
 
-    bytesFormatWriter.close(BucketAndPath("my-bucket", "my-path"))
+    bytesFormatWriter.close(RemotePathLocation("my-bucket", "my-path"))
   }
 
   "convert" should "throw error when avro value is supplied" in {
@@ -130,7 +130,7 @@ class BytesFormatWriterTest extends AnyFlatSpec with Matchers {
     assertThrows[IllegalStateException] {
       bytesFormatWriter.write(None, StructSinkData(users.head), topic)
     }
-    bytesFormatWriter.close(BucketAndPath("my-bucket", "my-path"))
+    bytesFormatWriter.close(RemotePathLocation("my-bucket", "my-path"))
   }
 
   private def getPixelBytes = {

--- a/kafka-connect-aws-s3/src/test/scala/io/lenses/streamreactor/connect/aws/s3/formats/CsvFormatStreamReaderTest.scala
+++ b/kafka-connect-aws-s3/src/test/scala/io/lenses/streamreactor/connect/aws/s3/formats/CsvFormatStreamReaderTest.scala
@@ -18,7 +18,7 @@ package io.lenses.streamreactor.connect.aws.s3.formats
 
 import java.io.ByteArrayInputStream
 
-import io.lenses.streamreactor.connect.aws.s3.model.{BucketAndPath, StringSourceData}
+import io.lenses.streamreactor.connect.aws.s3.model.{RemotePathLocation, StringSourceData}
 import io.lenses.streamreactor.connect.aws.s3.sink.utils.TestSampleSchemaAndData
 import org.mockito.MockitoSugar
 import org.scalatest.flatspec.AnyFlatSpec
@@ -26,7 +26,7 @@ import org.scalatest.matchers.should.Matchers
 
 class CsvFormatStreamReaderTest extends AnyFlatSpec with Matchers with MockitoSugar {
 
-  private val bucketAndPath = mock[BucketAndPath]
+  private val bucketAndPath = mock[RemotePathLocation]
 
   "next" should "throw an error when you try and read an empty file when headers are configured" in {
     val reader = setUpReader(List(), includesHeaders = true)

--- a/kafka-connect-aws-s3/src/test/scala/io/lenses/streamreactor/connect/aws/s3/formats/CsvFormatWriterTest.scala
+++ b/kafka-connect-aws-s3/src/test/scala/io/lenses/streamreactor/connect/aws/s3/formats/CsvFormatWriterTest.scala
@@ -19,7 +19,7 @@ package io.lenses.streamreactor.connect.aws.s3.formats
 
 import java.io.StringReader
 import au.com.bytecode.opencsv.CSVReader
-import io.lenses.streamreactor.connect.aws.s3.model.{BucketAndPath, StructSinkData}
+import io.lenses.streamreactor.connect.aws.s3.model.{RemotePathLocation, StructSinkData}
 import io.lenses.streamreactor.connect.aws.s3.sink.extractors.ExtractorError
 import io.lenses.streamreactor.connect.aws.s3.sink.extractors.ExtractorErrorType.UnexpectedType
 import io.lenses.streamreactor.connect.aws.s3.sink.utils.TestSampleSchemaAndData._
@@ -136,7 +136,7 @@ class CsvFormatWriterTest extends AnyFlatSpec with Matchers with Assertions {
     val caught = intercept[ExtractorError] {
       formatWriter.write(None, StructSinkData(struct), topic)
     }
-    formatWriter.close(BucketAndPath("my-bucket", "my-path"))
+    formatWriter.close(RemotePathLocation("my-bucket", "my-path"))
     caught.extractorErrorType should be(UnexpectedType)
   }
 
@@ -159,7 +159,7 @@ class CsvFormatWriterTest extends AnyFlatSpec with Matchers with Assertions {
     val caught = intercept[ExtractorError] {
       formatWriter.write(None, StructSinkData(struct), topic)
     }
-    formatWriter.close(BucketAndPath("my-bucket", "my-path"))
+    formatWriter.close(RemotePathLocation("my-bucket", "my-path"))
     caught.extractorErrorType should be(UnexpectedType)
   }
 }

--- a/kafka-connect-aws-s3/src/test/scala/io/lenses/streamreactor/connect/aws/s3/formats/CsvFormatWriterTest.scala
+++ b/kafka-connect-aws-s3/src/test/scala/io/lenses/streamreactor/connect/aws/s3/formats/CsvFormatWriterTest.scala
@@ -19,7 +19,7 @@ package io.lenses.streamreactor.connect.aws.s3.formats
 
 import java.io.StringReader
 import au.com.bytecode.opencsv.CSVReader
-import io.lenses.streamreactor.connect.aws.s3.model.StructSinkData
+import io.lenses.streamreactor.connect.aws.s3.model.{BucketAndPath, StructSinkData}
 import io.lenses.streamreactor.connect.aws.s3.sink.extractors.ExtractorError
 import io.lenses.streamreactor.connect.aws.s3.sink.extractors.ExtractorErrorType.UnexpectedType
 import io.lenses.streamreactor.connect.aws.s3.sink.utils.TestSampleSchemaAndData._
@@ -136,7 +136,7 @@ class CsvFormatWriterTest extends AnyFlatSpec with Matchers with Assertions {
     val caught = intercept[ExtractorError] {
       formatWriter.write(None, StructSinkData(struct), topic)
     }
-    formatWriter.close()
+    formatWriter.close(BucketAndPath("my-bucket", "my-path"))
     caught.extractorErrorType should be(UnexpectedType)
   }
 
@@ -159,7 +159,7 @@ class CsvFormatWriterTest extends AnyFlatSpec with Matchers with Assertions {
     val caught = intercept[ExtractorError] {
       formatWriter.write(None, StructSinkData(struct), topic)
     }
-    formatWriter.close()
+    formatWriter.close(BucketAndPath("my-bucket", "my-path"))
     caught.extractorErrorType should be(UnexpectedType)
   }
 }

--- a/kafka-connect-aws-s3/src/test/scala/io/lenses/streamreactor/connect/aws/s3/formats/ParquetFormatStreamReaderTest.scala
+++ b/kafka-connect-aws-s3/src/test/scala/io/lenses/streamreactor/connect/aws/s3/formats/ParquetFormatStreamReaderTest.scala
@@ -16,7 +16,7 @@
 
 package io.lenses.streamreactor.connect.aws.s3.formats
 
-import io.lenses.streamreactor.connect.aws.s3.model.BucketAndPath
+import io.lenses.streamreactor.connect.aws.s3.model.RemotePathLocation
 import org.apache.kafka.connect.data.Struct
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
@@ -24,7 +24,7 @@ import org.scalatest.matchers.should.Matchers
 
 class ParquetFormatStreamReaderTest extends AnyFlatSpec with Matchers {
 
-  private val bucketAndPath = BucketAndPath("my-bucket", "myPath")
+  private val bucketAndPath = RemotePathLocation("my-bucket", "myPath")
 
   "iteration" should "read parquet files" in {
     val inputStreamFn = () => getClass.getResourceAsStream("/parquet/1.parquet")

--- a/kafka-connect-aws-s3/src/test/scala/io/lenses/streamreactor/connect/aws/s3/formats/ParquetFormatWriterStreamTest.scala
+++ b/kafka-connect-aws-s3/src/test/scala/io/lenses/streamreactor/connect/aws/s3/formats/ParquetFormatWriterStreamTest.scala
@@ -34,7 +34,7 @@ class ParquetFormatWriterStreamTest extends AnyFlatSpec with Matchers with S3Tes
 
     val parquetFormatWriter = new ParquetFormatWriter(() => blobStream)
     parquetFormatWriter.write(None, StructSinkData(users.head), topic)
-    parquetFormatWriter.close()
+    parquetFormatWriter.close(BucketAndPath("my-bucket", "my-path"))
 
     val bytes = S3TestPayloadReader.readPayload(BucketName, "myPrefix", blobStoreContext)
 
@@ -49,7 +49,7 @@ class ParquetFormatWriterStreamTest extends AnyFlatSpec with Matchers with S3Tes
 
     val parquetFormatWriter = new ParquetFormatWriter(() => blobStream)
     firstUsers.foreach(e => parquetFormatWriter.write(None, StructSinkData(e), topic))
-    parquetFormatWriter.close()
+    parquetFormatWriter.close(BucketAndPath("my-bucket", "my-path"))
 
     val bytes = S3TestPayloadReader.readPayload(BucketName, "myPrefix", blobStoreContext)
     val genericRecords = parquetFormatReader.read(bytes)
@@ -90,6 +90,6 @@ class ParquetFormatWriterStreamTest extends AnyFlatSpec with Matchers with S3Tes
           ), Some(mapSchema)),
         topic)
     }.getMessage should be("Avro schema must be a record.")
-    parquetFormatWriter.close()
+    parquetFormatWriter.close(BucketAndPath("my-bucket", "my-path"))
   }
 }

--- a/kafka-connect-aws-s3/src/test/scala/io/lenses/streamreactor/connect/aws/s3/formats/ParquetFormatWriterStreamTest.scala
+++ b/kafka-connect-aws-s3/src/test/scala/io/lenses/streamreactor/connect/aws/s3/formats/ParquetFormatWriterStreamTest.scala
@@ -30,11 +30,11 @@ class ParquetFormatWriterStreamTest extends AnyFlatSpec with Matchers with S3Tes
   val parquetFormatReader = new ParquetFormatReader()
 
   "convert" should "write byte output stream with json for a single record" in {
-    val blobStream = new MultipartBlobStoreOutputStream(BucketAndPath(BucketName, "myPrefix"), 20000)(storageInterface)
+    val blobStream = new MultipartBlobStoreOutputStream(RemotePathLocation(BucketName, "myPrefix"), 20000)(storageInterface)
 
     val parquetFormatWriter = new ParquetFormatWriter(() => blobStream)
     parquetFormatWriter.write(None, StructSinkData(users.head), topic)
-    parquetFormatWriter.close(BucketAndPath("my-bucket", "my-path"))
+    parquetFormatWriter.close(RemotePathLocation("my-bucket", "my-path"))
 
     val bytes = S3TestPayloadReader.readPayload(BucketName, "myPrefix", blobStoreContext)
 
@@ -45,11 +45,11 @@ class ParquetFormatWriterStreamTest extends AnyFlatSpec with Matchers with S3Tes
   }
 
   "convert" should "write byte output stream with json for multiple records" in {
-    val blobStream = new MultipartBlobStoreOutputStream(BucketAndPath(BucketName, "myPrefix"), 100)(storageInterface)
+    val blobStream = new MultipartBlobStoreOutputStream(RemotePathLocation(BucketName, "myPrefix"), 100)(storageInterface)
 
     val parquetFormatWriter = new ParquetFormatWriter(() => blobStream)
     firstUsers.foreach(e => parquetFormatWriter.write(None, StructSinkData(e), topic))
-    parquetFormatWriter.close(BucketAndPath("my-bucket", "my-path"))
+    parquetFormatWriter.close(RemotePathLocation("my-bucket", "my-path"))
 
     val bytes = S3TestPayloadReader.readPayload(BucketName, "myPrefix", blobStoreContext)
     val genericRecords = parquetFormatReader.read(bytes)
@@ -59,7 +59,7 @@ class ParquetFormatWriterStreamTest extends AnyFlatSpec with Matchers with S3Tes
 
   "convert" should "throw an error when writing array without schema" in {
 
-    val blobStream = new MultipartBlobStoreOutputStream(BucketAndPath(BucketName, "myPrefix"), 100)(storageInterface)
+    val blobStream = new MultipartBlobStoreOutputStream(RemotePathLocation(BucketName, "myPrefix"), 100)(storageInterface)
     val parquetFormatWriter = new ParquetFormatWriter(() => blobStream)
     intercept[IllegalArgumentException] {
       parquetFormatWriter.write(
@@ -77,7 +77,7 @@ class ParquetFormatWriterStreamTest extends AnyFlatSpec with Matchers with S3Tes
   "convert" should "throw an exception when trying to write map values" in {
     val mapSchema = SchemaBuilder.map(Schema.STRING_SCHEMA, Schema.INT32_SCHEMA)
 
-    val blobStream = new MultipartBlobStoreOutputStream(BucketAndPath(BucketName, "myPrefix"), 100)(storageInterface)
+    val blobStream = new MultipartBlobStoreOutputStream(RemotePathLocation(BucketName, "myPrefix"), 100)(storageInterface)
     val parquetFormatWriter = new ParquetFormatWriter(() => blobStream)
     intercept[IllegalArgumentException] {
       parquetFormatWriter.write(
@@ -90,6 +90,6 @@ class ParquetFormatWriterStreamTest extends AnyFlatSpec with Matchers with S3Tes
           ), Some(mapSchema)),
         topic)
     }.getMessage should be("Avro schema must be a record.")
-    parquetFormatWriter.close(BucketAndPath("my-bucket", "my-path"))
+    parquetFormatWriter.close(RemotePathLocation("my-bucket", "my-path"))
   }
 }

--- a/kafka-connect-aws-s3/src/test/scala/io/lenses/streamreactor/connect/aws/s3/formats/TextFormatStreamReaderTest.scala
+++ b/kafka-connect-aws-s3/src/test/scala/io/lenses/streamreactor/connect/aws/s3/formats/TextFormatStreamReaderTest.scala
@@ -18,7 +18,7 @@ package io.lenses.streamreactor.connect.aws.s3.formats
 
 import java.io.ByteArrayInputStream
 
-import io.lenses.streamreactor.connect.aws.s3.model.{BucketAndPath, StringSourceData, StructSinkData}
+import io.lenses.streamreactor.connect.aws.s3.model.{RemotePathLocation, StringSourceData, StructSinkData}
 import io.lenses.streamreactor.connect.aws.s3.sink.utils.TestSampleSchemaAndData
 import io.lenses.streamreactor.connect.aws.s3.sink.utils.TestSampleSchemaAndData.{firstUsers, topic}
 import io.lenses.streamreactor.connect.aws.s3.storage.S3ByteArrayOutputStream
@@ -31,7 +31,7 @@ class TextFormatStreamReaderTest extends AnyFlatSpec with Matchers {
   "read" should "take read through all records" in {
 
     val byteArrayInputStream: ByteArrayInputStream = writeRecordsToOutputStream
-    val avroFormatStreamReader = new TextFormatStreamReader(() => byteArrayInputStream, BucketAndPath("test-bucket", "test-path"))
+    val avroFormatStreamReader = new TextFormatStreamReader(() => byteArrayInputStream, RemotePathLocation("test-bucket", "test-path"))
 
     avroFormatStreamReader.hasNext should be(true)
     avroFormatStreamReader.next should be(StringSourceData(TestSampleSchemaAndData.recordsAsJson(0), 0))
@@ -47,7 +47,7 @@ class TextFormatStreamReaderTest extends AnyFlatSpec with Matchers {
     val outputStream = new S3ByteArrayOutputStream()
     val jsonFormatWriter = new JsonFormatWriter(() => outputStream)
     firstUsers.foreach(data => jsonFormatWriter.write(None, StructSinkData(data), topic))
-    jsonFormatWriter.close(BucketAndPath("my-bucket", "my-path"))
+    jsonFormatWriter.close(RemotePathLocation("my-bucket", "my-path"))
 
     val byteArrayInputStream = new ByteArrayInputStream(outputStream.toByteArray)
     byteArrayInputStream

--- a/kafka-connect-aws-s3/src/test/scala/io/lenses/streamreactor/connect/aws/s3/formats/TextFormatStreamReaderTest.scala
+++ b/kafka-connect-aws-s3/src/test/scala/io/lenses/streamreactor/connect/aws/s3/formats/TextFormatStreamReaderTest.scala
@@ -47,7 +47,7 @@ class TextFormatStreamReaderTest extends AnyFlatSpec with Matchers {
     val outputStream = new S3ByteArrayOutputStream()
     val jsonFormatWriter = new JsonFormatWriter(() => outputStream)
     firstUsers.foreach(data => jsonFormatWriter.write(None, StructSinkData(data), topic))
-    jsonFormatWriter.close()
+    jsonFormatWriter.close(BucketAndPath("my-bucket", "my-path"))
 
     val byteArrayInputStream = new ByteArrayInputStream(outputStream.toByteArray)
     byteArrayInputStream

--- a/kafka-connect-aws-s3/src/test/scala/io/lenses/streamreactor/connect/aws/s3/model/RemoteRootLocationTest.scala
+++ b/kafka-connect-aws-s3/src/test/scala/io/lenses/streamreactor/connect/aws/s3/model/RemoteRootLocationTest.scala
@@ -21,31 +21,31 @@ import com.amazonaws.services.s3.model.IllegalBucketNameException
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 
-class BucketAndPrefixTest extends AnyFlatSpec with Matchers {
+class RemoteRootLocationTest extends AnyFlatSpec with Matchers {
 
   "bucketAndPrefix" should "reject prefixes with slashes" in {
     assertThrows[IllegalArgumentException] {
-      BucketAndPrefix("bucket", Some("/slash"))
+      RemoteRootLocation("bucket", Some("/slash"))
     }
   }
 
   "bucketAndPrefix" should "allow prefixes without slashes" in {
-    BucketAndPrefix("bucket", Some("noSlash"))
+    RemoteRootLocation("bucket", Some("noSlash"))
   }
 
   "bucketAndPrefix" should "split a the bucket and path" in {
-    BucketAndPrefix("bucket:path") should be(BucketAndPrefix("bucket", Some("path")))
+    RemoteRootLocation("bucket:path") should be(RemoteRootLocation("bucket", Some("path")))
   }
 
   "bucketAndPrefix" should "fail if given too many components to split" in {
     assertThrows[IllegalArgumentException] {
-      BucketAndPrefix("bucket:path:whatIsThis")
+      RemoteRootLocation("bucket:path:whatIsThis")
     }
   }
 
   "bucketAndPrefix" should "fail if not a valid bucket name" in {
     assertThrows[IllegalBucketNameException] {
-      BucketAndPrefix("bucket-police-refu$e-this-name:path")
+      RemoteRootLocation("bucket-police-refu$e-this-name:path")
     }
   }
 }

--- a/kafka-connect-aws-s3/src/test/scala/io/lenses/streamreactor/connect/aws/s3/model/S3OutputStreamOptionsTest.scala
+++ b/kafka-connect-aws-s3/src/test/scala/io/lenses/streamreactor/connect/aws/s3/model/S3OutputStreamOptionsTest.scala
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2021 Lenses.io
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.lenses.streamreactor.connect.aws.s3.model
+
+import io.lenses.streamreactor.connect.aws.s3.config.S3ConfigSettings.LOCAL_TMP_DIRECTORY
+import io.lenses.streamreactor.connect.aws.s3.model.BuildLocalOutputStreamOptions.PROPERTY_SINK_NAME
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+class S3OutputStreamOptionsTest extends AnyFlatSpec with Matchers {
+
+  behavior of "S3OutputStreamOptions"
+
+  it should "create StreamedOutputStreamOptions with warning when no write mode supplied" in {
+    S3OutputStreamOptions("", Map.empty[String,String]) should
+      be (Right(StreamedWriteOutputStreamOptions()))
+  }
+
+  it should "create StreamedOutputStreamOptions with warning when invalid write mode supplied" in {
+    S3OutputStreamOptions("whatisit", Map.empty[String,String]) should
+      be (Right(StreamedWriteOutputStreamOptions()))
+  }
+
+  it should "create StreamedOutputStreamOptions when invalid write mode supplied" in {
+    S3OutputStreamOptions("Streamed", Map.empty[String,String]) should
+      be (Right(StreamedWriteOutputStreamOptions()))
+  }
+
+  it should "create BuildLocalOutputStreamOptions when temp directory has been supplied" in {
+    S3OutputStreamOptions("buildlocal", Map(LOCAL_TMP_DIRECTORY -> "/my/path")) should
+      be (Right(BuildLocalOutputStreamOptions(LocalLocation("/my/path"))))
+  }
+
+  it should "create BuildLocalOutputStreamOptions when temp directory and sink name has been supplied" in {
+    // should ignore the sinkName
+    S3OutputStreamOptions("BuildLocal", Map(LOCAL_TMP_DIRECTORY -> "/my/path", PROPERTY_SINK_NAME -> "superSleekSinkName")) should
+      be (Right(BuildLocalOutputStreamOptions(LocalLocation("/my/path"))))
+  }
+
+  it should "create BuildLocalOutputStreamOptions when sink name has been supplied" in {
+    val tempDir = System.getProperty("java.io.tmpdir")
+    val result = S3OutputStreamOptions("BUILDLOCAL", Map(PROPERTY_SINK_NAME -> "superSleekSinkName"))
+    result.isRight should be (true)
+    result.right.get match {
+      case BuildLocalOutputStreamOptions(localLocation) => localLocation.path should startWith (s"$tempDir/superSleekSinkName")
+      case _ => fail("Wrong")
+    }
+  }
+
+  it should "not create BuildLocalOutputStreamOptions when nothing supplied" in {
+    val result = S3OutputStreamOptions("bUiLdLoCal", Map[String,String]())
+    result.isLeft should be (true)
+    result.left.get.getClass.getSimpleName should be ("IllegalStateException")
+    result.left.get.getMessage should be ("Either a local temporary directory (connect.s3.local.tmp.directory) or a Sink Name (name) must be configured to use 'BuildLocal' write mode.")
+  }
+
+}

--- a/kafka-connect-aws-s3/src/test/scala/io/lenses/streamreactor/connect/aws/s3/sink/OffsetSeekerTest.scala
+++ b/kafka-connect-aws-s3/src/test/scala/io/lenses/streamreactor/connect/aws/s3/sink/OffsetSeekerTest.scala
@@ -19,7 +19,7 @@ package io.lenses.streamreactor.connect.aws.s3.sink
 
 import io.lenses.streamreactor.connect.aws.s3.config.Format.Json
 import io.lenses.streamreactor.connect.aws.s3.config.FormatSelection
-import io.lenses.streamreactor.connect.aws.s3.model.{BucketAndPath, Offset, Topic, TopicPartitionOffset}
+import io.lenses.streamreactor.connect.aws.s3.model.{RemotePathLocation, Offset, Topic, TopicPartitionOffset}
 import io.lenses.streamreactor.connect.aws.s3.storage.StorageInterface
 import org.mockito.MockitoSugar
 import org.scalatest.flatspec.AnyFlatSpec
@@ -32,7 +32,7 @@ class OffsetSeekerTest extends AnyFlatSpec with MockitoSugar with Matchers {
 
   private implicit val storageInterface: StorageInterface = mock[StorageInterface]
 
-  private val bucketAndPath = BucketAndPath("my-bucket", "path/myTopic/0")
+  private val bucketAndPath = RemotePathLocation("my-bucket", "path/myTopic/0")
 
   "seek" should "return empty set when path does not exist" in {
 

--- a/kafka-connect-aws-s3/src/test/scala/io/lenses/streamreactor/connect/aws/s3/sink/S3AvroWriterManagerTest.scala
+++ b/kafka-connect-aws-s3/src/test/scala/io/lenses/streamreactor/connect/aws/s3/sink/S3AvroWriterManagerTest.scala
@@ -38,7 +38,7 @@ class S3AvroWriterManagerTest extends AnyFlatSpec with Matchers with S3TestConfi
   private val PathPrefix = "streamReactorBackups"
   private val avroFormatReader = new AvroFormatReader
 
-  private val bucketAndPrefix = BucketAndPrefix(BucketName, Some(PathPrefix))
+  private val bucketAndPrefix = RemoteRootLocation(BucketName, Some(PathPrefix))
   private val avroConfig = S3SinkConfig(S3Config(
     Some(Identity),
     Some(Credential),

--- a/kafka-connect-aws-s3/src/test/scala/io/lenses/streamreactor/connect/aws/s3/sink/S3JsonWriterManagerTest.scala
+++ b/kafka-connect-aws-s3/src/test/scala/io/lenses/streamreactor/connect/aws/s3/sink/S3JsonWriterManagerTest.scala
@@ -39,7 +39,7 @@ class S3JsonWriterManagerTest extends AnyFlatSpec with Matchers with S3TestConfi
 
   "json sink" should "write single json record" in {
 
-    val bucketAndPrefix = BucketAndPrefix(BucketName, Some(PathPrefix))
+    val bucketAndPrefix = RemoteRootLocation(BucketName, Some(PathPrefix))
     val config = S3SinkConfig(S3Config(
       Some(Identity),
       Some(Credential),
@@ -66,7 +66,7 @@ class S3JsonWriterManagerTest extends AnyFlatSpec with Matchers with S3TestConfi
 
   "json sink" should "write schemas to json" in {
 
-    val bucketAndPrefix = BucketAndPrefix(BucketName, Some(PathPrefix))
+    val bucketAndPrefix = RemoteRootLocation(BucketName, Some(PathPrefix))
     val config = S3SinkConfig(S3Config(
       Some(Identity),
       Some(Credential),

--- a/kafka-connect-aws-s3/src/test/scala/io/lenses/streamreactor/connect/aws/s3/sink/S3ParquetWriterManagerTest.scala
+++ b/kafka-connect-aws-s3/src/test/scala/io/lenses/streamreactor/connect/aws/s3/sink/S3ParquetWriterManagerTest.scala
@@ -38,7 +38,7 @@ class S3ParquetWriterManagerTest extends AnyFlatSpec with Matchers with S3TestCo
   private val PathPrefix = "streamReactorBackups"
   private val parquetFormatReader = new ParquetFormatReader
 
-  private val bucketAndPrefix = BucketAndPrefix(BucketName, Some(PathPrefix))
+  private val bucketAndPrefix = RemoteRootLocation(BucketName, Some(PathPrefix))
   private val parquetConfig = S3SinkConfig(S3Config(
     Some(Identity),
     Some(Credential),

--- a/kafka-connect-aws-s3/src/test/scala/io/lenses/streamreactor/connect/aws/s3/sink/S3SinkTaskTest.scala
+++ b/kafka-connect-aws-s3/src/test/scala/io/lenses/streamreactor/connect/aws/s3/sink/S3SinkTaskTest.scala
@@ -1421,6 +1421,33 @@ class S3SinkTaskTest extends AnyFlatSpec with Matchers with S3TestConfig with Mo
     )
   }
 
+  "S3SinkTask" should "flush for every record when configured flush count size of 1 with build local write mode" in {
+
+    val task = new S3SinkTask()
+
+    val props = DefaultProps
+      .combine(
+        Map(
+          "name" -> "s3SinkTaskBuildLocalTest",
+          "connect.s3.kcql" -> s"insert into $BucketName:$PrefixName select * from $TopicName WITH_FLUSH_COUNT = 1",
+          "connect.s3.write.mode" -> "BuildLocal",
+        )
+      ).asJava
+
+    task.start(props)
+    task.open(Seq(new TopicPartition(TopicName, 1)).asJava)
+    task.put(records.asJava)
+    task.close(Seq(new TopicPartition(TopicName, 1)).asJava)
+    task.stop()
+
+    blobStoreContext.getBlobStore.list(BucketName, ListContainerOptions.Builder.prefix("streamReactorBackups/myTopic/1/")).size() should be(3)
+
+    readFileToString(BucketName, "streamReactorBackups/myTopic/1/0.json", blobStoreContext) should be("""{"name":"sam","title":"mr","salary":100.43}""")
+    readFileToString(BucketName, "streamReactorBackups/myTopic/1/1.json", blobStoreContext) should be("""{"name":"laura","title":"ms","salary":429.06}""")
+    readFileToString(BucketName, "streamReactorBackups/myTopic/1/2.json", blobStoreContext) should be("""{"name":"tom","title":null,"salary":395.44}""")
+
+  }
+
 
   private def createSinkRecord(partition: Int, valueStruct: Struct, offset: Int, headers: lang.Iterable[Header]) = {
     new SinkRecord(TopicName, partition, null, null, null, valueStruct, offset, null, null, headers)

--- a/kafka-connect-aws-s3/src/test/scala/io/lenses/streamreactor/connect/aws/s3/source/GenerateResourcesTest.scala
+++ b/kafka-connect-aws-s3/src/test/scala/io/lenses/streamreactor/connect/aws/s3/source/GenerateResourcesTest.scala
@@ -5,7 +5,7 @@ import java.util.UUID
 import com.typesafe.scalalogging.LazyLogging
 import io.lenses.streamreactor.connect.aws.s3.formats._
 import io.lenses.streamreactor.connect.aws.s3.model.BytesWriteMode.KeyAndValueWithSizes
-import io.lenses.streamreactor.connect.aws.s3.model.{ByteArraySinkData, StructSinkData}
+import io.lenses.streamreactor.connect.aws.s3.model.{BucketAndPath, ByteArraySinkData, StructSinkData}
 import io.lenses.streamreactor.connect.aws.s3.sink.utils.TestSampleSchemaAndData.{schema, topic}
 import io.lenses.streamreactor.connect.aws.s3.storage.{S3ByteArrayOutputStream, S3OutputStream}
 import org.apache.commons.io.FileUtils
@@ -75,7 +75,7 @@ class GenerateResourcesTest extends AnyFlatSpec with Matchers with LazyLogging {
 
               val writer: S3FormatWriter = writerClass(outputStreamFn)
               1 to numberOfRecords foreach { _ => writer.write(None, StructSinkData(userGen.sample.get), topic) }
-              writer.close()
+              writer.close(BucketAndPath("","")) // TODO: FIX
 
               val dataFile = new File(s"$dir/$format/$fileNum.$format")
               logger.info(s"Writing $format file ${dataFile.getAbsolutePath}")
@@ -107,7 +107,7 @@ class GenerateResourcesTest extends AnyFlatSpec with Matchers with LazyLogging {
 
               val writer: S3FormatWriter = writerClass(outputStreamFn)
               1 to numberOfRecords foreach { _ => writer.write(Some(ByteArraySinkData("myKey".getBytes)), ByteArraySinkData("somestring".getBytes), topic) }
-              writer.close()
+              writer.close(BucketAndPath("","")) // TODO: FIX
 
               val dataFile = new File(s"$dir/$format/$fileNum.$format")
               logger.info(s"Writing $format file ${dataFile.getAbsolutePath}")

--- a/kafka-connect-aws-s3/src/test/scala/io/lenses/streamreactor/connect/aws/s3/source/GenerateResourcesTest.scala
+++ b/kafka-connect-aws-s3/src/test/scala/io/lenses/streamreactor/connect/aws/s3/source/GenerateResourcesTest.scala
@@ -5,7 +5,7 @@ import java.util.UUID
 import com.typesafe.scalalogging.LazyLogging
 import io.lenses.streamreactor.connect.aws.s3.formats._
 import io.lenses.streamreactor.connect.aws.s3.model.BytesWriteMode.KeyAndValueWithSizes
-import io.lenses.streamreactor.connect.aws.s3.model.{BucketAndPath, ByteArraySinkData, StructSinkData}
+import io.lenses.streamreactor.connect.aws.s3.model.{RemotePathLocation, ByteArraySinkData, StructSinkData}
 import io.lenses.streamreactor.connect.aws.s3.sink.utils.TestSampleSchemaAndData.{schema, topic}
 import io.lenses.streamreactor.connect.aws.s3.storage.{S3ByteArrayOutputStream, S3OutputStream}
 import org.apache.commons.io.FileUtils
@@ -75,7 +75,7 @@ class GenerateResourcesTest extends AnyFlatSpec with Matchers with LazyLogging {
 
               val writer: S3FormatWriter = writerClass(outputStreamFn)
               1 to numberOfRecords foreach { _ => writer.write(None, StructSinkData(userGen.sample.get), topic) }
-              writer.close(BucketAndPath("","")) // TODO: FIX
+              writer.close(RemotePathLocation("","")) // TODO: FIX
 
               val dataFile = new File(s"$dir/$format/$fileNum.$format")
               logger.info(s"Writing $format file ${dataFile.getAbsolutePath}")
@@ -107,7 +107,7 @@ class GenerateResourcesTest extends AnyFlatSpec with Matchers with LazyLogging {
 
               val writer: S3FormatWriter = writerClass(outputStreamFn)
               1 to numberOfRecords foreach { _ => writer.write(Some(ByteArraySinkData("myKey".getBytes)), ByteArraySinkData("somestring".getBytes), topic) }
-              writer.close(BucketAndPath("","")) // TODO: FIX
+              writer.close(RemotePathLocation("","")) // TODO: FIX
 
               val dataFile = new File(s"$dir/$format/$fileNum.$format")
               logger.info(s"Writing $format file ${dataFile.getAbsolutePath}")

--- a/kafka-connect-aws-s3/src/test/scala/io/lenses/streamreactor/connect/aws/s3/source/ResultReaderTest.scala
+++ b/kafka-connect-aws-s3/src/test/scala/io/lenses/streamreactor/connect/aws/s3/source/ResultReaderTest.scala
@@ -17,14 +17,14 @@
 package io.lenses.streamreactor.connect.aws.s3.source
 
 import io.lenses.streamreactor.connect.aws.s3.formats.S3FormatStreamReader
-import io.lenses.streamreactor.connect.aws.s3.model.{BucketAndPath, PollResults, SourceData, StringSourceData}
+import io.lenses.streamreactor.connect.aws.s3.model.{RemotePathLocation, PollResults, SourceData, StringSourceData}
 import org.mockito.MockitoSugar
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 
 class ResultReaderTest extends AnyFlatSpec with MockitoSugar with Matchers {
 
-  private val readerBucketAndPath = BucketAndPath("bucket-and-path", "prefix")
+  private val readerBucketAndPath = RemotePathLocation("bucket-and-path", "prefix")
   private val prefix = "MyPrefix"
   private val targetTopic = "MyTargetTopic"
   private val limit = 10

--- a/kafka-connect-aws-s3/src/test/scala/io/lenses/streamreactor/connect/aws/s3/source/S3BucketReaderManagerTest.scala
+++ b/kafka-connect-aws-s3/src/test/scala/io/lenses/streamreactor/connect/aws/s3/source/S3BucketReaderManagerTest.scala
@@ -38,7 +38,7 @@ class S3BucketReaderManagerTest extends AnyFlatSpec with MockitoSugar with Match
   private val format = FormatSelection(Format.Json)
   private val fileNamingStrategy = new HierarchicalS3FileNamingStrategy(format)
   private val prefix = "ing"
-  private val bucketAndPrefix: BucketAndPrefix = BucketAndPrefix("test", Some(prefix))
+  private val bucketAndPrefix: RemoteRootLocation = RemoteRootLocation("test", Some(prefix))
   private val targetTopic: String = "topic"
 
   private val sourceBucketOptions = SourceBucketOptions(
@@ -70,7 +70,7 @@ class S3BucketReaderManagerTest extends AnyFlatSpec with MockitoSugar with Match
     when(sourceLister.next(fileNamingStrategy, bucketAndPrefix, None, None)).thenReturn(Some(nextTopicPartitionOffset))
     when(sourceLister.next(fileNamingStrategy, bucketAndPrefix, Some(nextTopicPartitionOffset), None)).thenReturn(None)
 
-    val bucketAndPath = BucketAndPath(bucketAndPrefix.bucket, "ing/topic/9/0.json")
+    val bucketAndPath = RemotePathLocation(bucketAndPrefix.bucket, "ing/topic/9/0.json")
     val inputStream = new ByteArrayInputStream(TestSampleSchemaAndData.recordsAsJson(0).getBytes())
     when(storageInterface.getBlob(bucketAndPath)).thenReturn(inputStream)
 
@@ -103,7 +103,7 @@ class S3BucketReaderManagerTest extends AnyFlatSpec with MockitoSugar with Match
     when(sourceLister.next(fileNamingStrategy, bucketAndPrefix, None, Some(nextTopicPartitionOffset))).thenReturn(Some(nextTopicPartitionOffset))
     when(sourceLister.next(fileNamingStrategy, bucketAndPrefix, Some(nextTopicPartitionOffset), None)).thenReturn(None)
 
-    val bucketAndPath = BucketAndPath(bucketAndPrefix.bucket, "ing/topic/9/0.json")
+    val bucketAndPath = RemotePathLocation(bucketAndPrefix.bucket, "ing/topic/9/0.json")
     val inputStream = new ByteArrayInputStream(
       TestSampleSchemaAndData.recordsAsJson.mkString(System.lineSeparator()).getBytes
     )
@@ -135,13 +135,13 @@ class S3BucketReaderManagerTest extends AnyFlatSpec with MockitoSugar with Match
     val file1Name = "ing/topic/9/200.json"
     val file1Tpo = Topic("topic").withPartition(9).withOffset(200)
     val file1StoredFile = S3StoredFile(file1Name, file1Tpo)
-    val file1BucketAndPath = BucketAndPath(bucketAndPrefix.bucket, "ing/topic/9/200.json")
+    val file1BucketAndPath = RemotePathLocation(bucketAndPrefix.bucket, "ing/topic/9/200.json")
 
     val file2ByteArray = resourceToByteArray(getClass.getClassLoader.getResourceAsStream("json/2.json"))
     val file2Name = "ing/topic/9/400.json"
     val file2Tpo = Topic("topic").withPartition(9).withOffset(400)
     val file2StoredFile = S3StoredFile(file2Name, file2Tpo)
-    val file2BucketAndPath = BucketAndPath(bucketAndPrefix.bucket, "ing/topic/9/400.json")
+    val file2BucketAndPath = RemotePathLocation(bucketAndPrefix.bucket, "ing/topic/9/400.json")
 
     // start at file 2, line 10
     val offsetReaderResultFn: (String, String) => Option[OffsetReaderResult] = (bucketAndPath, prefix) => {
@@ -178,13 +178,13 @@ class S3BucketReaderManagerTest extends AnyFlatSpec with MockitoSugar with Match
     )
 
     val file1ByteArray = resourceToByteArray(getClass.getClassLoader.getResourceAsStream("json/1.json"))
-    val file1BucketAndPath = BucketAndPath(bucketAndPrefix.bucket, "ing/topic/9/200.json")
+    val file1BucketAndPath = RemotePathLocation(bucketAndPrefix.bucket, "ing/topic/9/200.json")
 
     val file2ByteArray = resourceToByteArray(getClass.getClassLoader.getResourceAsStream("json/2.json"))
     val file2Name = "ing/topic/9/400.json"
     val file2Tpo = Topic("topic").withPartition(9).withOffset(400)
     val file2StoredFile = S3StoredFile(file2Name, file2Tpo)
-    val file2BucketAndPath = BucketAndPath(bucketAndPrefix.bucket, "ing/topic/9/400.json")
+    val file2BucketAndPath = RemotePathLocation(bucketAndPrefix.bucket, "ing/topic/9/400.json")
 
     // start at file 2, line 10
     val offsetReaderResultFn: (String, String) => Option[OffsetReaderResult] = (bucketAndPath, prefix) => {
@@ -236,19 +236,19 @@ class S3BucketReaderManagerTest extends AnyFlatSpec with MockitoSugar with Match
     )
 
     val file1ByteArray = resourceToByteArray(getClass.getClassLoader.getResourceAsStream("json/1.json"))
-    val file1BucketAndPath = BucketAndPath(bucketAndPrefix.bucket, "ing/topic/9/200.json")
+    val file1BucketAndPath = RemotePathLocation(bucketAndPrefix.bucket, "ing/topic/9/200.json")
 
     val file2ByteArray = resourceToByteArray(getClass.getClassLoader.getResourceAsStream("json/2.json"))
     val file2Name = "ing/topic/9/400.json"
     val file2Tpo = Topic("topic").withPartition(9).withOffset(400)
     val file2StoredFile = S3StoredFile(file2Name, file2Tpo)
-    val file2BucketAndPath = BucketAndPath(bucketAndPrefix.bucket, "ing/topic/9/400.json")
+    val file2BucketAndPath = RemotePathLocation(bucketAndPrefix.bucket, "ing/topic/9/400.json")
 
     val file3ByteArray = resourceToByteArray(getClass.getClassLoader.getResourceAsStream("json/3.json"))
     val file3Name = "ing/topic/9/600.json"
     val file3Tpo = Topic("topic").withPartition(9).withOffset(600)
     val file3StoredFile = S3StoredFile(file3Name, file3Tpo)
-    val file3BucketAndPath = BucketAndPath(bucketAndPrefix.bucket, "ing/topic/9/600.json")
+    val file3BucketAndPath = RemotePathLocation(bucketAndPrefix.bucket, "ing/topic/9/600.json")
 
     // start at file 2, line 10
     val offsetReaderResultFn: (String, String) => Option[OffsetReaderResult] = (bucketAndPath, prefix) => {

--- a/kafka-connect-aws-s3/src/test/scala/io/lenses/streamreactor/connect/aws/s3/source/S3SourceListerTest.scala
+++ b/kafka-connect-aws-s3/src/test/scala/io/lenses/streamreactor/connect/aws/s3/source/S3SourceListerTest.scala
@@ -32,7 +32,7 @@ class S3SourceListerTest extends AnyFlatSpec with MockitoSugar with Matchers {
 
   private implicit val storageInterface: StorageInterface = mock[StorageInterface]
 
-  private val bucketAndPrefix = BucketAndPrefix("my-bucket", Some("path"))
+  private val bucketAndPrefix = RemoteRootLocation("my-bucket", Some("path"))
   private val sourceLister = new S3SourceLister
 
   // comes back in random order

--- a/kafka-connect-aws-s3/src/test/scala/io/lenses/streamreactor/connect/aws/s3/storage/BuildLocalOutputStreamTest.scala
+++ b/kafka-connect-aws-s3/src/test/scala/io/lenses/streamreactor/connect/aws/s3/storage/BuildLocalOutputStreamTest.scala
@@ -1,0 +1,90 @@
+
+/*
+ * Copyright 2020 Lenses.io
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.lenses.streamreactor.connect.aws.s3.storage
+
+import io.lenses.streamreactor.connect.aws.s3.formats.Using
+import io.lenses.streamreactor.connect.aws.s3.model.{BucketAndPath, LocalLocation}
+import org.mockito.MockitoSugar
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+import java.nio.file.Files
+import scala.io.Source
+
+class BuildLocalOutputStreamTest extends AnyFlatSpec with MockitoSugar with Matchers with Using {
+
+  private val testBucketAndPath = BucketAndPath("my-bucket", "my-path")
+  private val tmpDir = Files.createTempDirectory("myTmpDir")
+  private val testLocalLocation = LocalLocation(s"$tmpDir/tmpFileTest.tmp")
+
+  "write" should "write single byte sequences" in new TestContext {
+    val bytesToUpload: Array[Byte] = "Sausages".getBytes
+    target.write(bytesToUpload, 0, bytesToUpload.length)
+
+    verify(mockStorageInterface, never).uploadFile(
+      testLocalLocation,
+      testBucketAndPath
+    )
+
+    target.complete(testBucketAndPath)
+
+    readFileContents should be ("Sausages")
+
+    verify(mockStorageInterface, times(1)).uploadFile(
+      testLocalLocation,
+      testBucketAndPath
+    )
+
+    target.getPointer should be (8)
+  }
+
+  "write" should "write multiple byte sequences" in new TestContext {
+    val bytesToUpload1: Array[Byte] = "Sausages".getBytes
+    target.write(bytesToUpload1, 0, bytesToUpload1.length)
+    target.getPointer should be (8)
+
+    val bytesToUpload2: Array[Byte] = "Mash".getBytes
+    target.write(bytesToUpload2, 0, bytesToUpload2.length)
+    target.getPointer should be (12)
+
+    target.complete(testBucketAndPath)
+
+    readFileContents should be ("SausagesMash")
+
+    verify(mockStorageInterface, times(1)).uploadFile(
+      testLocalLocation,
+      testBucketAndPath
+    )
+  }
+
+  private def readFileContents = {
+    using(Source.fromFile(testLocalLocation.path)) {
+      _.getLines().mkString
+    }
+  }
+
+  class TestContext {
+
+    implicit val mockStorageInterface: StorageInterface = mock[StorageInterface]
+    doNothing.when(mockStorageInterface).uploadFile(testLocalLocation, testBucketAndPath)
+
+    val target = new BuildLocalOutputStream(testLocalLocation, false)
+  }
+
+}
+

--- a/kafka-connect-aws-s3/src/test/scala/io/lenses/streamreactor/connect/aws/s3/storage/BuildLocalOutputStreamTest.scala
+++ b/kafka-connect-aws-s3/src/test/scala/io/lenses/streamreactor/connect/aws/s3/storage/BuildLocalOutputStreamTest.scala
@@ -18,7 +18,7 @@
 package io.lenses.streamreactor.connect.aws.s3.storage
 
 import io.lenses.streamreactor.connect.aws.s3.formats.Using
-import io.lenses.streamreactor.connect.aws.s3.model.{BucketAndPath, LocalLocation}
+import io.lenses.streamreactor.connect.aws.s3.model.{RemotePathLocation, LocalLocation}
 import org.mockito.MockitoSugar
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
@@ -28,7 +28,7 @@ import scala.io.Source
 
 class BuildLocalOutputStreamTest extends AnyFlatSpec with MockitoSugar with Matchers with Using {
 
-  private val testBucketAndPath = BucketAndPath("my-bucket", "my-path")
+  private val testBucketAndPath = RemotePathLocation("my-bucket", "my-path")
   private val tmpDir = Files.createTempDirectory("myTmpDir")
   private val testLocalLocation = LocalLocation(s"$tmpDir/tmpFileTest.tmp")
 

--- a/kafka-connect-aws-s3/src/test/scala/io/lenses/streamreactor/connect/aws/s3/storage/MultipartBlobStoreOutputStreamTest.scala
+++ b/kafka-connect-aws-s3/src/test/scala/io/lenses/streamreactor/connect/aws/s3/storage/MultipartBlobStoreOutputStreamTest.scala
@@ -17,7 +17,7 @@
 
 package io.lenses.streamreactor.connect.aws.s3.storage
 
-import io.lenses.streamreactor.connect.aws.s3.model.BucketAndPath
+import io.lenses.streamreactor.connect.aws.s3.model.RemotePathLocation
 import org.jclouds.blobstore.domain.{MultipartPart, MultipartUpload}
 import org.mockito.ArgumentMatchers._
 import org.mockito.{ArgumentCaptor, ArgumentMatchers, MockitoSugar}
@@ -30,7 +30,7 @@ class MultipartBlobStoreOutputStreamTest extends AnyFlatSpec with MockitoSugar w
 
   private val MinFileSizeBytes = 10
 
-  private val testBucketAndPath = BucketAndPath("my-bucket", "my-path")
+  private val testBucketAndPath = RemotePathLocation("my-bucket", "my-path")
 
   /**
     * Create a byte array consisting of a given number of a repeating characters

--- a/kafka-connect-aws-s3/src/test/scala/io/lenses/streamreactor/connect/aws/s3/storage/MultipartBlobStoreOutputStreamTest.scala
+++ b/kafka-connect-aws-s3/src/test/scala/io/lenses/streamreactor/connect/aws/s3/storage/MultipartBlobStoreOutputStreamTest.scala
@@ -110,7 +110,7 @@ class MultipartBlobStoreOutputStreamTest extends AnyFlatSpec with MockitoSugar w
     val payloadCaptor: ArgumentCaptor[Array[Byte]] = setUpUploadPartPayloadCaptor(returnState)
 
     target.write(nBytes(8, 'X'), 0, 8)
-    target.complete
+    target.complete(testBucketAndPath)
 
     val submittedPayloads: Seq[Array[Byte]] = payloadCaptor.getAllValues.asScala.toList
     submittedPayloads should have size 1
@@ -127,7 +127,7 @@ class MultipartBlobStoreOutputStreamTest extends AnyFlatSpec with MockitoSugar w
 
     reset(mockStorageInterface)
 
-    target.complete
+    target.complete(testBucketAndPath)
 
     verify(mockStorageInterface, never).uploadPart(any[MultiPartUploadState], payloadCaptor.capture(), ArgumentMatchers.eq(8))
 

--- a/kafka-connect-aws-s3/src/test/scala/io/lenses/streamreactor/connect/aws/s3/storage/MultipartBlobStoreStorageInterfaceTest.scala
+++ b/kafka-connect-aws-s3/src/test/scala/io/lenses/streamreactor/connect/aws/s3/storage/MultipartBlobStoreStorageInterfaceTest.scala
@@ -17,7 +17,7 @@
 
 package io.lenses.streamreactor.connect.aws.s3.storage
 
-import io.lenses.streamreactor.connect.aws.s3.model.{BucketAndPath, BucketAndPrefix}
+import io.lenses.streamreactor.connect.aws.s3.model.{RemotePathLocation, RemoteRootLocation}
 import io.lenses.streamreactor.connect.aws.s3.sink.utils.S3TestPayloadReader
 import org.jclouds.blobstore.domain.internal.{PageSetImpl, StorageMetadataImpl}
 import org.jclouds.blobstore.domain.{BlobMetadata, MultipartPart, MultipartUpload, StorageMetadata, StorageType}
@@ -36,7 +36,7 @@ class MultipartBlobStoreStorageInterfaceTest extends AnyFlatSpec with MockitoSug
 
   private val blobStoreContext: BlobStoreContext = mock[BlobStoreContext]
   private val blobStore: BlobStore = mock[BlobStore]
-  private val testBucketAndPath = BucketAndPath("my-bucket", "myPath")
+  private val testBucketAndPath = RemotePathLocation("my-bucket", "myPath")
 
   when(blobStoreContext.getBlobStore).thenReturn(blobStore)
 
@@ -109,7 +109,7 @@ class MultipartBlobStoreStorageInterfaceTest extends AnyFlatSpec with MockitoSug
         any[ListContainerOptions]
       )
 
-    multipartBlobStoreStorageInterface.list(BucketAndPrefix(testBucketAndPath.bucket, Some("prefix"))) should
+    multipartBlobStoreStorageInterface.list(RemoteRootLocation(testBucketAndPath.bucket, Some("prefix"))) should
       be(List("first", "second"))
   }
 
@@ -124,7 +124,7 @@ class MultipartBlobStoreStorageInterfaceTest extends AnyFlatSpec with MockitoSug
         any[ListContainerOptions]
       )
 
-    multipartBlobStoreStorageInterface.list(BucketAndPrefix(testBucketAndPath.bucket, Some("prefix"))) should
+    multipartBlobStoreStorageInterface.list(RemoteRootLocation(testBucketAndPath.bucket, Some("prefix"))) should
       be(List("only"))
   }
 

--- a/kafka-connect-aws-s3/src/test/scala/io/lenses/streamreactor/connect/aws/s3/storage/S3ByteArrayOutputStream.scala
+++ b/kafka-connect-aws-s3/src/test/scala/io/lenses/streamreactor/connect/aws/s3/storage/S3ByteArrayOutputStream.scala
@@ -17,7 +17,7 @@
 
 package io.lenses.streamreactor.connect.aws.s3.storage
 
-import io.lenses.streamreactor.connect.aws.s3.model.BucketAndPath
+import io.lenses.streamreactor.connect.aws.s3.model.RemotePathLocation
 
 import java.io.ByteArrayOutputStream
 
@@ -27,7 +27,7 @@ class S3ByteArrayOutputStream extends S3OutputStream {
 
   var pointer: Long = 0L
 
-  override def complete(finalDestination: BucketAndPath) = {}
+  override def complete(finalDestination: RemotePathLocation) = {}
 
   override def getPointer: Long = pointer
 

--- a/kafka-connect-aws-s3/src/test/scala/io/lenses/streamreactor/connect/aws/s3/storage/S3ByteArrayOutputStream.scala
+++ b/kafka-connect-aws-s3/src/test/scala/io/lenses/streamreactor/connect/aws/s3/storage/S3ByteArrayOutputStream.scala
@@ -17,6 +17,8 @@
 
 package io.lenses.streamreactor.connect.aws.s3.storage
 
+import io.lenses.streamreactor.connect.aws.s3.model.BucketAndPath
+
 import java.io.ByteArrayOutputStream
 
 class S3ByteArrayOutputStream extends S3OutputStream {
@@ -25,7 +27,7 @@ class S3ByteArrayOutputStream extends S3OutputStream {
 
   var pointer: Long = 0L
 
-  override def complete: Boolean = true
+  override def complete(finalDestination: BucketAndPath) = {}
 
   override def getPointer: Long = pointer
 


### PR DESCRIPTION
Enabling the ability to build the file locally before uploading in one go in the commit.

This enables new configuration options to ensure the files are locally built and complete before uploading to S3.  This avoids the necessity for a rename and therefore doesn't clutter version history.

The new configuration options are:
`connect.s3.write.mode` options are `BuildLocal` (which builds the file locally before uploading) or `Streamed` (which keeps the previous behaviour of streaming)
`connect.s3.local.tmp.directory` is optional to supply a directory to write the files to locally.  If none is supplied and `BuildLocal` mode is used, then a directory will be created in your system temporary directory (eg /tmp)

The new `BuildLocal` write mode is currently limited to 5GB as it does not use the multipart upload API.