### PR TITLE
Deprecation of Old "aws.*" Properties & Implementation of YAML Profiles & KCQL Builder for Easier Configuration

### DIFF
--- a/kafka-connect-aws-s3/README-profiles.md
+++ b/kafka-connect-aws-s3/README-profiles.md
@@ -1,0 +1,55 @@
+# AWS S3 Connector Yaml Profile Loading
+
+This connector supports loading connector configuration via Yaml.
+
+## Specifying Profiles
+
+To specify a profile in your connector config you can use the following setting in your main connector configuration:
+
+    connect.s3.config.profiles=/resources/yaml/profile1.yaml,/resources/yaml/profile2.yaml
+
+Note: To ensure this works you must ensure that the directory in which the configuration files lie is in your classpath.
+
+Multiple configuration profiles can be specified via connector configuration.
+
+They will be loaded and the KCQL configurations will be merged.
+
+
+## Yaml File Format
+
+Here is an example Yaml configuration file.  Any of the properties as detailed in the documentation can be integrated into the Yaml file.
+
+    ---
+    connect.s3.aws.access.key: myAccessKey
+    connect.s3.aws.secret.key: mySecretKey
+    connect.s3.aws.auth.mode: myAuthMode
+    connect.s3.kcql: insert into `target-bucket:target-path` select * from `source.bucket` PARTITIONBY name,title,salary STOREAS `text` WITH_FLUSH_SIZE = 500000000 WITH_FLUSH_INTERVAL = 3600 WITH_FLUSH_COUNT = 50000
+
+For more flexibility when working with KCQL, a kcql builder Yaml map can be supplied in exchange for the Kcql String.
+
+    ---
+    connect.s3.kcql.builder:
+      source: my-kafka-topic
+      target: myBucket:myPartition
+      format: csv
+      partitions: name,title,salary
+      partitioner: Values
+      flush_size: 1
+      flush_interval: 2
+      flush_count: 3
+
+This will be used by the connector to build the relevant KCQL string at startup.
+
+## KCQL in connector configuration
+
+Due to limitations, if supplying the KCQL or the KCQL builder yaml, the source and target are always mandatory.
+
+To avoid having to set them use the special keyword "USE_PROFILE", which will ignore this property.
+
+For example a minimal kcql string:
+
+    connect.s3.kcql=insert into USE_PROFILE select * from USE_PROFILE
+
+Using this will enable you to set a mandatory KCQL string however fall back on the values in the profiles.
+
+Of course, the connector will fail if the valid options are not set somewhere in the profile chain. 

--- a/kafka-connect-aws-s3/README-source.md
+++ b/kafka-connect-aws-s3/README-source.md
@@ -15,9 +15,9 @@ An example configuration is provided:
     connector.class=io.lenses.streamreactor.connect.aws.s3.source.S3SourceConnector
     tasks.max=1
     connect.s3.kcql=insert into $TOPIC_NAME select * from $BUCKET_NAME:$PREFIX_NAME STOREAS `parquet`
-    aws.secret.key=SECRET_KEY
-    aws.access.key=ACCESS_KEY
-    aws.auth.mode=Credentials
+    connect.s3.aws.secret.key=SECRET_KEY
+    connect.s3.aws.access.key=ACCESS_KEY
+    connect.s3.aws.auth.mode=Credentials
     value.converter=io.confluent.connect.avro.AvroConverter
     value.converter.schema.registry.url=http://localhost:8089
 
@@ -34,16 +34,16 @@ Please read below for a detailed explanation of these and other options, includi
 
 ACCESS_KEY and SECRET_KEY are credentials generated within AWS IAM and must be set and configured with permissions to write to the desired S3 bucket.
 
-    aws.auth.mode=Credentials
-    aws.access.key=ACCESS_KEY
-    aws.secret.key=SECRET_KEY
+    connect.s3.aws.auth.mode=Credentials
+    connect.s3.aws.access.key=ACCESS_KEY
+    connect.s3.aws.secret.key=SECRET_KEY
 
 
 #### Default
 
 In this auth mode no credentials need be supplied.  If no auth mode is specified, then this default will be used.
 
-    aws.auth.mode=Default
+    connect.s3.aws.auth.mode=Default
     
 The credentials will be discovered through the default chain, in this order:
 

--- a/kafka-connect-aws-s3/README.md
+++ b/kafka-connect-aws-s3/README.md
@@ -42,3 +42,8 @@ Please see the [S3 Sink configuration readme](README-sink.md)
 
 Please see the [S3 Source configuration readme](README-source.md)
 
+
+## YAML Profile Support
+
+Please see the [YAML Profile readme](README-profiles.md)
+

--- a/kafka-connect-aws-s3/build.gradle
+++ b/kafka-connect-aws-s3/build.gradle
@@ -56,7 +56,7 @@ project(":kafka-connect-aws-s3") {
         compile("org.apache.hadoop:hadoop-common:$hadoopVersion")
         compile("org.apache.hadoop:hadoop-mapreduce-client-core:$hadoopVersion")
         compile("au.com.bytecode:opencsv:2.4")
-
+        compile("org.yaml:snakeyaml:1.29")
         testCompile("org.gaul:s3proxy:$s3ProxyVersion")
 
     }

