### PR TITLE
Extend sink jms connector to support converter classes from runtime

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -64,7 +64,7 @@ allprojects {
         slf4jVersion = "1.7.7"
         json4sVersion = "3.6.7"
         gsonVersion = "2.6.2"
-        kcqlVersion = "2.8.7"
+        kcqlVersion = "2.9.0"
         connectCLIVersion = "1.0.6"
         avro4sVersion = "1.6.4"
         smt = "2.0.0"

--- a/kafka-connect-jms/build.gradle
+++ b/kafka-connect-jms/build.gradle
@@ -24,6 +24,7 @@ project(":kafka-connect-jms") {
     dependencies {
         compile project(':kafka-connect-common')
         compile("javax.jms:javax.jms-api:$jmsVersion")
+        compile ("io.confluent:kafka-connect-protobuf-converter:$confluentVersion")
         testCompile("org.apache.activemq:activemq-all:5.14.5")
         testCompile("org.json4s:json4s-native_$scalaMajorVersion:$json4sVersion")
         testCompile("com.sksamuel.avro4s:avro4s-core_$scalaMajorVersion:$avro4sVersion")

--- a/kafka-connect-jms/src/main/scala/com/datamountaineer/streamreactor/connect/jms/config/JMSConfig.scala
+++ b/kafka-connect-jms/src/main/scala/com/datamountaineer/streamreactor/connect/jms/config/JMSConfig.scala
@@ -67,6 +67,8 @@ object JMSConfig {
 
     .define(JMSConfigConstants.DEFAULT_CONVERTER_CONFIG, Type.STRING, "", Importance.HIGH, JMSConfigConstants.DEFAULT_CONVERTER_DOC,
       "Converter", 1, ConfigDef.Width.MEDIUM, JMSConfigConstants.DEFAULT_CONVERTER_DISPLAY)
+    .define(JMSConfigConstants.DEFAULT_SINK_CONVERTER_CONFIG, Type.STRING, "", Importance.HIGH, JMSConfigConstants.DEFAULT_SINK_CONVERTER_DOC,
+        "Converter", 1, ConfigDef.Width.MEDIUM, JMSConfigConstants.DEFAULT_SINK_CONVERTER_DISPLAY)
     .define(JMSConfigConstants.THROW_ON_CONVERT_ERRORS_CONFIG, Type.BOOLEAN, JMSConfigConstants.THROW_ON_CONVERT_ERRORS_DEFAULT,
       Importance.HIGH, JMSConfigConstants.THROW_ON_CONVERT_ERRORS_DOC, "Converter", 2, ConfigDef.Width.MEDIUM,
       JMSConfigConstants.THROW_ON_CONVERT_ERRORS_DISPLAY)

--- a/kafka-connect-jms/src/main/scala/com/datamountaineer/streamreactor/connect/jms/config/JMSConfigConstants.scala
+++ b/kafka-connect-jms/src/main/scala/com/datamountaineer/streamreactor/connect/jms/config/JMSConfigConstants.scala
@@ -74,6 +74,13 @@ object JMSConfigConstants {
       |i.e. com.datamountaineer.streamreactor.connect.source.converters.AvroConverter""".stripMargin
   private[config] val DEFAULT_CONVERTER_DISPLAY = "Default Converter class"
 
+  val DEFAULT_SINK_CONVERTER_CONFIG = s"${CONNECTOR_PREFIX}.sink.default.converter"
+  private[config] val DEFAULT_SINK_CONVERTER_DOC =
+    """
+      |Contains a canonical class name for the default converter from a SinkRecord to a raw JMS message.
+      |i.e. com.datamountaineer.streamreactor.connect.jms.sink.converters.AvroMessageConverter""".stripMargin
+  private[config] val DEFAULT_SINK_CONVERTER_DISPLAY = "Default Sink Converter class"
+
   val HEADERS_CONFIG = s"${CONNECTOR_PREFIX}.headers"
   private[config] val HEADERS_CONFIG_DOC =
     s"""

--- a/kafka-connect-jms/src/main/scala/com/datamountaineer/streamreactor/connect/jms/sink/converters/JMSHeadersConverterWrapper.scala
+++ b/kafka-connect-jms/src/main/scala/com/datamountaineer/streamreactor/connect/jms/sink/converters/JMSHeadersConverterWrapper.scala
@@ -30,6 +30,7 @@ class JMSHeadersConverterWrapper(headers: Map[String, String], delegate: JMSMess
   override def convert(record: SinkRecord, session: Session, setting: JMSSetting): (String, Message) = {
     val response = delegate.convert(record, session, setting)
     val message = response._2
+    message.setStringProperty("JMSXGroupID", record.kafkaPartition().toString)
     for((key, value) <- headers) {
       message.setObjectProperty(key, value)
     }

--- a/kafka-connect-jms/src/test/scala/com/datamountaineer/streamreactor/connect/jms/TestBase.scala
+++ b/kafka-connect-jms/src/test/scala/com/datamountaineer/streamreactor/connect/jms/TestBase.scala
@@ -56,11 +56,14 @@ trait TestBase extends AnyWordSpec with Matchers with MockitoSugar {
   val JMS_URL_1 = "tcp://localhost:61621"
   val AVRO_QUEUE = "avro_queue"
   val QUEUE_CONVERTER = s"`com.datamountaineer.streamreactor.connect.converters.source.AvroConverter`"
+  val QUEUE_CONVERTER_JMS = s"`com.datamountaineer.streamreactor.connect.jms.sink.converters.AvroMessageConverter`"
+  val FORMAT = "AVRO"
   val AVRO_FILE = getSchemaFile()
 
 
   def getAvroProp(topic: String) = s"${topic}=${AVRO_FILE}"
   def getKCQL(target: String, source: String, jmsType: String) = s"INSERT INTO $target SELECT * FROM $source WITHTYPE $jmsType"
+  def getKCQLAvroSinkConverter(target: String, source: String, jmsType: String) = s"INSERT INTO $target SELECT * FROM $source WITHTYPE $jmsType WITHCONVERTER=$QUEUE_CONVERTER_JMS"
   def getKCQLAvroSource(topic: String, queue: String, jmsType: String) = s"INSERT INTO $topic SELECT * FROM $queue WITHTYPE $jmsType WITHCONVERTER=$QUEUE_CONVERTER"
 
   def getSchemaFile(): String = {


### PR DESCRIPTION
This change contains to extend sink jms connector to support converter classes from runtime(via connector property and via kcql WITHCONVERTER)

WITHFORMAT in kcql currently not seems to be supported as POJO mapping doesn't seem to be working