### PR TITLE
Don't swallow exception when S3SinkTask fails to open.

### DIFF
--- a/kafka-connect-aws-s3/src/main/scala/io/lenses/streamreactor/connect/aws/s3/sink/Exceptions.scala
+++ b/kafka-connect-aws-s3/src/main/scala/io/lenses/streamreactor/connect/aws/s3/sink/Exceptions.scala
@@ -19,6 +19,8 @@ package io.lenses.streamreactor.connect.aws.s3.sink
 import io.lenses.streamreactor.connect.aws.s3.model.TopicPartition
 
 trait SinkError {
+  def exception(): Throwable
+
   def message(): String
 
   def rollBack(): Boolean
@@ -80,6 +82,9 @@ case class BatchS3SinkError(
 
   def hasFatal: Boolean = fatal.nonEmpty
 
+  override def exception(): Throwable = {
+    fatal.head.exception
+  }
 
   override def message(): String = {
     "fatal:\n" + fatal.map(_.message).mkString("\n") + "\n\nnonFatal:\n" + nonFatal.map(_.message).mkString("\n") + "\n\nFatal TPs:\n" + fatal.map(_.topicPartitions())

--- a/kafka-connect-aws-s3/src/main/scala/io/lenses/streamreactor/connect/aws/s3/sink/S3SinkTask.scala
+++ b/kafka-connect-aws-s3/src/main/scala/io/lenses/streamreactor/connect/aws/s3/sink/S3SinkTask.scala
@@ -122,7 +122,7 @@ class S3SinkTask extends SinkTask with ErrorHandler {
         if (error.rollBack()) {
           rollback(error.topicPartitions())
         }
-        throw new IllegalStateException(error.message())
+        throw new IllegalStateException(error.message(), error.exception())
       case Right(_) =>
     }
   }

--- a/kafka-connect-aws-s3/src/main/scala/io/lenses/streamreactor/connect/aws/s3/sink/seek/IndexManager.scala
+++ b/kafka-connect-aws-s3/src/main/scala/io/lenses/streamreactor/connect/aws/s3/sink/seek/IndexManager.scala
@@ -100,7 +100,10 @@ class IndexManager(sinkName: String, maxIndexes: Int, fallbackSeeker: Option[Leg
     storageInterface.list(bucketAndPrefix.withPath(
       IndexFilenames.indexForTopicPartition(sinkName, topicPartition.topic.value, topicPartition.partition)
     ))
-      .leftMap(e => new NonFatalS3SinkError("Couldn't retrieve listing", e.exception))
+      .leftMap { e =>
+        logger.error("Error retrieving listing", e.exception)
+        new NonFatalS3SinkError("Couldn't retrieve listing", e.exception)
+      }
       .flatMap {
         indexes =>
           if (indexes.isEmpty && fallbackSeeker.nonEmpty) {


### PR DESCRIPTION
Without this, the per partition error messages are swallowed and you end up with a truncated stack trace that doesn't really tell you the problem. For example, if the connector is not authorized to list objects in the s3 bucket, the resulting stack trace gives you no indication of what went wrong.

Example stack trace of current code:

```
cp-kafka-connect-5b94d79d46-5fcx5 cp-kafka-connect 2022-05-09T19:15:56.244488779-07:00 [2022-05-10 02:15:56,243] ERROR WorkerSinkTask{id=casey-fego-s3-testing-sink-0} Task threw an uncaught and unrecoverable exception. Task is being killed and will not recover until manually restarted (org.apache.kafka.connect.runtime.WorkerTask)
cp-kafka-connect-5b94d79d46-5fcx5 cp-kafka-connect 2022-05-09T19:15:56.244501822-07:00 java.lang.IllegalStateException: fatal:
cp-kafka-connect-5b94d79d46-5fcx5 cp-kafka-connect 2022-05-09T19:15:56.244505643-07:00
cp-kafka-connect-5b94d79d46-5fcx5 cp-kafka-connect 2022-05-09T19:15:56.244508846-07:00
cp-kafka-connect-5b94d79d46-5fcx5 cp-kafka-connect 2022-05-09T19:15:56.244511930-07:00 nonFatal:
cp-kafka-connect-5b94d79d46-5fcx5 cp-kafka-connect 2022-05-09T19:15:56.244514722-07:00 Couldn't retrieve listing
cp-kafka-connect-5b94d79d46-5fcx5 cp-kafka-connect 2022-05-09T19:15:56.244517866-07:00
cp-kafka-connect-5b94d79d46-5fcx5 cp-kafka-connect 2022-05-09T19:15:56.244521181-07:00 Fatal TPs:
cp-kafka-connect-5b94d79d46-5fcx5 cp-kafka-connect 2022-05-09T19:15:56.244524274-07:00 HashSet()
cp-kafka-connect-5b94d79d46-5fcx5 cp-kafka-connect 2022-05-09T19:15:56.244527302-07:00  at io.lenses.streamreactor.connect.aws.s3.sink.S3SinkTask.handleErrors(S3SinkTask.scala:125)
cp-kafka-connect-5b94d79d46-5fcx5 cp-kafka-connect 2022-05-09T19:15:56.244530792-07:00  at io.lenses.streamreactor.connect.aws.s3.sink.S3SinkTask.open(S3SinkTask.scala:212)
cp-kafka-connect-5b94d79d46-5fcx5 cp-kafka-connect 2022-05-09T19:15:56.244534136-07:00  at org.apache.kafka.connect.runtime.WorkerSinkTask.openPartitions(WorkerSinkTask.java:644)
cp-kafka-connect-5b94d79d46-5fcx5 cp-kafka-connect 2022-05-09T19:15:56.244536986-07:00  at org.apache.kafka.connect.runtime.WorkerSinkTask.access$1200(WorkerSinkTask.java:73)
cp-kafka-connect-5b94d79d46-5fcx5 cp-kafka-connect 2022-05-09T19:15:56.244540199-07:00  at org.apache.kafka.connect.runtime.WorkerSinkTask$HandleRebalance.onPartitionsAssigned(WorkerSinkTask.java:740)
cp-kafka-connect-5b94d79d46-5fcx5 cp-kafka-connect 2022-05-09T19:15:56.244543274-07:00  at org.apache.kafka.clients.consumer.internals.ConsumerCoordinator.invokePartitionsAssigned(ConsumerCoordinator.java:296)
cp-kafka-connect-5b94d79d46-5fcx5 cp-kafka-connect 2022-05-09T19:15:56.244546317-07:00  at org.apache.kafka.clients.consumer.internals.ConsumerCoordinator.onJoinComplete(ConsumerCoordinator.java:433)
cp-kafka-connect-5b94d79d46-5fcx5 cp-kafka-connect 2022-05-09T19:15:56.244549295-07:00  at org.apache.kafka.clients.consumer.internals.AbstractCoordinator.joinGroupIfNeeded(AbstractCoordinator.java:450)
cp-kafka-connect-5b94d79d46-5fcx5 cp-kafka-connect 2022-05-09T19:15:56.244552472-07:00  at org.apache.kafka.clients.consumer.internals.AbstractCoordinator.ensureActiveGroup(AbstractCoordinator.java:366)
cp-kafka-connect-5b94d79d46-5fcx5 cp-kafka-connect 2022-05-09T19:15:56.244555928-07:00  at org.apache.kafka.clients.consumer.internals.ConsumerCoordinator.poll(ConsumerCoordinator.java:511)
cp-kafka-connect-5b94d79d46-5fcx5 cp-kafka-connect 2022-05-09T19:15:56.244559525-07:00  at org.apache.kafka.clients.consumer.KafkaConsumer.updateAssignmentMetadataIfNeeded(KafkaConsumer.java:1262)
cp-kafka-connect-5b94d79d46-5fcx5 cp-kafka-connect 2022-05-09T19:15:56.244563503-07:00  at org.apache.kafka.clients.consumer.KafkaConsumer.poll(KafkaConsumer.java:1231)
cp-kafka-connect-5b94d79d46-5fcx5 cp-kafka-connect 2022-05-09T19:15:56.244566595-07:00  at org.apache.kafka.clients.consumer.KafkaConsumer.poll(KafkaConsumer.java:1211)
cp-kafka-connect-5b94d79d46-5fcx5 cp-kafka-connect 2022-05-09T19:15:56.244569609-07:00  at org.apache.kafka.connect.runtime.WorkerSinkTask.pollConsumer(WorkerSinkTask.java:473)
cp-kafka-connect-5b94d79d46-5fcx5 cp-kafka-connect 2022-05-09T19:15:56.244572785-07:00  at org.apache.kafka.connect.runtime.WorkerSinkTask.poll(WorkerSinkTask.java:329)
cp-kafka-connect-5b94d79d46-5fcx5 cp-kafka-connect 2022-05-09T19:15:56.244575924-07:00  at org.apache.kafka.connect.runtime.WorkerSinkTask.iteration(WorkerSinkTask.java:235)
cp-kafka-connect-5b94d79d46-5fcx5 cp-kafka-connect 2022-05-09T19:15:56.244582930-07:00  at org.apache.kafka.connect.runtime.WorkerSinkTask.execute(WorkerSinkTask.java:204)
cp-kafka-connect-5b94d79d46-5fcx5 cp-kafka-connect 2022-05-09T19:15:56.244587400-07:00  at org.apache.kafka.connect.runtime.WorkerTask.doRun(WorkerTask.java:200)
cp-kafka-connect-5b94d79d46-5fcx5 cp-kafka-connect 2022-05-09T19:15:56.244591353-07:00  at org.apache.kafka.connect.runtime.WorkerTask.run(WorkerTask.java:255)
cp-kafka-connect-5b94d79d46-5fcx5 cp-kafka-connect 2022-05-09T19:15:56.244594364-07:00  at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:515)
cp-kafka-connect-5b94d79d46-5fcx5 cp-kafka-connect 2022-05-09T19:15:56.244597823-07:00  at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
cp-kafka-connect-5b94d79d46-5fcx5 cp-kafka-connect 2022-05-09T19:15:56.244600768-07:00  at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
cp-kafka-connect-5b94d79d46-5fcx5 cp-kafka-connect 2022-05-09T19:15:56.244603935-07:00  at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
cp-kafka-connect-5b94d79d46-5fcx5 cp-kafka-connect 2022-05-09T19:15:56.244607543-07:00  at java.base/java.lang.Thread.run(Thread.java:829)
```

and example stack trace after this change:

```
[2022-05-10 21:16:29,286] ERROR Error retrieving listing (io.lenses.streamreactor.connect.aws.s3.sink.seek.IndexManager)software.amazon.awssdk.services.s3.model.S3Exception: Access Denied (Service: S3, Status Code: 403, Request ID: W3XY5PBACH1NY7RX, Extended Request ID: DgPvUpaLF0iF9R5E5seeA3q2cDeKzKEYLI5+U9y7ZjNiKSC5mfa3XkbGAZq3MHYtb0vOzfooKbI=)at software.amazon.awssdk.protocols.xml.internal.unmarshall.AwsXmlPredicatedResponseHandler.handleErrorResponse(AwsXmlPredicatedResponseHandler.java:156)at software.amazon.awssdk.protocols.xml.internal.unmarshall.AwsXmlPredicatedResponseHandler.handleResponse(AwsXmlPredicatedResponseHandler.java:108)at software.amazon.awssdk.protocols.xml.internal.unmarshall.AwsXmlPredicatedResponseHandler.handle(AwsXmlPredicatedResponseHandler.java:85)at software.amazon.awssdk.protocols.xml.internal.unmarshall.AwsXmlPredicatedResponseHandler.handle(AwsXmlPredicatedResponseHandler.java:43)at software.amazon.awssdk.awscore.client.handler.AwsSyncClientHandler$Crc32ValidationResponseHandler.handle(AwsSyncClientHandler.java:95)at software.amazon.awssdk.core.internal.handler.BaseClientHandler.lambda$successTransformationResponseHandler$7(BaseClientHandler.java:245)at software.amazon.awssdk.core.internal.http.pipeline.stages.HandleResponseStage.execute(HandleResponseStage.java:40)at software.amazon.awssdk.core.internal.http.pipeline.stages.HandleResponseStage.execute(HandleResponseStage.java:30)at software.amazon.awssdk.core.internal.http.pipeline.RequestPipelineBuilder$ComposingRequestPipelineStage.execute(RequestPipelineBuilder.java:206)at software.amazon.awssdk.core.internal.http.pipeline.stages.ApiCallAttemptTimeoutTrackingStage.execute(ApiCallAttemptTimeoutTrackingStage.java:73)at software.amazon.awssdk.core.internal.http.pipeline.stages.ApiCallAttemptTimeoutTrackingStage.execute(ApiCallAttemptTimeoutTrackingStage.java:42)at software.amazon.awssdk.core.internal.http.pipeline.stages.TimeoutExceptionHandlingStage.execute(TimeoutExceptionHandlingStage.java:78)at software.amazon.awssdk.core.internal.http.pipeline.stages.TimeoutExceptionHandlingStage.execute(TimeoutExceptionHandlingStage.java:40)at software.amazon.awssdk.core.internal.http.pipeline.stages.ApiCallAttemptMetricCollectionStage.execute(ApiCallAttemptMetricCollectionStage.java:50)at software.amazon.awssdk.core.internal.http.pipeline.stages.ApiCallAttemptMetricCollectionStage.execute(ApiCallAttemptMetricCollectionStage.java:36)at software.amazon.awssdk.core.internal.http.pipeline.stages.RetryableStage.execute(RetryableStage.java:81)at software.amazon.awssdk.core.internal.http.pipeline.stages.RetryableStage.execute(RetryableStage.java:36)at software.amazon.awssdk.core.internal.http.pipeline.RequestPipelineBuilder$ComposingRequestPipelineStage.execute(RequestPipelineBuilder.java:206)at software.amazon.awssdk.core.internal.http.StreamManagingStage.execute(StreamManagingStage.java:56)at software.amazon.awssdk.core.internal.http.StreamManagingStage.execute(StreamManagingStage.java:36)at software.amazon.awssdk.core.internal.http.pipeline.stages.ApiCallTimeoutTrackingStage.executeWithTimer(ApiCallTimeoutTrackingStage.java:80)at software.amazon.awssdk.core.internal.http.pipeline.stages.ApiCallTimeoutTrackingStage.execute(ApiCallTimeoutTrackingStage.java:60)at software.amazon.awssdk.core.internal.http.pipeline.stages.ApiCallTimeoutTrackingStage.execute(ApiCallTimeoutTrackingStage.java:42)at software.amazon.awssdk.core.internal.http.pipeline.stages.ApiCallMetricCollectionStage.execute(ApiCallMetricCollectionStage.java:48)at software.amazon.awssdk.core.internal.http.pipeline.stages.ApiCallMetricCollectionStage.execute(ApiCallMetricCollectionStage.java:31)at software.amazon.awssdk.core.internal.http.pipeline.RequestPipelineBuilder$ComposingRequestPipelineStage.execute(RequestPipelineBuilder.java:206)at software.amazon.awssdk.core.internal.http.pipeline.RequestPipelineBuilder$ComposingRequestPipelineStage.execute(RequestPipelineBuilder.java:206)at software.amazon.awssdk.core.internal.http.pipeline.stages.ExecutionFailureExceptionReportingStage.execute(ExecutionFailureExceptionReportingStage.java:37)at software.amazon.awssdk.core.internal.http.pipeline.stages.ExecutionFailureExceptionReportingStage.execute(ExecutionFailureExceptionReportingStage.java:26)at software.amazon.awssdk.core.internal.http.AmazonSyncHttpClient$RequestExecutionBuilderImpl.execute(AmazonSyncHttpClient.java:193)at software.amazon.awssdk.core.internal.handler.BaseSyncClientHandler.invoke(BaseSyncClientHandler.java:103)at software.amazon.awssdk.core.internal.handler.BaseSyncClientHandler.doExecute(BaseSyncClientHandler.java:167)at software.amazon.awssdk.core.internal.handler.BaseSyncClientHandler.lambda$execute$1(BaseSyncClientHandler.java:82)at software.amazon.awssdk.core.internal.handler.BaseSyncClientHandler.measureApiCallSuccess(BaseSyncClientHandler.java:175)at software.amazon.awssdk.core.internal.handler.BaseSyncClientHandler.execute(BaseSyncClientHandler.java:76)at software.amazon.awssdk.core.client.handler.SdkSyncClientHandler.execute(SdkSyncClientHandler.java:45)at software.amazon.awssdk.awscore.client.handler.AwsSyncClientHandler.execute(AwsSyncClientHandler.java:56)at software.amazon.awssdk.services.s3.DefaultS3Client.listObjectsV2(DefaultS3Client.java:6430)at io.lenses.streamreactor.connect.aws.s3.storage.AwsS3StorageInterface.$anonfun$list$5(AwsS3StorageInterface.scala:133)at scala.util.Try$.apply(Try.scala:210)at io.lenses.streamreactor.connect.aws.s3.storage.AwsS3StorageInterface.list(AwsS3StorageInterface.scala:123)at io.lenses.streamreactor.connect.aws.s3.sink.seek.IndexManager.seek(IndexManager.scala:101)at io.lenses.streamreactor.connect.aws.s3.sink.S3WriterManager.$anonfun$seekOffsetsForTopicPartition$2(S3WriterManager.scala:142)at scala.util.Either.flatMap(Either.scala:352)at io.lenses.streamreactor.connect.aws.s3.sink.S3WriterManager.$anonfun$seekOffsetsForTopicPartition$1(S3WriterManager.scala:141)at scala.util.Either.flatMap(Either.scala:352)at io.lenses.streamreactor.connect.aws.s3.sink.S3WriterManager.seekOffsetsForTopicPartition(S3WriterManager.scala:140)at io.lenses.streamreactor.connect.aws.s3.sink.S3WriterManager.$anonfun$open$1(S3WriterManager.scala:124)at scala.collection.StrictOptimizedIterableOps.map(StrictOptimizedIterableOps.scala:99)at scala.collection.StrictOptimizedIterableOps.map$(StrictOptimizedIterableOps.scala:86)at scala.collection.immutable.HashSet.map(HashSet.scala:34)at io.lenses.streamreactor.connect.aws.s3.sink.S3WriterManager.open(S3WriterManager.scala:124)at io.lenses.streamreactor.connect.aws.s3.sink.S3SinkTask.open(S3SinkTask.scala:212)at org.apache.kafka.connect.runtime.WorkerSinkTask.openPartitions(WorkerSinkTask.java:644)at org.apache.kafka.connect.runtime.WorkerSinkTask.access$1200(WorkerSinkTask.java:73)at org.apache.kafka.connect.runtime.WorkerSinkTask$HandleRebalance.onPartitionsAssigned(WorkerSinkTask.java:740)at org.apache.kafka.clients.consumer.internals.ConsumerCoordinator.invokePartitionsAssigned(ConsumerCoordinator.java:296)at org.apache.kafka.clients.consumer.internals.ConsumerCoordinator.onJoinComplete(ConsumerCoordinator.java:433)at org.apache.kafka.clients.consumer.internals.AbstractCoordinator.joinGroupIfNeeded(AbstractCoordinator.java:450)at org.apache.kafka.clients.consumer.internals.AbstractCoordinator.ensureActiveGroup(AbstractCoordinator.java:366)at org.apache.kafka.clients.consumer.internals.ConsumerCoordinator.poll(ConsumerCoordinator.java:511)at org.apache.kafka.clients.consumer.KafkaConsumer.updateAssignmentMetadataIfNeeded(KafkaConsumer.java:1262)at org.apache.kafka.clients.consumer.KafkaConsumer.poll(KafkaConsumer.java:1231)at org.apache.kafka.clients.consumer.KafkaConsumer.poll(KafkaConsumer.java:1211)at org.apache.kafka.connect.runtime.WorkerSinkTask.pollConsumer(WorkerSinkTask.java:473)at org.apache.kafka.connect.runtime.WorkerSinkTask.poll(WorkerSinkTask.java:329)at org.apache.kafka.connect.runtime.WorkerSinkTask.iteration(WorkerSinkTask.java:235)at org.apache.kafka.connect.runtime.WorkerSinkTask.execute(WorkerSinkTask.java:204)at org.apache.kafka.connect.runtime.WorkerTask.doRun(WorkerTask.java:200)at org.apache.kafka.connect.runtime.WorkerTask.run(WorkerTask.java:255)at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:515)at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)at java.base/java.lang.Thread.run(Thread.java:829)
```