### PR TITLE
S3 Sink - Date Partitioning

### DIFF
--- a/kafka-connect-aws-s3/src/main/scala/io/lenses/streamreactor/connect/aws/s3/model/PartitionField.scala
+++ b/kafka-connect-aws-s3/src/main/scala/io/lenses/streamreactor/connect/aws/s3/model/PartitionField.scala
@@ -47,6 +47,7 @@ object PartitionField {
       case PartitionSpecifier.Partition => PartitionPartitionField()
       case PartitionSpecifier.Header => throw new IllegalArgumentException("cannot partition by Header partition field without path")
       case PartitionSpecifier.Value => throw new IllegalArgumentException("cannot partition by Value partition field without path")
+      case PartitionSpecifier.Date => throw new IllegalArgumentException("cannot partition by Date partition field without format")
     }
   }
 
@@ -57,6 +58,7 @@ object PartitionField {
       case PartitionSpecifier.Header => HeaderPartitionField(PartitionNamePath(path: _*))
       case PartitionSpecifier.Topic => throw new IllegalArgumentException("partitioning by topic requires no path")
       case PartitionSpecifier.Partition => throw new IllegalArgumentException("partitioning by partition requires no path")
+      case PartitionSpecifier.Date => if (path.size == 1) DatePartitionField(path.head) else throw new IllegalArgumentException("only one format should be provided for date")
     }
   }
 
@@ -92,3 +94,6 @@ case class PartitionPartitionField() extends PartitionField {
   override def valuePrefixDisplay(): String = "partition"
 }
 
+case class DatePartitionField(format: String) extends PartitionField {
+  override def valuePrefixDisplay(): String = "date"
+}

--- a/kafka-connect-aws-s3/src/main/scala/io/lenses/streamreactor/connect/aws/s3/model/PartitionField.scala
+++ b/kafka-connect-aws-s3/src/main/scala/io/lenses/streamreactor/connect/aws/s3/model/PartitionField.scala
@@ -19,6 +19,8 @@ package io.lenses.streamreactor.connect.aws.s3.model
 import com.datamountaineer.kcql.Kcql
 
 import scala.jdk.CollectionConverters.IteratorHasAsScala
