### PR TITLE
Parquet data size flushing fixes

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -62,6 +62,7 @@ jobs:
         with:
           files: "**/target/**/test-reports/*.xml"
           check_name: ${{ matrix.module }}
+          comment_mode: off
 
   build-and-upload-assembly:
     needs: initiate

--- a/kafka-connect-aws-s3/src/main/scala/io/lenses/streamreactor/connect/aws/s3/formats/ParquetFormatWriter.scala
+++ b/kafka-connect-aws-s3/src/main/scala/io/lenses/streamreactor/connect/aws/s3/formats/ParquetFormatWriter.scala
@@ -29,6 +29,7 @@ import org.apache.parquet.avro.AvroParquetWriter
 import org.apache.parquet.hadoop.ParquetWriter
 import org.apache.parquet.hadoop.ParquetWriter.{DEFAULT_BLOCK_SIZE, DEFAULT_PAGE_SIZE}
 
+import scala.jdk.CollectionConverters.collectionAsScalaIterableConverter
 import scala.util.Try
 
 class ParquetFormatWriter(outputStreamFn: () => S3OutputStream) extends S3FormatWriter with LazyLogging {
@@ -78,6 +79,6 @@ class ParquetFormatWriter(outputStreamFn: () => S3OutputStream) extends S3Format
     } yield closed
   }
 
-  override def getPointer: Long = outputStream.getPointer
+  override def getPointer: Long = writer.getDataSize
 
 }

--- a/kafka-connect-aws-s3/src/main/scala/io/lenses/streamreactor/connect/aws/s3/formats/ParquetFormatWriter.scala
+++ b/kafka-connect-aws-s3/src/main/scala/io/lenses/streamreactor/connect/aws/s3/formats/ParquetFormatWriter.scala
@@ -29,7 +29,6 @@ import org.apache.parquet.avro.AvroParquetWriter
 import org.apache.parquet.hadoop.ParquetWriter
 import org.apache.parquet.hadoop.ParquetWriter.{DEFAULT_BLOCK_SIZE, DEFAULT_PAGE_SIZE}
 