--- a/kafka-connect-aws-s3/src/main/scala/io/lenses/streamreactor/connect/aws/s3/config/S3ConfigSettings.scala
+++ b/kafka-connect-aws-s3/src/main/scala/io/lenses/streamreactor/connect/aws/s3/config/S3ConfigSettings.scala
@@ -23,16 +23,26 @@ object S3ConfigSettings {
 
   val CONNECTOR_PREFIX = "connect.s3"
 
-  val AWS_ACCESS_KEY: String = "aws.access.key"
-  val AWS_SECRET_KEY: String = "aws.secret.key"
-  val AUTH_MODE: String = "aws.auth.mode"
-  val CUSTOM_ENDPOINT: String = "aws.custom.endpoint"
-  val ENABLE_VIRTUAL_HOST_BUCKETS: String = "aws.vhost.bucket"
+  // Deprecated and will be removed in future
+  val DEP_AWS_ACCESS_KEY: String = "aws.access.key"
+  val DEP_AWS_SECRET_KEY: String = "aws.secret.key"
+  val DEP_AUTH_MODE: String = "aws.auth.mode"
+  val DEP_CUSTOM_ENDPOINT: String = "aws.custom.endpoint"
+  val DEP_ENABLE_VIRTUAL_HOST_BUCKETS: String = "aws.vhost.bucket"
+
+  val AWS_ACCESS_KEY: String = s"$CONNECTOR_PREFIX.aws.access.key"
+  val AWS_SECRET_KEY: String = s"$CONNECTOR_PREFIX.aws.secret.key"
+  val AUTH_MODE: String = s"$CONNECTOR_PREFIX.aws.auth.mode"
+  val CUSTOM_ENDPOINT: String = s"$CONNECTOR_PREFIX.custom.endpoint"
+  val ENABLE_VIRTUAL_HOST_BUCKETS: String = s"$CONNECTOR_PREFIX.vhost.bucket"
+
   val DISABLE_FLUSH_COUNT: String = s"$CONNECTOR_PREFIX.disable.flush.count"
   val WRITE_MODE: String = s"$CONNECTOR_PREFIX.write.mode"
   val LOCAL_TMP_DIRECTORY: String = s"$CONNECTOR_PREFIX.local.tmp.directory"
 
-  val KcqlKey = s"$CONNECTOR_PREFIX.$KCQL_PROP_SUFFIX"
+  val PROFILES: String = s"$CONNECTOR_PREFIX.config.profiles"
+
+  val KCQL_BUILDER = s"$CONNECTOR_PREFIX.$KCQL_PROP_SUFFIX.builder"
   val KCQL_CONFIG = s"$CONNECTOR_PREFIX.$KCQL_PROP_SUFFIX"
   val KCQL_DOC = "Contains the Kafka Connect Query Language describing the flow from Apache Kafka topics to Apache Hive tables."
   val KCQL_DISPLAY = "KCQL commands"

--- a/kafka-connect-aws-s3/src/main/scala/io/lenses/streamreactor/connect/aws/s3/config/processors/ConfigDefProcessor.scala
+++ b/kafka-connect-aws-s3/src/main/scala/io/lenses/streamreactor/connect/aws/s3/config/processors/ConfigDefProcessor.scala
@@ -14,16 +14,14 @@
  * limitations under the License.
  */
 
-package io.lenses.streamreactor.connect.aws.s3.config
+package io.lenses.streamreactor.connect.aws.s3.config.processors
 
-import com.datamountaineer.streamreactor.common.config.base.traits.BaseSettings
-import io.lenses.streamreactor.connect.aws.s3.config.S3ConfigSettings.WRITE_MODE
-import io.lenses.streamreactor.connect.aws.s3.model.S3OutputStreamOptions
+/**
+  * ConfigDefProcessor provides an interface to process the configs on entry
+  * into the sink.
+  */
+trait ConfigDefProcessor {
 
-trait S3WriteModeSettings extends BaseSettings {
-
-  def s3WriteOptions(s3ConfigDefBuilder: S3ConfigDefBuilder) : Either[Exception,S3OutputStreamOptions] = {
-    S3OutputStreamOptions(getString(WRITE_MODE), s3ConfigDefBuilder)
-  }
+  def process(input: Map[String, AnyRef]): Either[Throwable, Map[String, AnyRef]]
 
 }

--- a/kafka-connect-aws-s3/src/main/scala/io/lenses/streamreactor/connect/aws/s3/config/processors/DeprecationConfigDefProcessor.scala
+++ b/kafka-connect-aws-s3/src/main/scala/io/lenses/streamreactor/connect/aws/s3/config/processors/DeprecationConfigDefProcessor.scala
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2021 Lenses.io
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.lenses.streamreactor.connect.aws.s3.config.processors
+
+import cats.implicits._
+import com.typesafe.scalalogging.LazyLogging
+import io.lenses.streamreactor.connect.aws.s3.config.S3ConfigSettings.{DEP_AUTH_MODE, DEP_AWS_ACCESS_KEY, DEP_AWS_SECRET_KEY, DEP_CUSTOM_ENDPOINT, DEP_ENABLE_VIRTUAL_HOST_BUCKETS, _}
+
+import scala.collection.immutable.ListMap
+import scala.collection.mutable
+
+/**
+  * Some properties are officially deprecated in the connector.  To allow backwards compatibility, this remaps the old properties to their new string values.
+  */
+class DeprecationConfigDefProcessor extends ConfigDefProcessor with LazyLogging {
+
+  private val deprecatedProps: Map[String, String] = ListMap(
+    DEP_AUTH_MODE -> AUTH_MODE,
+    DEP_AWS_ACCESS_KEY -> AWS_ACCESS_KEY,
+    DEP_AWS_SECRET_KEY -> AWS_SECRET_KEY,
+    DEP_ENABLE_VIRTUAL_HOST_BUCKETS -> ENABLE_VIRTUAL_HOST_BUCKETS,
+    DEP_CUSTOM_ENDPOINT -> CUSTOM_ENDPOINT
+  )
+
+  override def process(input: Map[String, AnyRef]): Either[Exception, Map[String, AnyRef]] = {
+
+    val mutableInput = mutable.Map(input.toSeq: _*)
+    deprecatedProps.foreach {
+      case (oldPropKey, newPropKey) =>
+        if (mutableInput.contains(oldPropKey)) {
+          mutableInput.put(newPropKey, mutableInput(oldPropKey))
+          mutableInput.remove(oldPropKey)
+        }
+    }
+
+    mutableInput.toMap.asRight
+  }
+}

--- a/kafka-connect-aws-s3/src/main/scala/io/lenses/streamreactor/connect/aws/s3/config/processors/YamlProfileProcessor.scala
+++ b/kafka-connect-aws-s3/src/main/scala/io/lenses/streamreactor/connect/aws/s3/config/processors/YamlProfileProcessor.scala
@@ -1,0 +1,124 @@
+/*
+ * Copyright 2021 Lenses.io
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.lenses.streamreactor.connect.aws.s3.config.processors
+
+import cats.implicits._
+import com.typesafe.scalalogging.LazyLogging
+import io.lenses.streamreactor.connect.aws.s3.config.S3ConfigSettings
+import io.lenses.streamreactor.connect.aws.s3.config.processors.kcql.KcqlProcessor
+import org.yaml.snakeyaml.Yaml
+
+import java.io.{FileNotFoundException, InputStream, SequenceInputStream}
+import java.util
+import java.util.Collections.enumeration
+import scala.jdk.CollectionConverters._
+import scala.util.{Failure, Success, Try}
+
+/**
+  * If Yaml profiles are configured on the connector, this tries to load them via a classpath resource, and uses the
+  * KcqlProcessor to merge the various different profiles into a single Kcql string.
+  */
+class YamlProfileProcessor extends ConfigDefProcessor with LazyLogging {
+
+  private val yaml = new Yaml()
+
+  override def process(connectorConfig: Map[String, AnyRef]): Either[Throwable, Map[String, AnyRef]] = {
+    val profileResources = for {
+      profileResources <- getConfigProfileProperty(connectorConfig)
+    } yield profileResources
+    profileResources match {
+      case Left(error) => error.asLeft[Map[String, AnyRef]]
+      case Right(None) => connectorConfig.asRight
+      case Right(Some(value)) => parseProps(connectorConfig, value)
+    }
+  }
+
+  def closeStreams(streams: Seq[InputStream]) : Either[Throwable, Unit] = {
+    streams.foreach(s => Try(s.close()))
+    ().asRight
+  }
+
+  private def parseProps(connectorConfig: Map[String, AnyRef], profileResources: String): Either[Throwable, Map[String, AnyRef]] = {
+
+    for {
+      streams <- openProfileFiles(profileResources)
+      seqInputStream <- openSequenceInputStream(streams)
+      yamlConfigs <- parseMapProperties(seqInputStream)
+      _ <- closeStreams(seqInputStream +: streams)
+      flattenedYamlProps <- flattenRootYamlProps(yamlConfigs)
+      kcqlString <- KcqlProcessor.process(yamlConfigs :+ connectorConfig)
+      merged <- mergeYamlProperties(connectorConfig, flattenedYamlProps, kcqlString)
+    } yield merged
+  }
+
+  private def getConfigProfileProperty(input: Map[String, AnyRef]): Either[Throwable, Option[String]] = {
+    input.get(S3ConfigSettings.PROFILES) match {
+      case Some(value: String) => Some(value).asRight
+      case None => None.asRight
+      case other => new IllegalArgumentException(s"Invalid configuration: $other").asLeft
+    }
+  }
+
+  private def openProfileFiles(profiles: String): Either[Throwable, List[InputStream]] = {
+    profiles.split(",").map(
+      profile =>
+        Try {
+          classOf[YamlProfileProcessor].getResourceAsStream(profile)
+        } match {
+          case Success(value: InputStream) => value
+          case Failure(exception) => return exception.asLeft[List[InputStream]]
+          case Success(null) => return new FileNotFoundException(s"yaml profile not found: $profile").asLeft[List[InputStream]]
+        }
+    ).toList.asRight
+  }
+
+  private def openSequenceInputStream(fileInputStreams: List[InputStream]): Either[Throwable, SequenceInputStream] = {
+    fileInputStreams.filterNot(_ == null) match {
+      case Nil => new IllegalStateException("No valid input streams").asLeft[SequenceInputStream]
+      case isList: List[InputStream] => Try {
+        new SequenceInputStream(enumeration(isList.asJava))
+      }.toEither
+    }
+  }
+
+  private def parseMapProperties(fullYamlStream: SequenceInputStream): Either[Throwable, List[Map[String, AnyRef]]] = {
+    Try {
+      yaml.loadAll(fullYamlStream).asScala.map {
+        case map: util.Map[_, _] => map.asInstanceOf[util.Map[String, AnyRef]].asScala.toMap
+        case _ => throw new IllegalStateException("Unexpected type") //TODO don't throw
+      }.toList
+    }.toEither
+  }
+
+  private def flattenRootYamlProps(configSets: List[Map[String, AnyRef]]): Either[Throwable, Map[String, AnyRef]] = {
+
+    configSets.flatMap {
+      _.flatMap {
+        case (k: String, v: AnyRef) => Some(k, v)
+        case _ => None
+      }
+    }.toMap.asRight
+  }
+
+  private def mergeYamlProperties(input: Map[String, AnyRef], yamlProps: Map[String, AnyRef], kcqlString: String): Either[Throwable, Map[String, AnyRef]] = {
+    var merged: Map[String, AnyRef] = yamlProps ++ input
+    merged = merged -- Seq(S3ConfigSettings.KCQL_BUILDER, S3ConfigSettings.PROFILES)
+    merged = merged + (S3ConfigSettings.KCQL_CONFIG -> kcqlString)
+    merged.asRight
+  }
+
+}

--- a/kafka-connect-aws-s3/src/main/scala/io/lenses/streamreactor/connect/aws/s3/config/processors/kcql/KcqlMapToStringConverter.scala
+++ b/kafka-connect-aws-s3/src/main/scala/io/lenses/streamreactor/connect/aws/s3/config/processors/kcql/KcqlMapToStringConverter.scala
@@ -1,0 +1,104 @@
+/*
+ * Copyright 2021 Lenses.io
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.lenses.streamreactor.connect.aws.s3.config.processors.kcql
+
+import cats.implicits.catsSyntaxEitherId
+
+/**
+  * Converts KCQL properties to a KCQL String for use by the connector configuration in the following format.
+  */
+object KcqlMapToStringConverter {
+
+  /**
+    * Given a Map of KCQL Properties Map[KcqlProp, String], this builds and returns a Kcql string.
+    *
+    * {{{
+    * INSERT INTO bucketAddress:pathPrefix
+    * SELECT *
+    * FROM kafka-topic
+    * [PARTITIONBY (partition[, partition] ...)]
+    * [STOREAS storage_format]
+    * [WITHPARTITIONER = partitioner]
+    * [WITH_FLUSH_SIZE = flush_size]
+    * [WITH_FLUSH_INTERVAL = flush_interval]
+    * [WITH_FLUSH_COUNT = flush_count]
+    * }}}
+    */
+  def convert(kcqlAsProperties: Map[KcqlProp, String]): Either[String, String] = {
+
+    def nonOptional(propName: KcqlProp): Either[String, String] = {
+      optional(propName).fold(_.asLeft, {
+        case Some(value) => value.asRight
+        case None => "no value for nonOptional".asLeft
+      })
+    }
+
+    def optional(propName: KcqlProp): Either[String, Option[String]] = {
+      kcqlAsProperties.get(propName) match {
+        case Some(value: String) => Some(value).asRight
+        case None => None.asRight
+      }
+    }
+
+    for {
+      target <- nonOptional(KcqlProp.Target)
+      source <- nonOptional(KcqlProp.Source)
+      partitions <- optional(KcqlProp.Partitions)
+      format <- optional(KcqlProp.Format)
+      partitioner <- optional(KcqlProp.Partitioner)
+      flush_size <- optional(KcqlProp.FlushSize)
+      flush_interval <- optional(KcqlProp.FlushInterval)
+      flush_count <- optional(KcqlProp.FlushCount)
+    } yield joinKcql(
+      generateInsert(target, source),
+      generatePartitions(partitions),
+      generateFormat(format),
+      generatePartitioner(partitioner),
+      generateFlushSize(flush_size, flush_interval, flush_count)
+    )
+  }
+
+  private def generateInsert(target: String, source: String): String = {
+    s"INSERT INTO `$target` SELECT * FROM `$source`"
+  }
+
+  private def generatePartitions(partitions: Option[String]): Option[String] = {
+    partitions.map("PARTITIONBY " + _)
+  }
+
+  private def generateFormat(format: Option[String]): Option[String] = format.map("STOREAS `" + _ + "`")
+
+  private def generatePartitioner(partitioner: Option[String]): Option[String] = partitioner.map("WITHPARTITIONER = " + _)
+
+  private def generateFlushSize(flush_size: Option[String], flush_interval: Option[String], flush_count: Option[String]): Option[String] = {
+    Option(Seq(
+      flush_size.map("WITH_FLUSH_SIZE = " + _),
+      flush_interval.map("WITH_FLUSH_INTERVAL = " + _),
+      flush_count.map("WITH_FLUSH_COUNT = " + _)
+    ).filter(_.nonEmpty).flatten.mkString(" "))
+  }
+
+  private def joinKcql(
+                        insert: String,
+                        partitions: Option[String],
+                        format: Option[String],
+                        partitioner: Option[String],
+                        flush: Option[String]) = {
+    Seq(Some(insert), partitions, format, partitioner, flush).filter(_.nonEmpty).flatten.mkString(" ")
+  }
+
+}

--- a/kafka-connect-aws-s3/src/main/scala/io/lenses/streamreactor/connect/aws/s3/config/processors/kcql/KcqlProcessor.scala
+++ b/kafka-connect-aws-s3/src/main/scala/io/lenses/streamreactor/connect/aws/s3/config/processors/kcql/KcqlProcessor.scala
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2021 Lenses.io
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.lenses.streamreactor.connect.aws.s3.config.processors.kcql
+
+import cats.implicits.catsSyntaxEitherId
+import com.typesafe.scalalogging.LazyLogging
+import io.lenses.streamreactor.connect.aws.s3.config.S3ConfigSettings
+
+import java.util
+
+/**
+  * Given a list of profiles and configurations, the KcqlProcessor pulls out the relevant properties for
+  * the Kcql string, and the exploded Kcql configuration (available in Yaml) and merges them until
+  * finally reaching a single Kcql string with the combined configurations.
+  */
+object KcqlProcessor extends LazyLogging {
+
+  def process(configs: List[Map[String, AnyRef]]): Either[Throwable, String] = {
+
+    val (error, validCfgs) = configs.map {
+      cfg =>
+        for {
+          kcqlConf <- getKcqlConfig(cfg)
+          builderConf <- getBuilderConfig(cfg)
+          cfgs <- singleCfg(Seq(kcqlConf, builderConf).filter(_.nonEmpty))
+        } yield cfgs
+    }.partition(_.isLeft)
+
+    error.headOption match {
+      case Some(Left(value)) => value.asLeft[String]
+      case None =>
+        KcqlMapToStringConverter
+          .convert(
+            flattenMap(extractPropMap(validCfgs))
+          )
+          .left.map(new IllegalStateException(_))
+      case Some(Right(_)) => new IllegalStateException("Impossible for this to be Right. Match error avoidance in action.").asLeft
+    }
+  }
+
+  private def flattenMap(propMap: Seq[Map[KcqlProp, String]]): Map[KcqlProp, String] = propMap.reduce(_ ++ _)
+
+  private def extractPropMap(allCfg: Seq[Either[Throwable, Map[KcqlProp, String]]]): Seq[Map[KcqlProp, String]] = {
+    allCfg
+      .collect {
+        case Right(value: Map[KcqlProp, String]) => value
+      }
+      .filter(_.nonEmpty)
+  }
+
+  private def getBuilderConfig(config: Map[String, AnyRef]): Either[Throwable, Map[KcqlProp, String]] = {
+    config.get(S3ConfigSettings.KCQL_BUILDER) match {
+      case Some(value: util.Map[_, _]) =>
+        YamlToKcqlMapConverter.convert(value)
+      case None =>
+        Map.empty[KcqlProp, String].asRight
+      case other =>
+        new IllegalStateException(s"unexpected type specified: $other").asLeft
+    }
+  }
+
+
+  private def getKcqlConfig(config: Map[String, AnyRef]): Either[Throwable, Map[KcqlProp, String]] = {
+    config.get(S3ConfigSettings.KCQL_CONFIG) match {
+      case Some(value: String) => StringToKcqlMapConverter.convert(value)
+      case _ => Map.empty[KcqlProp, String].asRight
+    }
+  }
+
+  private def singleCfg(cfgs: Seq[Map[KcqlProp, String]]): Either[Throwable, Map[KcqlProp, String]] = {
+    cfgs.size match {
+      case 0 => Map.empty[KcqlProp, String].asRight
+      case 1 => cfgs.head.asRight
+      case _ => new IllegalArgumentException("Too many configs in one profile").asLeft
+    }
+  }
+}

--- a/kafka-connect-aws-s3/src/main/scala/io/lenses/streamreactor/connect/aws/s3/config/processors/kcql/KcqlProp.scala
+++ b/kafka-connect-aws-s3/src/main/scala/io/lenses/streamreactor/connect/aws/s3/config/processors/kcql/KcqlProp.scala
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2021 Lenses.io
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.lenses.streamreactor.connect.aws.s3.config.processors.kcql
+
+import com.datamountaineer.kcql.Kcql
+import enumeratum._
+
+import scala.collection.immutable
+import scala.jdk.CollectionConverters.asScalaIteratorConverter
+
+/**
+  * KcqlProp is an enum that represents a Kcql Property
+  *
+  * @param entryName    the string representation of the key, for example to use in a yaml document.
+  * @param kcqlToString a function that optionally takes a String value from the Kcql object
+  */
+sealed abstract class KcqlProp(override val entryName: String, val kcqlToString: Kcql => Option[String]) extends EnumEntry
+
+object KcqlProp extends Enum[KcqlProp] {
+
+  override val values: immutable.IndexedSeq[KcqlProp] = findValues
+
+  case object Source extends KcqlProp("source", k => fromString(k.getSource))
+
+  case object Target extends KcqlProp("target", k => fromString(k.getTarget))
+
+  case object Format extends KcqlProp("format", k => fromString(k.getStoredAs).map(_.replace("`", "")))
+
+  case object Partitioner extends KcqlProp("partitioner", k => fromString(k.getWithPartitioner))
+
+  case object Partitions extends KcqlProp("partitions", k => {
+    val filtered: Seq[String] = k.getPartitionBy.asScala.toSeq.filter(_.nonEmpty)
+    filtered.size match {
+      case 0 => Option.empty[String]
+      case _ => Some(filtered.mkString(","))
+    }
+  })
+
+  case object FlushSize extends KcqlProp("flush_size", k => fromLong(k.getWithFlushSize))
+
+  case object FlushInterval extends KcqlProp("flush_interval", k => fromLong(k.getWithFlushInterval))
+
+  case object FlushCount extends KcqlProp("flush_count", k => fromLong(k.getWithFlushCount))
+
+  private def fromString(source: String): Option[String] = Option(source).filter(_.nonEmpty)
+
+  private def fromLong(source: Long): Option[String] = Option(String.valueOf(source)).filterNot(_ == "0")
+
+}

--- a/kafka-connect-aws-s3/src/main/scala/io/lenses/streamreactor/connect/aws/s3/config/processors/kcql/StringToKcqlMapConverter.scala
+++ b/kafka-connect-aws-s3/src/main/scala/io/lenses/streamreactor/connect/aws/s3/config/processors/kcql/StringToKcqlMapConverter.scala
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2021 Lenses.io
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.lenses.streamreactor.connect.aws.s3.config.processors.kcql
+
+import cats.implicits.catsSyntaxEitherId
+import com.datamountaineer.kcql.Kcql
+
+import scala.util.Try
+
+/**
+  * Converts a Kcql String to a map of properties which can be merged/combined more easier than the
+  * Kcql object.
+  */
+object StringToKcqlMapConverter {
+
+  def convert(kcqlString: String): Either[Throwable, Map[KcqlProp, String]] = {
+    for {
+      kcql <- Try(Kcql.parse(kcqlString)).toEither
+      map <- kcqlToKcqlMap(kcql).asRight
+    } yield map
+  }
+
+  private def kcqlToKcqlMap(kcql: Kcql): Map[KcqlProp, String] = {
+    KcqlProp
+      .values
+      .flatMap(
+        kcqlProp => kcqlProp.kcqlToString(kcql) match {
+          case Some("use_profile") => None
+          case Some("USE_PROFILE") => None
+          case Some(value) => Some(kcqlProp, value)
+          case None => None
+        }
+      )
+      .toMap
+  }
+}

--- a/kafka-connect-aws-s3/src/main/scala/io/lenses/streamreactor/connect/aws/s3/config/processors/kcql/YamlToKcqlMapConverter.scala
+++ b/kafka-connect-aws-s3/src/main/scala/io/lenses/streamreactor/connect/aws/s3/config/processors/kcql/YamlToKcqlMapConverter.scala
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2021 Lenses.io
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.lenses.streamreactor.connect.aws.s3.config.processors.kcql
+
+import cats.implicits.catsSyntaxEitherId
+
+import java.util
+import scala.jdk.CollectionConverters.mapAsScalaMapConverter
+
+object YamlToKcqlMapConverter {
+
+  def convert(value: util.Map[_, _]): Either[Throwable, Map[KcqlProp, String]] = {
+    val mapped = value.asScala.map {
+      case (k: String, v: Int) => (KcqlProp.withName(k), String.valueOf(v)).asRight
+      case (k: String, v: Long) => (KcqlProp.withName(k), String.valueOf(v)).asRight
+      case (k: String, v: String) => (KcqlProp.withName(k), v).asRight
+      case other => new IllegalArgumentException("Invalid value for other " + other).asLeft
+    }
+    val (l, r) = mapped.partition(_.isLeft)
+    if(l.nonEmpty) {
+      r.head.left.get.asLeft
+    } else {
+      r.map(_.right.get).toMap.asRight
+    }
+  }
+}

--- a/kafka-connect-aws-s3/src/main/scala/io/lenses/streamreactor/connect/aws/s3/formats/CsvFormatStreamReader.scala
+++ b/kafka-connect-aws-s3/src/main/scala/io/lenses/streamreactor/connect/aws/s3/formats/CsvFormatStreamReader.scala
@@ -24,7 +24,7 @@ import io.lenses.streamreactor.connect.aws.s3.model.{RemotePathLocation, StringS
 class CsvFormatStreamReader(inputStreamFn: () => InputStream, bucketAndPath: RemotePathLocation, hasHeaders: Boolean)
   extends TextFormatStreamReader(inputStreamFn, bucketAndPath) {
 
-  private var firstRun : Boolean = true;
+  private var firstRun : Boolean = true
 
   override def next(): StringSourceData = {
     if(firstRun) {

--- a/kafka-connect-aws-s3/src/main/scala/io/lenses/streamreactor/connect/aws/s3/model/BytesWriteMode.scala
+++ b/kafka-connect-aws-s3/src/main/scala/io/lenses/streamreactor/connect/aws/s3/model/BytesWriteMode.scala
@@ -37,8 +37,8 @@ object BytesWriteMode extends Enum[BytesWriteMode] {
 
     override def read(inputStream: DataInputStream): BytesOutputRow = WithSizesBytesOutputRowReader.read(
       inputStream,
-      true,
-      true
+      readKey = true,
+      readValue = true
     )
   }
 
@@ -47,8 +47,8 @@ object BytesWriteMode extends Enum[BytesWriteMode] {
 
     override def read(inputStream: DataInputStream): BytesOutputRow = WithSizesBytesOutputRowReader.read(
       inputStream,
-      true,
-      false
+      readKey = true,
+      readValue = false
     )
   }
 
@@ -57,8 +57,8 @@ object BytesWriteMode extends Enum[BytesWriteMode] {
 
     override def read(inputStream: DataInputStream): BytesOutputRow = WithSizesBytesOutputRowReader.read(
       inputStream,
-      false,
-      true
+      readKey = false,
+      readValue = true
     )
   }
 

--- a/kafka-connect-aws-s3/src/main/scala/io/lenses/streamreactor/connect/aws/s3/source/config/S3SourceConfig.scala
+++ b/kafka-connect-aws-s3/src/main/scala/io/lenses/streamreactor/connect/aws/s3/source/config/S3SourceConfig.scala
@@ -19,16 +19,14 @@ package io.lenses.streamreactor.connect.aws.s3.source.config
 import com.datamountaineer.kcql.Kcql
 import io.lenses.streamreactor.connect.aws.s3.config.Format.Json
 import io.lenses.streamreactor.connect.aws.s3.config.{FormatSelection, S3Config, S3ConfigDefBuilder}
-import io.lenses.streamreactor.connect.aws.s3.model.{RemoteRootLocation, PartitionSelection}
+import io.lenses.streamreactor.connect.aws.s3.model.{PartitionSelection, RemoteRootLocation}
 import io.lenses.streamreactor.connect.aws.s3.sink.{HierarchicalS3FileNamingStrategy, PartitionedS3FileNamingStrategy, S3FileNamingStrategy}
-
-import scala.collection.JavaConverters._
 
 object S3SourceConfig {
 
-  def apply(props: Map[String, String]): S3SourceConfig = S3SourceConfig(
-    S3Config(props),
-    SourceBucketOptions(props)
+  def apply(s3ConfigDefBuilder: S3ConfigDefBuilder): S3SourceConfig = S3SourceConfig(
+    S3Config(s3ConfigDefBuilder.getParsedValues),
+    SourceBucketOptions(s3ConfigDefBuilder)
   )
 
 }
@@ -50,11 +48,8 @@ case class SourceBucketOptions(
 object SourceBucketOptions {
 
   private val DEFAULT_LIMIT = 1024
-  private val DEFAULT_BATCH_SIZE = 1000000
 
-  def apply(props: Map[String, String]): Seq[SourceBucketOptions] = {
-
-    val config = S3ConfigDefBuilder(props.asJava)
+  def apply(config: S3ConfigDefBuilder): Seq[SourceBucketOptions] = {
 
     config.getKCQL.map {
 

--- a/kafka-connect-aws-s3/src/test/resources/profiles/default.yaml
+++ b/kafka-connect-aws-s3/src/test/resources/profiles/default.yaml
@@ -1,0 +1,5 @@
+---
+connect.s3.aws.access.key: myAccessKey
+connect.s3.aws.secret.key: mySecretKey
+connect.s3.aws.auth.mode: myAuthMode
+connect.s3.kcql: insert into `target-bucket:target-path` select * from `source.bucket` PARTITIONBY name,title,salary STOREAS `text` WITH_FLUSH_SIZE = 500000000 WITH_FLUSH_INTERVAL = 3600 WITH_FLUSH_COUNT = 50000

--- a/kafka-connect-aws-s3/src/test/resources/profiles/example.yaml
+++ b/kafka-connect-aws-s3/src/test/resources/profiles/example.yaml
@@ -1,0 +1,13 @@
+---
+connect.s3.retry.interval: 10000
+connect.s3.error.policy: RETRY
+connect.s3.http.max.retries: 20
+connect.s3.kcql: insert into `target-bucket:target-path` select * from `source.bucket` STOREAS `text` WITH_FLUSH_SIZE = 500000000 WITH_FLUSH_INTERVAL = 3600 WITH_FLUSH_COUNT = 50000
+connect.s3.aws.access.key: myAccessKey
+connect.s3.max.retries: 10
+connect.s3.vhost.bucket: true
+connect.s3.aws.secret.key: mySecretKey
+connect.s3.aws.region: us-east-1
+connect.s3.http.retry.interval: 20000
+connect.s3.custom.endpoint: aws-endpoint.com
+connect.s3.aws.auth.mode: Credentials

--- a/kafka-connect-aws-s3/src/test/resources/profiles/inttest1.yaml
+++ b/kafka-connect-aws-s3/src/test/resources/profiles/inttest1.yaml
@@ -1,0 +1,9 @@
+---
+connect.s3.kcql: insert into `target-bucket:target-path` select * from `source.bucket` WITH_FLUSH_COUNT = 1
+
+connect.s3.aws.auth.mode: Credentials
+connect.s3.aws.access.key: identity
+connect.s3.aws.secret.key: credential
+
+connect.s3.vhost.bucket: true
+connect.s3.custom.endpoint: http://127.0.0.1:8099

--- a/kafka-connect-aws-s3/src/test/resources/profiles/inttest2.yaml
+++ b/kafka-connect-aws-s3/src/test/resources/profiles/inttest2.yaml
@@ -1,0 +1,5 @@
+---
+connect.s3.kcql.builder:
+  source: myTopic
+  target: employees:streamReactorBackups
+  format: json

--- a/kafka-connect-aws-s3/src/test/resources/profiles/kcql.yaml
+++ b/kafka-connect-aws-s3/src/test/resources/profiles/kcql.yaml
@@ -1,0 +1,7 @@
+---
+connect.s3.kcql.builder:
+  partitions: name,title,salary
+  partitioner: Values
+  flush_size: 1
+  flush_interval: 2
+  flush_count: 3

--- a/kafka-connect-aws-s3/src/test/resources/profiles/kcql_all.yaml
+++ b/kafka-connect-aws-s3/src/test/resources/profiles/kcql_all.yaml
@@ -1,0 +1,10 @@
+---
+connect.s3.kcql.builder:
+  source: my-kafka-topic
+  target: myBucket:myPartition
+  format: csv
+  partitions: name,title,salary
+  partitioner: Values
+  flush_size: 1
+  flush_interval: 2
+  flush_count: 3

--- a/kafka-connect-aws-s3/src/test/resources/profiles/kcql_override.yaml
+++ b/kafka-connect-aws-s3/src/test/resources/profiles/kcql_override.yaml
@@ -1,0 +1,5 @@
+---
+connect.s3.kcql.builder:
+  source: my-kafka-override-topic
+  target: myOverrideBucket:myOverridePartition
+  format: parquet

--- a/kafka-connect-aws-s3/src/test/resources/profiles/override.yaml
+++ b/kafka-connect-aws-s3/src/test/resources/profiles/override.yaml
@@ -1,0 +1,3 @@
+---
+connect.s3.aws.access.key: overrideAccessKey
+connect.s3.local.tmp.directory: /my/local/tmp/dir

--- a/kafka-connect-aws-s3/src/test/scala/io/lenses/streamreactor/connect/aws/s3/config/S3ConfigDefTest.scala
+++ b/kafka-connect-aws-s3/src/test/scala/io/lenses/streamreactor/connect/aws/s3/config/S3ConfigDefTest.scala
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2021 Lenses.io
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.lenses.streamreactor.connect.aws.s3.config
+
+import cats.implicits._
+import io.lenses.streamreactor.connect.aws.s3.config.S3ConfigSettings._
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+import scala.collection.JavaConverters._
+
+class S3ConfigDefTest extends AnyFlatSpec with Matchers {
+
+  private val DeprecatedProps: Map[String,String] = Map(
+    DEP_AWS_ACCESS_KEY -> "DepAccessKey",
+    DEP_AWS_SECRET_KEY -> "DepSecretKey",
+    DEP_AUTH_MODE -> AuthMode.Credentials.toString,
+    DEP_CUSTOM_ENDPOINT -> "http://deprecated",
+    DEP_ENABLE_VIRTUAL_HOST_BUCKETS -> "true",
+    KCQL_CONFIG -> "SELECT * FROM DEPRECATED",
+  )
+
+  private val DefaultProps: Map[String,String]  = Map(
+    AWS_ACCESS_KEY -> "AccessKey",
+    AWS_SECRET_KEY -> "SecretKey",
+    AUTH_MODE -> AuthMode.Default.toString,
+    CUSTOM_ENDPOINT -> "http://default",
+    ENABLE_VIRTUAL_HOST_BUCKETS -> "true",
+    KCQL_CONFIG -> "SELECT * FROM DEFAULT",
+  )
+
+  "S3ConfigDef" should "parse original properties" in {
+    val resultMap = S3ConfigDef.config.parse(DefaultProps.asJava).asScala
+    resultMap should have size (14)
+    DeprecatedProps.filterNot{case(k, _) => k == KCQL_CONFIG}.foreach{case (k,_) => resultMap.get(k) should be (None)}
+    DefaultProps.foreach{case (k, _) => resultMap.keySet.contains(k) should be (true)}
+  }
+
+  "S3ConfigDef" should "parse deprecated properties" in {
+    val resultMap = S3ConfigDef.config.parse(DeprecatedProps.asJava).asScala
+    resultMap should have size (14)
+    DeprecatedProps.filterNot{case(k, _) => k == KCQL_CONFIG}.foreach{case (k,_) => resultMap.get(k) should be (None)}
+    DefaultProps.foreach{case (k, _) => resultMap.keySet.contains(k) should be (true)}
+  }
+
+  "S3ConfigDef" should "parse merged properties" in {
+    val mergedProps = DefaultProps.combine(DeprecatedProps)
+    val resultMap = S3ConfigDef.config.parse(mergedProps.asJava).asScala
+    DeprecatedProps.filterNot{case(k, _) => k == KCQL_CONFIG}.foreach{case (k,_) => resultMap.get(k) should be (None)}
+    DefaultProps.foreach{case (k, _) => resultMap.keySet.contains(k) should be (true)}
+  }
+}

--- a/kafka-connect-aws-s3/src/test/scala/io/lenses/streamreactor/connect/aws/s3/config/S3SinkConfigDefBuilderTest.scala
+++ b/kafka-connect-aws-s3/src/test/scala/io/lenses/streamreactor/connect/aws/s3/config/S3SinkConfigDefBuilderTest.scala
@@ -32,7 +32,7 @@ class S3SinkConfigDefBuilderTest extends AnyFlatSpec with MockitoSugar with Matc
   "apply" should "respect defined properties" in {
     val props = Map("connect.s3.kcql" -> s"insert into $BucketName:$PrefixName select * from $TopicName PARTITIONBY _key STOREAS `CSV` WITHPARTITIONER=Values WITH_FLUSH_COUNT = 1")
 
-    val kcql = S3ConfigDefBuilder(props.asJava).getKCQL
+    val kcql = S3ConfigDefBuilder(None, props.asJava).getKCQL
     kcql should have size 1
 
     val element = kcql.head
@@ -49,7 +49,7 @@ class S3SinkConfigDefBuilderTest extends AnyFlatSpec with MockitoSugar with Matc
       "connect.s3.kcql" -> s"insert into $BucketName:$PrefixName select * from $TopicName PARTITIONBY _key STOREAS `CSV` WITHPARTITIONER=Values"
     )
 
-    val commitPolicy = S3ConfigDefBuilder(props.asJava).commitPolicy(S3ConfigDefBuilder(props.asJava).getKCQL.head)
+    val commitPolicy = S3ConfigDefBuilder(None, props.asJava).commitPolicy(S3ConfigDefBuilder(None, props.asJava).getKCQL.head)
 
     commitPolicy.recordCount should be (Some(S3FlushSettings.defaultFlushCount))
     commitPolicy.fileSize should be (Some(S3FlushSettings.defaultFlushSize))
@@ -62,7 +62,7 @@ class S3SinkConfigDefBuilderTest extends AnyFlatSpec with MockitoSugar with Matc
       "connect.s3.kcql" -> s"insert into $BucketName:$PrefixName select * from $TopicName PARTITIONBY _key STOREAS `CSV` WITHPARTITIONER=Values"
     )
 
-    val commitPolicy = S3ConfigDefBuilder(props.asJava).commitPolicy(S3ConfigDefBuilder(props.asJava).getKCQL.head)
+    val commitPolicy = S3ConfigDefBuilder(None, props.asJava).commitPolicy(S3ConfigDefBuilder(None, props.asJava).getKCQL.head)
 
     commitPolicy.recordCount should be (None)
     commitPolicy.fileSize should be (Some(S3FlushSettings.defaultFlushSize))
@@ -72,7 +72,7 @@ class S3SinkConfigDefBuilderTest extends AnyFlatSpec with MockitoSugar with Matc
   "apply" should "respect custom flush settings" in {
     val props = Map("connect.s3.kcql" -> s"insert into $BucketName:$PrefixName select * from $TopicName PARTITIONBY _key STOREAS `CSV` WITH_FLUSH_SIZE = 3 WITH_FLUSH_INTERVAL = 2 WITH_FLUSH_COUNT = 1")
 
-    val commitPolicy = S3ConfigDefBuilder(props.asJava).commitPolicy(S3ConfigDefBuilder(props.asJava).getKCQL.head)
+    val commitPolicy = S3ConfigDefBuilder(None, props.asJava).commitPolicy(S3ConfigDefBuilder(None, props.asJava).getKCQL.head)
 
     commitPolicy.recordCount should be (Some(1))
     commitPolicy.fileSize should be (Some(3))

--- a/kafka-connect-aws-s3/src/test/scala/io/lenses/streamreactor/connect/aws/s3/config/processors/YamlProfileProcessorTest.scala
+++ b/kafka-connect-aws-s3/src/test/scala/io/lenses/streamreactor/connect/aws/s3/config/processors/YamlProfileProcessorTest.scala
@@ -1,0 +1,119 @@
+/*
+ * Copyright 2021 Lenses.io
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.lenses.streamreactor.connect.aws.s3.config.processors
+
+import cats.implicits._
+import io.lenses.streamreactor.connect.aws.s3.config.S3ConfigSettings.KCQL_CONFIG
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+class YamlProfileProcessorTest extends AnyFlatSpec with Matchers {
+
+  "process" should "load in single example yaml file" in {
+    val result = process(Map(), "/profiles/example.yaml")
+
+    result should be ('Right)
+    val r = result.right.get
+    r.size should be (12)
+    r should contain allOf(
+      "connect.s3.retry.interval" -> 10000,
+      "connect.s3.error.policy" -> "RETRY",
+      "connect.s3.http.max.retries" -> 20,
+      "connect.s3.kcql" -> "INSERT INTO `target-bucket:target-path` SELECT * FROM `source.bucket` STOREAS `text` WITH_FLUSH_SIZE = 500000000 WITH_FLUSH_INTERVAL = 3600 WITH_FLUSH_COUNT = 50000",
+      "connect.s3.aws.access.key" -> "myAccessKey",
+      "connect.s3.max.retries" -> 10,
+      "connect.s3.vhost.bucket" -> true,
+      "connect.s3.aws.secret.key" -> "mySecretKey",
+      "connect.s3.aws.region" -> "us-east-1",
+      "connect.s3.http.retry.interval" -> 20000,
+      "connect.s3.custom.endpoint" -> "aws-endpoint.com",
+      "connect.s3.aws.auth.mode" -> "Credentials",
+    )
+
+  }
+
+  "process" should "load in single Yaml file" in {
+    val result = process(Map(),"/profiles/default.yaml")
+
+    result should be ('Right)
+    val r = result.right.get
+    r.size should be (4)
+    r should contain allOf(
+      "connect.s3.kcql" -> "INSERT INTO `target-bucket:target-path` SELECT * FROM `source.bucket` PARTITIONBY name,title,salary STOREAS `text` WITH_FLUSH_SIZE = 500000000 WITH_FLUSH_INTERVAL = 3600 WITH_FLUSH_COUNT = 50000",
+      "connect.s3.aws.access.key" -> "myAccessKey",
+      "connect.s3.aws.secret.key" -> "mySecretKey",
+      "connect.s3.aws.auth.mode" -> "myAuthMode",
+    )
+  }
+
+  "process" should "resolve multiple Yaml files" in {
+    val result = process(Map(),"/profiles/default.yaml","/profiles/override.yaml")
+
+    result should be ('Right)
+    val r = result.right.get
+    r.size should be (5)
+    r should contain allOf(
+      "connect.s3.kcql" -> "INSERT INTO `target-bucket:target-path` SELECT * FROM `source.bucket` PARTITIONBY name,title,salary STOREAS `text` WITH_FLUSH_SIZE = 500000000 WITH_FLUSH_INTERVAL = 3600 WITH_FLUSH_COUNT = 50000",
+      "connect.s3.aws.access.key" -> "overrideAccessKey",
+      "connect.s3.aws.secret.key" -> "mySecretKey",
+      "connect.s3.aws.auth.mode" -> "myAuthMode",
+      "connect.s3.local.tmp.directory" -> "/my/local/tmp/dir",
+    )
+  }
+
+  "process" should "merge kcql options" in {
+    val result = process(Map(),"/profiles/kcql_all.yaml","/profiles/kcql_override.yaml")
+
+    result should be ('Right)
+    val r: Map[String, AnyRef] = result.right.get
+    r.size should be (1)
+    r("connect.s3.kcql") should be ("INSERT INTO `myOverrideBucket:myOverridePartition` SELECT * FROM `my-kafka-override-topic` PARTITIONBY name,title,salary STOREAS `parquet` WITHPARTITIONER = Values WITH_FLUSH_SIZE = 1 WITH_FLUSH_INTERVAL = 2 WITH_FLUSH_COUNT = 3")
+  }
+
+  "process" should "merge kcql options from kcql string and builder" in {
+    val result = process(Map(),"/profiles/default.yaml","/profiles/kcql_override.yaml")
+
+    result should be ('Right)
+    val r: Map[String, AnyRef] = result.right.get
+    r.size should be (4)
+    r("connect.s3.kcql") should be ("INSERT INTO `myOverrideBucket:myOverridePartition` SELECT * FROM `my-kafka-override-topic` PARTITIONBY name,title,salary STOREAS `parquet` WITH_FLUSH_SIZE = 500000000 WITH_FLUSH_INTERVAL = 3600 WITH_FLUSH_COUNT = 50000")
+  }
+
+  "process" should "merge allow overriding kcql properties with connector config" in {
+    val result = process(Map(KCQL_CONFIG -> "INSERT INTO expectedTarget SELECT * FROM expectedSource PARTITIONBY name,title,salary STOREAS `parquet` WITH_FLUSH_SIZE = 500000000 WITH_FLUSH_INTERVAL = 3600 WITH_FLUSH_COUNT = 50000"),"/profiles/default.yaml","/profiles/kcql_override.yaml")
+
+    result should be ('Right)
+    val r: Map[String, AnyRef] = result.right.get
+    r.size should be (4)
+    r("connect.s3.kcql") should be ("INSERT INTO `expectedTarget` SELECT * FROM `expectedSource` PARTITIONBY name,title,salary STOREAS `parquet` WITH_FLUSH_SIZE = 500000000 WITH_FLUSH_INTERVAL = 3600 WITH_FLUSH_COUNT = 50000")
+  }
+
+  "process" should "merge allow retaining kcql properties when overriding" in {
+    val result = process(Map(KCQL_CONFIG -> "INSERT INTO use_profile SELECT * FROM use_profile PARTITIONBY name,title,salary STOREAS `parquet` WITH_FLUSH_SIZE = 500000000 WITH_FLUSH_INTERVAL = 3600 WITH_FLUSH_COUNT = 50000"),"/profiles/default.yaml","/profiles/kcql_override.yaml")
+
+    result should be ('Right)
+    val r: Map[String, AnyRef] = result.right.get
+    r.size should be (4)
+    r("connect.s3.kcql") should be ("INSERT INTO `myOverrideBucket:myOverridePartition` SELECT * FROM `my-kafka-override-topic` PARTITIONBY name,title,salary STOREAS `parquet` WITH_FLUSH_SIZE = 500000000 WITH_FLUSH_INTERVAL = 3600 WITH_FLUSH_COUNT = 50000")
+  }
+
+  private def process(properties: Map[String,String], yamls: String*) = {
+    new YamlProfileProcessor().process(Map[String, String](
+      "connect.s3.config.profiles" -> yamls.mkString(","),
+    ).combine(properties))
+  }
+}

--- a/kafka-connect-aws-s3/src/test/scala/io/lenses/streamreactor/connect/aws/s3/model/S3OutputStreamOptionsTest.scala
+++ b/kafka-connect-aws-s3/src/test/scala/io/lenses/streamreactor/connect/aws/s3/model/S3OutputStreamOptionsTest.scala
@@ -16,44 +16,52 @@
 
 package io.lenses.streamreactor.connect.aws.s3.model
 
+import io.lenses.streamreactor.connect.aws.s3.config.S3ConfigDefBuilder
 import io.lenses.streamreactor.connect.aws.s3.config.S3ConfigSettings.LOCAL_TMP_DIRECTORY
 import io.lenses.streamreactor.connect.aws.s3.model.BuildLocalOutputStreamOptions.PROPERTY_SINK_NAME
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
+
+import scala.jdk.CollectionConverters.mapAsJavaMapConverter
 
 class S3OutputStreamOptionsTest extends AnyFlatSpec with Matchers {
 
   behavior of "S3OutputStreamOptions"
 
   it should "create StreamedOutputStreamOptions with warning when no write mode supplied" in {
-    S3OutputStreamOptions("", Map.empty[String,String]) should
+    S3OutputStreamOptions("", adapt(Map.empty[String, String])) should
       be (Right(StreamedWriteOutputStreamOptions()))
   }
 
   it should "create StreamedOutputStreamOptions with warning when invalid write mode supplied" in {
-    S3OutputStreamOptions("whatisit", Map.empty[String,String]) should
+    S3OutputStreamOptions("whatisit", adapt(Map.empty[String, String])) should
       be (Right(StreamedWriteOutputStreamOptions()))
   }
 
+  private def adapt(map : Map[String,String], sinkName : Option[String] = None) = {
+    val newMap = map + {"connect.s3.kcql" -> "assda"}
+    S3ConfigDefBuilder(sinkName, newMap.asJava)
+  }
+
   it should "create StreamedOutputStreamOptions when invalid write mode supplied" in {
-    S3OutputStreamOptions("Streamed", Map.empty[String,String]) should
+    S3OutputStreamOptions("Streamed",  adapt(Map.empty[String, String])) should
       be (Right(StreamedWriteOutputStreamOptions()))
   }
 
   it should "create BuildLocalOutputStreamOptions when temp directory has been supplied" in {
-    S3OutputStreamOptions("buildlocal", Map(LOCAL_TMP_DIRECTORY -> "/my/path")) should
+    S3OutputStreamOptions("buildlocal", adapt(Map(LOCAL_TMP_DIRECTORY -> "/my/path"))) should
       be (Right(BuildLocalOutputStreamOptions(LocalLocation("/my/path"))))
   }
 
   it should "create BuildLocalOutputStreamOptions when temp directory and sink name has been supplied" in {
     // should ignore the sinkName
-    S3OutputStreamOptions("BuildLocal", Map(LOCAL_TMP_DIRECTORY -> "/my/path", PROPERTY_SINK_NAME -> "superSleekSinkName")) should
+    S3OutputStreamOptions("BuildLocal", adapt(Map(LOCAL_TMP_DIRECTORY -> "/my/path", PROPERTY_SINK_NAME -> "superSleekSinkName"))) should
       be (Right(BuildLocalOutputStreamOptions(LocalLocation("/my/path"))))
   }
 
   it should "create BuildLocalOutputStreamOptions when sink name has been supplied" in {
     val tempDir = System.getProperty("java.io.tmpdir")
-    val result = S3OutputStreamOptions("BUILDLOCAL", Map(PROPERTY_SINK_NAME -> "superSleekSinkName"))
+    val result = S3OutputStreamOptions("BUILDLOCAL", adapt(Map(), Option("superSleekSinkName")))
     result.isRight should be (true)
     result.right.get match {
       case BuildLocalOutputStreamOptions(localLocation) => localLocation.path should startWith (s"$tempDir/superSleekSinkName")
@@ -62,7 +70,7 @@ class S3OutputStreamOptionsTest extends AnyFlatSpec with Matchers {
   }
 
   it should "not create BuildLocalOutputStreamOptions when nothing supplied" in {
-    val result = S3OutputStreamOptions("bUiLdLoCal", Map[String,String]())
+    val result = S3OutputStreamOptions("bUiLdLoCal", adapt(Map[String,String]()))
     result.isLeft should be (true)
     result.left.get.getClass.getSimpleName should be ("IllegalStateException")
     result.left.get.getMessage should be ("Either a local temporary directory (connect.s3.local.tmp.directory) or a Sink Name (name) must be configured to use 'BuildLocal' write mode.")

--- a/kafka-connect-aws-s3/src/test/scala/io/lenses/streamreactor/connect/aws/s3/source/S3SourceTaskTest.scala
+++ b/kafka-connect-aws-s3/src/test/scala/io/lenses/streamreactor/connect/aws/s3/source/S3SourceTaskTest.scala
@@ -143,7 +143,7 @@ class S3SourceTaskTest extends AnyFlatSpec with Matchers with S3TestConfig with 
   }
 
   "task" should "read stored bytes files continuously" in {
-    val (format, formatOptions) = (Format.Bytes, Some(FormatOptions.ValueOnly));
+    val (format, formatOptions) = (Format.Bytes, Some(FormatOptions.ValueOnly))
 
     setUpBucketData(BucketName, blobStoreContext, format, formatOptions)
 
@@ -173,7 +173,7 @@ class S3SourceTaskTest extends AnyFlatSpec with Matchers with S3TestConfig with 
   }
 
   "task" should "read stored bytes key/value files continuously" in {
-    val (format, formatOptions) = (Format.Bytes, Some(FormatOptions.KeyAndValueWithSizes));
+    val (format, formatOptions) = (Format.Bytes, Some(FormatOptions.KeyAndValueWithSizes))
 
     setUpBucketData(BucketName, blobStoreContext, format, formatOptions)
 


### PR DESCRIPTION
This PR contains multiple features.


**Deprecation of Properties**

The following properties will be deprecated and replaced as follows:

    aws.auth.mode       ->  connect.s3.aws.auth.mod
    aws.access.key      ->  connect.s3.aws.access.key
    aws.secret.key      ->  connect.s3.aws.secret.key
    aws.custom.endpoint ->  connect.s3.custom.endpoint
    aws.vhost.bucket    ->  connect.s3.vhost.bucket

Functionality has been added to ensure that backwards compatibility will be maintained if the old properties are used.


**YAML Profiles**

Configuration profiles via Yaml is now possible.  The configuration file must be located on the classpath.

To specify a profile in your connector config you can use the following setting in your main connector configuration:

    connect.s3.config.profiles=/resources/yaml/profile1.yaml,/resources/yaml/profile2.yaml

An example configuration file follows:

    ---
    connect.s3.aws.access.key: myAccessKey
    connect.s3.aws.secret.key: mySecretKey
    connect.s3.aws.auth.mode: myAuthMode
    connect.s3.kcql: insert into `target-bucket:target-path` select * from `source.bucket` PARTITIONBY name,title,salary STOREAS `text` WITH_FLUSH_SIZE = 500000000 WITH_FLUSH_INTERVAL = 3600 WITH_FLUSH_COUNT = 50000

For more flexibility when working with KCQL, a kcql builder Yaml map can be supplied in exchange for the Kcql String.  This will be turned into a KCQL string for use by the connector.

    ---
    connect.s3.kcql.builder:
      source: my-kafka-topic
      target: myBucket:myPartition
      format: csv
      partitions: name,title,salary
      partitioner: Values
      flush_size: 1
      flush_interval: 2
      flush_count: 3

KCQL strings from different profiles will be merged in order of specification, with the last given priority.

Overriding can be avoided for source and target by using the keyword "USE_PROFILE", which will ignore this property.

For example a minimal kcql string:

    connect.s3.kcql=insert into USE_PROFILE select * from USE_PROFILE