+import java.time.format.DateTimeFormatter
+import java.util.TimeZone
 
 sealed trait PartitionField {
   def valuePrefixDisplay(): String
@@ -96,4 +98,6 @@ case class PartitionPartitionField() extends PartitionField {
 
 case class DatePartitionField(format: String) extends PartitionField {
   override def valuePrefixDisplay(): String = "date"
+
+  def formatter = DateTimeFormatter.ofPattern(format).withZone( TimeZone.getDefault.toZoneId)
 }

--- a/kafka-connect-aws-s3/src/main/scala/io/lenses/streamreactor/connect/aws/s3/model/PartitionSpecifier.scala
+++ b/kafka-connect-aws-s3/src/main/scala/io/lenses/streamreactor/connect/aws/s3/model/PartitionSpecifier.scala
@@ -35,4 +35,6 @@ object PartitionSpecifier extends Enum[PartitionSpecifier] {
   case object Header extends PartitionSpecifier("_header")
 
   case object Value extends PartitionSpecifier("_value")
+
+  case object Date extends PartitionSpecifier("_date")
 }

--- a/kafka-connect-aws-s3/src/main/scala/io/lenses/streamreactor/connect/aws/s3/model/SinkData.scala
+++ b/kafka-connect-aws-s3/src/main/scala/io/lenses/streamreactor/connect/aws/s3/model/SinkData.scala
@@ -18,10 +18,13 @@ package io.lenses.streamreactor.connect.aws.s3.model
 
 import org.apache.kafka.connect.data.{Schema, Struct}
 
+import java.time.Instant
+
 case class MessageDetail(
                           keySinkData: Option[SinkData],
                           valueSinkData: SinkData,
-                          headers: Map[String, SinkData]
+                          headers: Map[String, SinkData],
+                          time: Option[Instant],
                         )
 
 sealed trait SinkData {

--- a/kafka-connect-aws-s3/src/main/scala/io/lenses/streamreactor/connect/aws/s3/sink/FileNamingStrategy.scala
+++ b/kafka-connect-aws-s3/src/main/scala/io/lenses/streamreactor/connect/aws/s3/sink/FileNamingStrategy.scala
@@ -26,6 +26,8 @@ import io.lenses.streamreactor.connect.aws.s3.model.location.{RemoteS3PathLocati
 import io.lenses.streamreactor.connect.aws.s3.sink.extractors.ExtractorErrorAdaptor.adaptErrorResponse
 import io.lenses.streamreactor.connect.aws.s3.sink.extractors.SinkDataExtractor
 
+import java.time.LocalDate
+import java.time.format.DateTimeFormatter
 import java.io.File
 import java.util.UUID
 import scala.util.matching.Regex
@@ -147,6 +149,7 @@ class PartitionedS3FileNamingStrategy(formatSelection: FormatSelection, partitio
           case partition@WholeKeyPartitionField() => partition -> getPartitionByWholeKeyValue(messageDetail.keySinkData)
           case partition@TopicPartitionField() => partition -> topicPartition.topic.value
           case partition@PartitionPartitionField() => partition -> topicPartition.partition.toString
+          case partition@DatePartitionField(format) => partition -> DateTimeFormatter.ofPattern(format).format(LocalDate.now())
         }
         .toMap[PartitionField, String]
     }.toEither.left.map(ex => FatalS3SinkError(ex.getMessage, ex, topicPartition))

--- a/kafka-connect-aws-s3/src/main/scala/io/lenses/streamreactor/connect/aws/s3/sink/FileNamingStrategy.scala
+++ b/kafka-connect-aws-s3/src/main/scala/io/lenses/streamreactor/connect/aws/s3/sink/FileNamingStrategy.scala
@@ -26,8 +26,6 @@ import io.lenses.streamreactor.connect.aws.s3.model.location.{RemoteS3PathLocati
 import io.lenses.streamreactor.connect.aws.s3.sink.extractors.ExtractorErrorAdaptor.adaptErrorResponse
 import io.lenses.streamreactor.connect.aws.s3.sink.extractors.SinkDataExtractor
 
-import java.time.LocalDate
-import java.time.format.DateTimeFormatter
 import java.io.File
 import java.util.UUID
 import scala.util.matching.Regex
@@ -149,7 +147,10 @@ class PartitionedS3FileNamingStrategy(formatSelection: FormatSelection, partitio
           case partition@WholeKeyPartitionField() => partition -> getPartitionByWholeKeyValue(messageDetail.keySinkData)
           case partition@TopicPartitionField() => partition -> topicPartition.topic.value
           case partition@PartitionPartitionField() => partition -> topicPartition.partition.toString
-          case partition@DatePartitionField(format) => partition -> DateTimeFormatter.ofPattern(format).format(LocalDate.now())
+          case partition@DatePartitionField(_) => partition ->
+            messageDetail.time.fold(
+              throw new IllegalArgumentException("No valid timestamp parsed from kafka connect message, however date partitioning was requested")
+            )(partition.formatter.format)
         }
         .toMap[PartitionField, String]
     }.toEither.left.map(ex => FatalS3SinkError(ex.getMessage, ex, topicPartition))

--- a/kafka-connect-aws-s3/src/test/scala/io/lenses/streamreactor/connect/aws/s3/sink/S3AvroWriterManagerTest.scala
+++ b/kafka-connect-aws-s3/src/test/scala/io/lenses/streamreactor/connect/aws/s3/sink/S3AvroWriterManagerTest.scala
@@ -64,7 +64,7 @@ class S3AvroWriterManagerTest extends AnyFlatSpec with Matchers with S3ProxyCont
     firstUsers.zipWithIndex.foreach {
       case (struct: Struct, index: Int) =>
         val writeRes = sink.write(
-          TopicPartitionOffset(Topic(TopicName), 1, Offset((index + 1).toLong)), MessageDetail(None, StructSinkData(struct), Map.empty[String, SinkData]))
+          TopicPartitionOffset(Topic(TopicName), 1, Offset((index + 1).toLong)), MessageDetail(None, StructSinkData(struct), Map.empty[String, SinkData], None))
         writeRes.isRight should be (true)
     }
 
@@ -98,7 +98,7 @@ class S3AvroWriterManagerTest extends AnyFlatSpec with Matchers with S3ProxyCont
     val sink = S3WriterManager.from(avroConfig, "sinkName")
     firstUsers.concat(usersWithNewSchema).zipWithIndex.foreach {
       case (user, index) =>
-        sink.write(TopicPartitionOffset(Topic(TopicName), 1, Offset((index + 1).toLong)), MessageDetail(None, StructSinkData(user), Map.empty[String, SinkData]))
+        sink.write(TopicPartitionOffset(Topic(TopicName), 1, Offset((index + 1).toLong)), MessageDetail(None, StructSinkData(user), Map.empty[String, SinkData], None))
     }
     sink.close()
 

--- a/kafka-connect-aws-s3/src/test/scala/io/lenses/streamreactor/connect/aws/s3/sink/S3JsonWriterManagerTest.scala
+++ b/kafka-connect-aws-s3/src/test/scala/io/lenses/streamreactor/connect/aws/s3/sink/S3JsonWriterManagerTest.scala
@@ -56,7 +56,7 @@ class S3JsonWriterManagerTest extends AnyFlatSpec with Matchers with S3ProxyCont
     )
 
     val sink = S3WriterManager.from(config, "sinkName")
-    sink.write(TopicPartitionOffset(Topic(TopicName), 1, Offset(1)), MessageDetail(None, StructSinkData(users.head), Map.empty[String, SinkData]))
+    sink.write(TopicPartitionOffset(Topic(TopicName), 1, Offset(1)), MessageDetail(None, StructSinkData(users.head), Map.empty[String, SinkData], None))
     sink.close()
 
     listBucketPath(BucketName, "streamReactorBackups/myTopic/1/").size should be(1)
@@ -88,7 +88,7 @@ class S3JsonWriterManagerTest extends AnyFlatSpec with Matchers with S3ProxyCont
 
     val sink = S3WriterManager.from(config, "sinkName")
     firstUsers.zipWithIndex.foreach {
-      case (struct: Struct, index: Int) => sink.write(TopicPartitionOffset(Topic(TopicName), 1, Offset((index + 1).toLong)), MessageDetail(None, StructSinkData(struct), Map.empty[String, SinkData]))
+      case (struct: Struct, index: Int) => sink.write(TopicPartitionOffset(Topic(TopicName), 1, Offset(index.toLong + 1)), MessageDetail(None, StructSinkData(struct), Map.empty[String, SinkData], None))
     }
 
     sink.close()

--- a/kafka-connect-aws-s3/src/test/scala/io/lenses/streamreactor/connect/aws/s3/sink/S3ParquetWriterManagerTest.scala
+++ b/kafka-connect-aws-s3/src/test/scala/io/lenses/streamreactor/connect/aws/s3/sink/S3ParquetWriterManagerTest.scala
@@ -64,7 +64,7 @@ class S3ParquetWriterManagerTest extends AnyFlatSpec with Matchers with S3ProxyC
     val sink = S3WriterManager.from(parquetConfig, "sinkName")
     firstUsers.zipWithIndex.foreach {
       case (struct: Struct, index: Int) =>
-        sink.write(TopicPartitionOffset(Topic(TopicName), 1, Offset((index + 1).toLong)), MessageDetail(None, StructSinkData(struct), Map.empty[String, SinkData]))
+        sink.write(TopicPartitionOffset(Topic(TopicName), 1, Offset(index.toLong + 1)), MessageDetail(None, StructSinkData(struct), Map.empty[String, SinkData], None))
     }
 
     sink.close()
@@ -97,7 +97,7 @@ class S3ParquetWriterManagerTest extends AnyFlatSpec with Matchers with S3ProxyC
     val sink = S3WriterManager.from(parquetConfig, "sinkName")
     firstUsers.concat(usersWithNewSchema).zipWithIndex.foreach {
       case (user, index) =>
-        sink.write(TopicPartitionOffset(Topic(TopicName), 1, Offset((index + 1).toLong)), MessageDetail(None, StructSinkData(user), Map.empty[String, SinkData]))
+        sink.write(TopicPartitionOffset(Topic(TopicName), 1, Offset(index.toLong + 1)), MessageDetail(None, StructSinkData(user), Map.empty[String, SinkData], None))
     }
     sink.close()
 


### PR DESCRIPTION
This PR adds date partitioning into the S3 Sink.

The formats can be specified using the preconfigured strings from https://docs.oracle.com/javase/8/docs/api/java/time/format/DateTimeFormatter.html

An example of the KCQL configuration:

`insert into $BucketName:$PrefixName select * from $TopicName PARTITIONBY _date.uuuu,_date.LL,_date.dd WITHPARTITIONER=Values WITH_FLUSH_COUNT = 1`

This will partition by year/month/day for example 2020/10/25