-import scala.jdk.CollectionConverters.collectionAsScalaIterableConverter
 import scala.util.Try
 
 class ParquetFormatWriter(outputStreamFn: () => S3OutputStream) extends S3FormatWriter with LazyLogging {

--- a/kafka-connect-aws-s3/src/main/scala/io/lenses/streamreactor/connect/aws/s3/sink/writer/CommitState.scala
+++ b/kafka-connect-aws-s3/src/main/scala/io/lenses/streamreactor/connect/aws/s3/sink/writer/CommitState.scala
@@ -54,11 +54,11 @@ case class CommitState(
 
 object CommitState {
 
-  def apply(tp: TopicPartition): CommitState = {
+  def apply(tp: TopicPartition, seekedOffset: Option[Offset]): CommitState = {
     CommitState(
       topicPartition = tp,
       createdTimestamp = System.currentTimeMillis(),
-      committedOffset = None,
+      committedOffset = seekedOffset,
       lastFlushedTime = None,
       recordCount = 0,
       lastKnownFileSize = 0,

--- a/kafka-connect-aws-s3/src/main/scala/io/lenses/streamreactor/connect/aws/s3/storage/JCloudsStorageInterface.scala
+++ b/kafka-connect-aws-s3/src/main/scala/io/lenses/streamreactor/connect/aws/s3/storage/JCloudsStorageInterface.scala
@@ -26,6 +26,7 @@ import org.jclouds.blobstore.domain.StorageType
 import org.jclouds.blobstore.options.ListContainerOptions
 
 import java.io.{File, InputStream}
+import java.time.Instant
 import scala.jdk.CollectionConverters.{CollectionHasAsScala, SeqHasAsJava}
 import scala.util.{Failure, Success, Try}
 
@@ -142,4 +143,7 @@ class JCloudsStorageInterface(sinkName: String, blobStoreContext: BlobStoreConte
     }.toEither.leftMap(FileLoadError(_, bucketAndPath.path))
   }
 
+  override def getBlobModified(location: RemoteS3PathLocation): Instant = {
+    blobStore.blobMetadata(location.bucket, location.path).getLastModified.toInstant
+  }
 }

--- a/kafka-connect-aws-s3/src/main/scala/io/lenses/streamreactor/connect/aws/s3/storage/StorageInterface.scala
+++ b/kafka-connect-aws-s3/src/main/scala/io/lenses/streamreactor/connect/aws/s3/storage/StorageInterface.scala
@@ -20,6 +20,7 @@ package io.lenses.streamreactor.connect.aws.s3.storage
 import io.lenses.streamreactor.connect.aws.s3.model.location.RemoteS3PathLocation
 
 import java.io.{File, InputStream}
+import java.time.{Instant, LocalDateTime}
 
 trait StorageInterface {
 
@@ -36,6 +37,8 @@ trait StorageInterface {
   def getBlobAsString(bucketAndPath: RemoteS3PathLocation): Either[FileLoadError, String]
 
   def getBlobSize(bucketAndPath: RemoteS3PathLocation): Long
+
+  def getBlobModified(location: RemoteS3PathLocation): Instant
 
   def writeStringToFile(target: RemoteS3PathLocation, data: String): Either[UploadError, Unit]
 

--- a/kafka-connect-aws-s3/src/main/scala/io/lenses/streamreactor/connect/aws/s3/storage/StorageInterface.scala
+++ b/kafka-connect-aws-s3/src/main/scala/io/lenses/streamreactor/connect/aws/s3/storage/StorageInterface.scala
@@ -20,7 +20,7 @@ package io.lenses.streamreactor.connect.aws.s3.storage
 import io.lenses.streamreactor.connect.aws.s3.model.location.RemoteS3PathLocation
 
 import java.io.{File, InputStream}
-import java.time.{Instant, LocalDateTime}
+import java.time.Instant
 
 trait StorageInterface {
 

--- a/kafka-connect-aws-s3/src/test/scala/io/lenses/streamreactor/connect/aws/s3/formats/ParquetFormatWriterStreamTest.scala
+++ b/kafka-connect-aws-s3/src/test/scala/io/lenses/streamreactor/connect/aws/s3/formats/ParquetFormatWriterStreamTest.scala
@@ -36,12 +36,17 @@ class ParquetFormatWriterStreamTest extends AnyFlatSpec with Matchers with S3Pro
     val blobStream = new BuildLocalOutputStream( toBufferedOutputStream(localFile), Topic("testTopic").withPartition(1))
     val parquetFormatWriter = new ParquetFormatWriter(() => blobStream)
     parquetFormatWriter.write(None, StructSinkData(users.head), topic)
+    parquetFormatWriter.getPointer should be (21)
+    parquetFormatWriter.write(None, StructSinkData(users(1)), topic)
+    parquetFormatWriter.getPointer should be (44)
+    parquetFormatWriter.write(None, StructSinkData(users(2)), topic)
+    parquetFormatWriter.getPointer should be (59)
     parquetFormatWriter.complete() should be (Right(()))
 
     val bytes = localFileAsBytes(localFile)
 
     val genericRecords = parquetFormatReader.read(bytes)
-    genericRecords.size should be(1)
+    genericRecords.size should be(3)
     checkRecord(genericRecords.head, "sam", "mr", 100.43)
 
   }

--- a/kafka-connect-aws-s3/src/test/scala/io/lenses/streamreactor/connect/aws/s3/formats/TextFormatWriterTest.scala
+++ b/kafka-connect-aws-s3/src/test/scala/io/lenses/streamreactor/connect/aws/s3/formats/TextFormatWriterTest.scala
@@ -34,7 +34,7 @@ class TextFormatWriterTest extends AnyFlatSpec with Matchers with EitherValues {
     jsonFormatWriter.write(None, StringSinkData("Sausages"), topic)
 
     outputStream.toString should be("Sausages\n")
-    outputStream.getPointer should be (8)
+    outputStream.getPointer should be (9L)
 
   }
 

--- a/kafka-connect-aws-s3/src/test/scala/io/lenses/streamreactor/connect/aws/s3/formats/TextFormatWriterTest.scala
+++ b/kafka-connect-aws-s3/src/test/scala/io/lenses/streamreactor/connect/aws/s3/formats/TextFormatWriterTest.scala
@@ -34,6 +34,7 @@ class TextFormatWriterTest extends AnyFlatSpec with Matchers with EitherValues {
     jsonFormatWriter.write(None, StringSinkData("Sausages"), topic)
 
     outputStream.toString should be("Sausages\n")
+    outputStream.getPointer should be (8)
 
   }
 

--- a/kafka-connect-aws-s3/src/test/scala/io/lenses/streamreactor/connect/aws/s3/sink/S3SinkTaskTest.scala
+++ b/kafka-connect-aws-s3/src/test/scala/io/lenses/streamreactor/connect/aws/s3/sink/S3SinkTaskTest.scala
@@ -32,6 +32,7 @@ import org.apache.kafka.common.TopicPartition
 import org.apache.kafka.connect.data.{Schema, SchemaBuilder, Struct}
 import org.apache.kafka.connect.errors.{ConnectException, RetriableException}
 import org.apache.kafka.connect.header.{ConnectHeaders, Header}
+import org.apache.kafka.connect.json.JsonConverter
 import org.apache.kafka.connect.sink.{SinkRecord, SinkTaskContext}
 import org.mockito.MockitoSugar
 import org.scalatest.flatspec.AnyFlatSpec
@@ -39,6 +40,7 @@ import org.scalatest.matchers.should.Matchers
 
 import java.io.StringReader
 import java.nio.file.Files
+import java.util.UUID
 import java.{lang, util}
 import scala.jdk.CollectionConverters.{MapHasAsJava, MapHasAsScala, SeqHasAsJava}
 
@@ -194,6 +196,37 @@ class S3SinkTaskTest extends AnyFlatSpec with Matchers with S3ProxyContainerTest
     listBucketPath(BucketName, "streamReactorBackups/myTopic/1/").size should be(1)
 
     remoteFileAsString(BucketName, "streamReactorBackups/myTopic/1/1.json") should be("""{"name":"sam","title":"mr","salary":100.43}{"name":"laura","title":"ms","salary":429.06}""")
+
+  }
+
+  "S3SinkTask" should "flush on configured file size for Parquet" in {
+
+    val task = new S3SinkTask()
+
+    val props = DefaultProps
+      .combine(
+        Map(
+          "connect.s3.kcql" -> s"insert into $BucketName:$PrefixName select * from $TopicName STOREAS `Parquet` WITH_FLUSH_SIZE = 20"
+        )
+      ).asJava
+
+    task.start(props)
+    task.open(Seq(new TopicPartition(TopicName, 1)).asJava)
+    task.put(records.asJava)
+    task.close(Seq(new TopicPartition(TopicName, 1)).asJava)
+    task.stop()
+
+    listBucketPath(BucketName, "streamReactorBackups/myTopic/1/").size should be(2)
+    getFileSize(BucketName, "streamReactorBackups/myTopic/1/0.parquet") should be(941)
+    getFileSize(BucketName, "streamReactorBackups/myTopic/1/1.parquet") should be(954)
+
+    var genericRecords = parquetFormatReader.read(remoteFileAsBytes(BucketName, "streamReactorBackups/myTopic/1/0.parquet"))
+    genericRecords.size should be (1)
+    checkRecord(genericRecords.head, "sam", "mr", 100.43)
+
+    genericRecords = parquetFormatReader.read(remoteFileAsBytes(BucketName, "streamReactorBackups/myTopic/1/1.parquet"))
+    genericRecords.size should be (1)
+    checkRecord(genericRecords.head, "laura", "ms", 429.06)
 
   }
 

--- a/kafka-connect-aws-s3/src/test/scala/io/lenses/streamreactor/connect/aws/s3/sink/S3SinkTaskTest.scala
+++ b/kafka-connect-aws-s3/src/test/scala/io/lenses/streamreactor/connect/aws/s3/sink/S3SinkTaskTest.scala
@@ -17,8 +17,8 @@
 
 package io.lenses.streamreactor.connect.aws.s3.sink
 
-import com.opencsv.CSVReader
 import cats.implicits._
+import com.opencsv.CSVReader
 import io.lenses.streamreactor.connect.aws.s3.SlowTest
 import io.lenses.streamreactor.connect.aws.s3.config.AuthMode
 import io.lenses.streamreactor.connect.aws.s3.config.S3ConfigSettings._
@@ -32,7 +32,6 @@ import org.apache.kafka.common.TopicPartition
 import org.apache.kafka.connect.data.{Schema, SchemaBuilder, Struct}
 import org.apache.kafka.connect.errors.{ConnectException, RetriableException}
 import org.apache.kafka.connect.header.{ConnectHeaders, Header}
-import org.apache.kafka.connect.json.JsonConverter
 import org.apache.kafka.connect.sink.{SinkRecord, SinkTaskContext}
 import org.mockito.MockitoSugar
 import org.scalatest.flatspec.AnyFlatSpec
@@ -40,7 +39,6 @@ import org.scalatest.matchers.should.Matchers
 
 import java.io.StringReader
 import java.nio.file.Files
-import java.util.UUID
 import java.{lang, util}
 import scala.jdk.CollectionConverters.{MapHasAsJava, MapHasAsScala, SeqHasAsJava}
 
@@ -87,6 +85,10 @@ class S3SinkTaskTest extends AnyFlatSpec with Matchers with S3ProxyContainerTest
   }
 
   private val records = firstUsers.zipWithIndex.map { case (user, k) =>
+    toSinkRecord(user, k)
+  }
+
+  private def toSinkRecord(user: Struct, k: Int) = {
     new SinkRecord(TopicName, 1, null, null, schema, user, k.toLong)
   }
 
@@ -230,37 +232,121 @@ class S3SinkTaskTest extends AnyFlatSpec with Matchers with S3ProxyContainerTest
 
   }
 
-  /**
-    * The difference in this test is that the sink is opened again, which will cause the offsets to be copied to the
-    * context
-    */
-  "S3SinkTask" should "put existing offsets to the context"  taggedAs SlowTest in {
+  def createTask(context: SinkTaskContext, props: util.Map[String,String]): S3SinkTask = {
+    reset(context)
+    val task: S3SinkTask = new S3SinkTask()
+    task.initialize(context)
+    task.start(props)
+    task
+  }
 
-    val task = new S3SinkTask()
+     /**
+      * The difference in this test is that the sink is opened again, which will cause the offsets to be copied to the
+      * context
+      */
+    "S3SinkTask" should "put existing offsets to the context"  taggedAs SlowTest in {
+
+      val task = new S3SinkTask()
+
+      val props = DefaultProps
+        .combine(
+          Map(
+            "connect.s3.kcql" -> s"insert into $BucketName:$PrefixName select * from $TopicName WITH_FLUSH_COUNT = 1"
+          )
+        ).asJava
+
+      val sinkTaskContext = mock[SinkTaskContext]
+      task.initialize(sinkTaskContext)
+      task.start(props)
+      task.open(Seq(new TopicPartition(TopicName, 1)).asJava)
+      task.put(records.asJava)
+      task.open(Seq(new TopicPartition(TopicName, 1)).asJava)
+      task.close(Seq(new TopicPartition(TopicName, 1)).asJava)
+      task.stop()
+
+      listBucketPath(BucketName, "streamReactorBackups/myTopic/1/").size should be(3)
+
+      remoteFileAsString(BucketName, "streamReactorBackups/myTopic/1/0.json") should be("""{"name":"sam","title":"mr","salary":100.43}""")
+      remoteFileAsString(BucketName, "streamReactorBackups/myTopic/1/1.json") should be("""{"name":"laura","title":"ms","salary":429.06}""")
+      remoteFileAsString(BucketName, "streamReactorBackups/myTopic/1/2.json") should be("""{"name":"tom","title":null,"salary":395.44}""")
+
+      verify(sinkTaskContext).offset(new TopicPartition("myTopic", 1), 2)
+    }
+
+  "S3SinkTask" should "skip when kafka connect resends the same offsets after opening" in {
 
     val props = DefaultProps
       .combine(
         Map(
-          "connect.s3.kcql" -> s"insert into $BucketName:$PrefixName select * from $TopicName WITH_FLUSH_COUNT = 1"
+          "connect.s3.kcql" -> s"insert into $BucketName:$PrefixName select * from $TopicName STOREAS `Parquet` WITH_FLUSH_COUNT = 2"
         )
       ).asJava
+    val context = mock[SinkTaskContext]
 
-    val sinkTaskContext = mock[SinkTaskContext]
-    task.initialize(sinkTaskContext)
-    task.start(props)
+    var task: S3SinkTask = createTask(context, props)
+
     task.open(Seq(new TopicPartition(TopicName, 1)).asJava)
+    verify(context, never).offset(new TopicPartition("myTopic", 1), 0)
     task.put(records.asJava)
-    task.open(Seq(new TopicPartition(TopicName, 1)).asJava)
-    task.close(Seq(new TopicPartition(TopicName, 1)).asJava)
+    task.close(Seq(new TopicPartition("myTopic", 1)).asJava)
     task.stop()
 
-    listBucketPath(BucketName, "streamReactorBackups/myTopic/1/").size should be(3)
+    val list = listBucketPath(BucketName, "streamReactorBackups/myTopic/1/")
+    list.size should be(1)
+    list should contain("streamReactorBackups/myTopic/1/1.parquet")
 
-    remoteFileAsString(BucketName, "streamReactorBackups/myTopic/1/0.json") should be("""{"name":"sam","title":"mr","salary":100.43}""")
-    remoteFileAsString(BucketName, "streamReactorBackups/myTopic/1/1.json") should be("""{"name":"laura","title":"ms","salary":429.06}""")
-    remoteFileAsString(BucketName, "streamReactorBackups/myTopic/1/2.json") should be("""{"name":"tom","title":null,"salary":395.44}""")
+    val modificationDate = getModificationDate(BucketName, "streamReactorBackups/mytopic/1/1.parquet")
 
-    verify(sinkTaskContext).offset(new TopicPartition("myTopic", 1), 2)
+    task = createTask(context, props)
+    task.open(Seq(new TopicPartition(TopicName, 1)).asJava)
+    verify(context).offset(new TopicPartition("myTopic", 1), 1)
+    task.put(records.asJava)
+
+    listBucketPath(BucketName, "streamReactorBackups/myTopic/1/").size should be(1)
+
+    // file should not have been overwritten
+    getModificationDate(BucketName, "streamReactorBackups/mytopic/1/1.parquet") should be (modificationDate)
+
+    task.close(Seq(new TopicPartition("myTopic", 1)).asJava)
+    task.stop()
+
+    task = createTask(context, props)
+    task.open(Seq(new TopicPartition(TopicName, 1)).asJava)
+    verify(context).offset(new TopicPartition("myTopic", 1), 1)
+    // only 1 "real" record so should leave it hanging again
+    task.put(List(records(1), records(2)).asJava)
+
+
+    listBucketPath(BucketName, "streamReactorBackups/myTopic/1/").size should be(1)
+
+    // file should not have been overwritten
+    getModificationDate(BucketName, "streamReactorBackups/mytopic/1/1.parquet") should be (modificationDate)
+
+    task.close(Seq(new TopicPartition("myTopic", 1)).asJava)
+    task.stop()
+
+
+
+
+    task = createTask(context, props)
+    task.open(Seq(new TopicPartition(TopicName, 1)).asJava)
+    verify(context).offset(new TopicPartition("myTopic", 1), 1)
+
+    // this time we have an unseen record (3), which should be processed alongside (2) to give us a new file
+    task.put(List(
+      records(1),
+      records(2),
+      toSinkRecord(users(3), 3)
+    ).asJava)
+
+    listBucketPath(BucketName, "streamReactorBackups/myTopic/1/").size should be(2)
+
+    // file should not have been overwritten
+    getModificationDate(BucketName, "streamReactorBackups/mytopic/1/1.parquet") should be (modificationDate)
+
+    task.close(Seq(new TopicPartition("myTopic", 1)).asJava)
+    task.stop()
+
   }
 
   "S3SinkTask" should "write to parquet format"  taggedAs SlowTest in {
@@ -369,8 +455,7 @@ class S3SinkTaskTest extends AnyFlatSpec with Matchers with S3ProxyContainerTest
 
     val task = new S3SinkTask()
 
-    val extraRecord = new SinkRecord(TopicName, 1, null, null, schema,
-      new Struct(schema).put("name", "bob").put("title", "mr").put("salary", 200.86), 3)
+    val extraRecord = toSinkRecord(new Struct(schema).put("name", "bob").put("title", "mr").put("salary", 200.86), 3)
 
     val allRecords: List[SinkRecord] = records :+ extraRecord
 
@@ -412,8 +497,7 @@ class S3SinkTaskTest extends AnyFlatSpec with Matchers with S3ProxyContainerTest
 
     val task = new S3SinkTask()
 
-    val extraRecord = new SinkRecord(TopicName, 1, null, null, schema,
-      new Struct(schema).put("name", "bob").put("title", "mr").put("salary", 200.86), 3)
+    val extraRecord = toSinkRecord(new Struct(schema).put("name", "bob").put("title", "mr").put("salary", 200.86), 3)
 
     val allRecords: List[SinkRecord] = records :+ extraRecord
 
@@ -494,7 +578,7 @@ class S3SinkTaskTest extends AnyFlatSpec with Matchers with S3ProxyContainerTest
     )
 
     val records = partitionedData.zipWithIndex.map { case (user, k) =>
-      new SinkRecord(TopicName, 1, null, null, schema, user, k.toLong)
+      toSinkRecord(user, k)
     }
 
     val props = DefaultProps
@@ -926,8 +1010,8 @@ class S3SinkTaskTest extends AnyFlatSpec with Matchers with S3ProxyContainerTest
 
     val kafkaPartitionedRecords = List(
       new SinkRecord(TopicName, 0, null, null, schema, users(0), 0),
-      new SinkRecord(TopicName, 1, null, null, schema, users(1), 0),
-      new SinkRecord(TopicName, 1, null, null, schema, users(2), 1)
+      toSinkRecord(users(1), 0),
+      toSinkRecord(users(2), 1)
     )
 
     val topicPartitionsToManage = Seq(
@@ -1308,8 +1392,8 @@ class S3SinkTaskTest extends AnyFlatSpec with Matchers with S3ProxyContainerTest
 
     val kafkaPartitionedRecords = List(
       new SinkRecord(TopicName, 0, null, null, schema, nested(0), 0),
-      new SinkRecord(TopicName, 1, null, null, schema, nested(1), 0),
-      new SinkRecord(TopicName, 1, null, null, schema, nested(2), 1)
+      toSinkRecord(nested(1), 0),
+      toSinkRecord(nested(2), 1)
     )
 
     val topicPartitionsToManage = Seq(

--- a/kafka-connect-aws-s3/src/test/scala/io/lenses/streamreactor/connect/aws/s3/sink/S3SinkTaskTest.scala
+++ b/kafka-connect-aws-s3/src/test/scala/io/lenses/streamreactor/connect/aws/s3/sink/S3SinkTaskTest.scala
@@ -240,38 +240,38 @@ class S3SinkTaskTest extends AnyFlatSpec with Matchers with S3ProxyContainerTest
     task
   }
 
-     /**
-      * The difference in this test is that the sink is opened again, which will cause the offsets to be copied to the
-      * context
-      */
-    "S3SinkTask" should "put existing offsets to the context"  taggedAs SlowTest in {
+  /**
+    * The difference in this test is that the sink is opened again, which will cause the offsets to be copied to the
+    * context
+    */
+  "S3SinkTask" should "put existing offsets to the context" taggedAs SlowTest in {
 
-      val task = new S3SinkTask()
+    val task = new S3SinkTask()
 
-      val props = DefaultProps
-        .combine(
-          Map(
-            "connect.s3.kcql" -> s"insert into $BucketName:$PrefixName select * from $TopicName WITH_FLUSH_COUNT = 1"
-          )
-        ).asJava
+    val props = DefaultProps
+      .combine(
+        Map(
+          "connect.s3.kcql" -> s"insert into $BucketName:$PrefixName select * from $TopicName WITH_FLUSH_COUNT = 1"
+        )
+      ).asJava
 
-      val sinkTaskContext = mock[SinkTaskContext]
-      task.initialize(sinkTaskContext)
-      task.start(props)
-      task.open(Seq(new TopicPartition(TopicName, 1)).asJava)
-      task.put(records.asJava)
-      task.open(Seq(new TopicPartition(TopicName, 1)).asJava)
-      task.close(Seq(new TopicPartition(TopicName, 1)).asJava)
-      task.stop()
+    val sinkTaskContext = mock[SinkTaskContext]
+    task.initialize(sinkTaskContext)
+    task.start(props)
+    task.open(Seq(new TopicPartition(TopicName, 1)).asJava)
+    task.put(records.asJava)
+    task.open(Seq(new TopicPartition(TopicName, 1)).asJava)
+    task.close(Seq(new TopicPartition(TopicName, 1)).asJava)
+    task.stop()
 
-      listBucketPath(BucketName, "streamReactorBackups/myTopic/1/").size should be(3)
+    listBucketPath(BucketName, "streamReactorBackups/myTopic/1/").size should be(3)
 
-      remoteFileAsString(BucketName, "streamReactorBackups/myTopic/1/0.json") should be("""{"name":"sam","title":"mr","salary":100.43}""")
-      remoteFileAsString(BucketName, "streamReactorBackups/myTopic/1/1.json") should be("""{"name":"laura","title":"ms","salary":429.06}""")
-      remoteFileAsString(BucketName, "streamReactorBackups/myTopic/1/2.json") should be("""{"name":"tom","title":null,"salary":395.44}""")
+    remoteFileAsString(BucketName, "streamReactorBackups/myTopic/1/0.json") should be("""{"name":"sam","title":"mr","salary":100.43}""")
+    remoteFileAsString(BucketName, "streamReactorBackups/myTopic/1/1.json") should be("""{"name":"laura","title":"ms","salary":429.06}""")
+    remoteFileAsString(BucketName, "streamReactorBackups/myTopic/1/2.json") should be("""{"name":"tom","title":null,"salary":395.44}""")
 
-      verify(sinkTaskContext).offset(new TopicPartition("myTopic", 1), 2)
-    }
+    verify(sinkTaskContext).offset(new TopicPartition("myTopic", 1), 2)
+  }
 
   "S3SinkTask" should "skip when kafka connect resends the same offsets after opening" in {
 
@@ -295,7 +295,7 @@ class S3SinkTaskTest extends AnyFlatSpec with Matchers with S3ProxyContainerTest
     list.size should be(1)
     list should contain("streamReactorBackups/myTopic/1/1.parquet")
 
-    val modificationDate = getModificationDate(BucketName, "streamReactorBackups/mytopic/1/1.parquet")
+    val modificationDate = getModificationDate(BucketName, "streamReactorBackups/myTopic/1/1.parquet")
 
     task = createTask(context, props)
     task.open(Seq(new TopicPartition(TopicName, 1)).asJava)
@@ -305,7 +305,7 @@ class S3SinkTaskTest extends AnyFlatSpec with Matchers with S3ProxyContainerTest
     listBucketPath(BucketName, "streamReactorBackups/myTopic/1/").size should be(1)
 
     // file should not have been overwritten
-    getModificationDate(BucketName, "streamReactorBackups/mytopic/1/1.parquet") should be (modificationDate)
+    getModificationDate(BucketName, "streamReactorBackups/myTopic/1/1.parquet") should be (modificationDate)
 
     task.close(Seq(new TopicPartition("myTopic", 1)).asJava)
     task.stop()
@@ -316,17 +316,13 @@ class S3SinkTaskTest extends AnyFlatSpec with Matchers with S3ProxyContainerTest
     // only 1 "real" record so should leave it hanging again
     task.put(List(records(1), records(2)).asJava)
 
-
     listBucketPath(BucketName, "streamReactorBackups/myTopic/1/").size should be(1)
 
     // file should not have been overwritten
-    getModificationDate(BucketName, "streamReactorBackups/mytopic/1/1.parquet") should be (modificationDate)
+    getModificationDate(BucketName, "streamReactorBackups/myTopic/1/1.parquet") should be (modificationDate)
 
     task.close(Seq(new TopicPartition("myTopic", 1)).asJava)
     task.stop()
-
-
-
 
     task = createTask(context, props)
     task.open(Seq(new TopicPartition(TopicName, 1)).asJava)
@@ -342,7 +338,7 @@ class S3SinkTaskTest extends AnyFlatSpec with Matchers with S3ProxyContainerTest
     listBucketPath(BucketName, "streamReactorBackups/myTopic/1/").size should be(2)
 
     // file should not have been overwritten
-    getModificationDate(BucketName, "streamReactorBackups/mytopic/1/1.parquet") should be (modificationDate)
+    getModificationDate(BucketName, "streamReactorBackups/myTopic/1/1.parquet") should be (modificationDate)
 
     task.close(Seq(new TopicPartition("myTopic", 1)).asJava)
     task.stop()
@@ -398,8 +394,6 @@ class S3SinkTaskTest extends AnyFlatSpec with Matchers with S3ProxyContainerTest
     checkRecord(genericRecords.head, "sam", "mr", 100.43)
 
   }
-
-
 
   "S3SinkTask" should "error when trying to write AVRO to text format" in {
 

--- a/kafka-connect-aws-s3/src/test/scala/io/lenses/streamreactor/connect/aws/s3/sink/S3WriterManagerTest.scala
+++ b/kafka-connect-aws-s3/src/test/scala/io/lenses/streamreactor/connect/aws/s3/sink/S3WriterManagerTest.scala
@@ -6,7 +6,7 @@ import io.lenses.streamreactor.connect.aws.s3.formats.S3FormatWriter
 import io.lenses.streamreactor.connect.aws.s3.model.Topic
 import io.lenses.streamreactor.connect.aws.s3.model.location.{RemoteS3PathLocation, RemoteS3RootLocation}
 import io.lenses.streamreactor.connect.aws.s3.sink.seek.IndexManager
-import io.lenses.streamreactor.connect.aws.s3.sink.utils.S3TestConfig
+import io.lenses.streamreactor.connect.aws.s3.sink.utils.S3ProxyContainerTest
 import org.apache.kafka.clients.consumer.OffsetAndMetadata
 import org.mockito.MockitoSugar
 import org.scalatest.flatspec.AnyFlatSpec
@@ -15,7 +15,7 @@ import org.scalatest.matchers.should.Matchers
 import java.io.File
 import scala.concurrent.duration.{FiniteDuration, SECONDS}
 
-class S3WriterManagerTest extends AnyFlatSpec with Matchers with S3TestConfig with MockitoSugar {
+class S3WriterManagerTest extends AnyFlatSpec with Matchers with S3ProxyContainerTest with MockitoSugar {
 
   private val topicPartition = Topic("topic").withPartition(10)
 

--- a/kafka-connect-aws-s3/src/test/scala/io/lenses/streamreactor/connect/aws/s3/sink/S3WriterManagerTest.scala
+++ b/kafka-connect-aws-s3/src/test/scala/io/lenses/streamreactor/connect/aws/s3/sink/S3WriterManagerTest.scala
@@ -1,0 +1,37 @@
+package io.lenses.streamreactor.connect.aws.s3.sink
+
+import cats.implicits.catsSyntaxEitherId
+import io.lenses.streamreactor.connect.aws.s3.config.FormatSelection
+import io.lenses.streamreactor.connect.aws.s3.formats.S3FormatWriter
+import io.lenses.streamreactor.connect.aws.s3.model.Topic
+import io.lenses.streamreactor.connect.aws.s3.model.location.{RemoteS3PathLocation, RemoteS3RootLocation}
+import io.lenses.streamreactor.connect.aws.s3.sink.seek.IndexManager
+import io.lenses.streamreactor.connect.aws.s3.sink.utils.S3TestConfig
+import org.apache.kafka.clients.consumer.OffsetAndMetadata
+import org.mockito.MockitoSugar
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+import java.io.File
+import scala.concurrent.duration.{FiniteDuration, SECONDS}
+
+class S3WriterManagerTest extends AnyFlatSpec with Matchers with S3TestConfig with MockitoSugar {
+
+  private val topicPartition = Topic("topic").withPartition(10)
+
+  "S3WriterManager" should "return empty map when no offset or metadata writers can be found" in {
+    val wm = new S3WriterManager(
+      "myLovelySink",
+      _ => DefaultCommitPolicy(Some(5L),Some(FiniteDuration(5, SECONDS)),Some(5L)).asRight,
+      _ => RemoteS3RootLocation("bucketAndPath:location").asRight,
+      _ => new HierarchicalS3FileNamingStrategy(FormatSelection("csv")).asRight,
+      (_,_) => new File("blah.csv").asRight,
+      (_,_,_) => RemoteS3PathLocation("bucket", "path").asRight,
+      (_,_) => mock[S3FormatWriter].asRight,
+      mock[IndexManager]
+    )
+
+    val result = wm.preCommit(Map(topicPartition -> new OffsetAndMetadata(999)))
+    result should be (Map())
+  }
+}

--- a/kafka-connect-aws-s3/src/test/scala/io/lenses/streamreactor/connect/aws/s3/sink/utils/RemoteFileTestHelper.scala
+++ b/kafka-connect-aws-s3/src/test/scala/io/lenses/streamreactor/connect/aws/s3/sink/utils/RemoteFileTestHelper.scala
@@ -22,6 +22,7 @@ import io.lenses.streamreactor.connect.aws.s3.storage.StorageInterface
 
 import java.io.{File, InputStream}
 import java.nio.file.Files
+import java.time.{Instant, LocalDateTime}
 
 class RemoteFileTestHelper(implicit storageInterface: StorageInterface) {
 
@@ -34,6 +35,10 @@ class RemoteFileTestHelper(implicit storageInterface: StorageInterface) {
 
   def getFileSize(bucketName: String, fileName: String): Long = {
     storageInterface.getBlobSize(RemoteS3PathLocation(bucketName, fileName))
+  }
+
+  def getModificationDate(bucketName: String, fileName: String): Instant = {
+    storageInterface.getBlobModified(RemoteS3PathLocation(bucketName, fileName))
   }
 
   def remoteFileAsBytes(bucketName: String, fileName: String): Array[Byte] = {

--- a/kafka-connect-aws-s3/src/test/scala/io/lenses/streamreactor/connect/aws/s3/sink/utils/RemoteFileTestHelper.scala
+++ b/kafka-connect-aws-s3/src/test/scala/io/lenses/streamreactor/connect/aws/s3/sink/utils/RemoteFileTestHelper.scala
@@ -32,6 +32,10 @@ class RemoteFileTestHelper(implicit storageInterface: StorageInterface) {
     }
   }
 
+  def getFileSize(bucketName: String, fileName: String): Long = {
+    storageInterface.getBlobSize(RemoteS3PathLocation(bucketName, fileName))
+  }
+
   def remoteFileAsBytes(bucketName: String, fileName: String): Array[Byte] = {
     streamToByteArray(remoteFileAsStream(bucketName, fileName))
   }

--- a/kafka-connect-aws-s3/src/test/scala/io/lenses/streamreactor/connect/aws/s3/sink/utils/RemoteFileTestHelper.scala
+++ b/kafka-connect-aws-s3/src/test/scala/io/lenses/streamreactor/connect/aws/s3/sink/utils/RemoteFileTestHelper.scala
@@ -22,7 +22,7 @@ import io.lenses.streamreactor.connect.aws.s3.storage.StorageInterface
 
 import java.io.{File, InputStream}
 import java.nio.file.Files
-import java.time.{Instant, LocalDateTime}
+import java.time.Instant
 
 class RemoteFileTestHelper(implicit storageInterface: StorageInterface) {
 

--- a/kafka-connect-aws-s3/src/test/scala/io/lenses/streamreactor/connect/aws/s3/source/S3SourceTaskTest.scala
+++ b/kafka-connect-aws-s3/src/test/scala/io/lenses/streamreactor/connect/aws/s3/source/S3SourceTaskTest.scala
@@ -237,11 +237,11 @@ class S3SourceTaskTest extends AnyFlatSpec with Matchers with S3ProxyContainerTe
     val dir = "nested/byteskv"
     val task = new S3SourceTask()
 
-    val formatExtensionString = generateFormatString(formatOptions)
+    val formatExtensionString = bucketSetup.generateFormatString(formatOptions)
 
     val props = DefaultProps
       .combine(
-        Map("connect.s3.kcql" -> s"insert into $TopicName select * from $BucketName:$PrefixName/$dir STOREAS `${format.entryName}$formatExtensionString` LIMIT 190")
+        Map("connect.s3.kcql" -> s"insert into ${bucketSetup.TopicName} select * from $BucketName:${bucketSetup.PrefixName}/$dir STOREAS `${format.entryName}$formatExtensionString` LIMIT 190")
       ).asJava
 
     task.start(props)
@@ -264,11 +264,11 @@ class S3SourceTaskTest extends AnyFlatSpec with Matchers with S3ProxyContainerTe
     sourceRecords7 should have size 0
 
     sourceRecords1.asScala
-      .union(sourceRecords2.asScala)
-      .union(sourceRecords3.asScala)
-      .union(sourceRecords4.asScala)
-      .union(sourceRecords5.asScala)
-      .union(sourceRecords6.asScala)
+      .concat(sourceRecords2.asScala)
+      .concat(sourceRecords3.asScala)
+      .concat(sourceRecords4.asScala)
+      .concat(sourceRecords5.asScala)
+      .concat(sourceRecords6.asScala)
       .toSet should have size 1000
 
     sourceRecords1.get(0).key should be("myKey".getBytes)

--- a/kafka-connect-aws-s3/src/test/scala/io/lenses/streamreactor/connect/aws/s3/source/S3SourceTaskTest.scala
+++ b/kafka-connect-aws-s3/src/test/scala/io/lenses/streamreactor/connect/aws/s3/source/S3SourceTaskTest.scala
@@ -231,6 +231,50 @@ class S3SourceTaskTest extends AnyFlatSpec with Matchers with S3ProxyContainerTe
     sourceRecords1.get(0).value() should be("somestring".getBytes)
   }
 
+  "task" should "read stored nested bytes key/value files continuously" in {
+    val (format, formatOptions) = (Format.Bytes, Some(FormatOptions.KeyAndValueWithSizes))
+
+    val dir = "nested/byteskv"
+    val task = new S3SourceTask()
+
+    val formatExtensionString = generateFormatString(formatOptions)
+
+    val props = DefaultProps
+      .combine(
+        Map("connect.s3.kcql" -> s"insert into $TopicName select * from $BucketName:$PrefixName/$dir STOREAS `${format.entryName}$formatExtensionString` LIMIT 190")
+      ).asJava
+
+    task.start(props)
+    val sourceRecords1 = task.poll()
+    val sourceRecords2 = task.poll()
+    val sourceRecords3 = task.poll()
+    val sourceRecords4 = task.poll()
+    val sourceRecords5 = task.poll()
+    val sourceRecords6 = task.poll()
+    val sourceRecords7 = task.poll()
+
+    task.stop()
+
+    sourceRecords1 should have size 190
+    sourceRecords2 should have size 190
+    sourceRecords3 should have size 190
+    sourceRecords4 should have size 190
+    sourceRecords5 should have size 190
+    sourceRecords6 should have size 50
+    sourceRecords7 should have size 0
+
+    sourceRecords1.asScala
+      .union(sourceRecords2.asScala)
+      .union(sourceRecords3.asScala)
+      .union(sourceRecords4.asScala)
+      .union(sourceRecords5.asScala)
+      .union(sourceRecords6.asScala)
+      .toSet should have size 1000
+
+    sourceRecords1.get(0).key should be("myKey".getBytes)
+    sourceRecords1.get(0).value() should be("somestring".getBytes)
+  }
+
   override def cleanUpEnabled: Boolean = false
 
   override def setUpTestData(): Unit = {
@@ -244,5 +288,6 @@ class S3SourceTaskTest extends AnyFlatSpec with Matchers with S3ProxyContainerTe
 
     bucketSetup.setUpBucketData(BucketName, Bytes, Some(KeyAndValueWithSizes), "byteskv")
     bucketSetup.setUpBucketData(BucketName, Bytes, Some(ValueOnly), "bytesval")
+    bucketSetup.setUpBucketData(BucketName, Bytes, Some(KeyAndValueWithSizes), "nested/byteskv")
   }
 }


### PR DESCRIPTION
Fixes
* ensure Parquet writer tracks written data effectively
* keep last seeked offset in sink
* avoid NPE in preCommit
* avoid test reports being added to the PR in github actions