### PR TITLE
Source: Retain partitions from filename or regex

### DIFF
--- a/kafka-connect-aws-s3/src/main/scala/io/lenses/streamreactor/connect/aws/s3/config/S3ConfigDef.scala
+++ b/kafka-connect-aws-s3/src/main/scala/io/lenses/streamreactor/connect/aws/s3/config/S3ConfigDef.scala
@@ -17,7 +17,6 @@
 package io.lenses.streamreactor.connect.aws.s3.config
 
 import cats.implicits.catsSyntaxEitherId
-import com.datamountaineer.streamreactor.common.config.base.traits._
 import com.typesafe.scalalogging.LazyLogging
 import io.lenses.streamreactor.connect.aws.s3.config.processors.ConfigDefProcessor
 import io.lenses.streamreactor.connect.aws.s3.config.processors.DeprecationConfigDefProcessor
@@ -183,6 +182,28 @@ object S3ConfigDef {
       2,
       ConfigDef.Width.LONG,
       SEEK_MAX_INDEX_FILES,
+    )
+    .define(
+      SOURCE_PARTITION_EXTRACTOR_TYPE,
+      Type.STRING,
+      null,
+      Importance.LOW,
+      SOURCE_PARTITION_EXTRACTOR_TYPE_DOC,
+      "Source",
+      1,
+      ConfigDef.Width.MEDIUM,
+      SOURCE_PARTITION_EXTRACTOR_TYPE,
+    )
+    .define(
+      SOURCE_PARTITION_EXTRACTOR_REGEX,
+      Type.STRING,
+      null,
+      Importance.LOW,
+      SOURCE_PARTITION_EXTRACTOR_REGEX_DOC,
+      "Source",
+      2,
+      ConfigDef.Width.MEDIUM,
+      SOURCE_PARTITION_EXTRACTOR_REGEX,
     )
     .define(
       POOL_MAX_CONNECTIONS,

--- a/kafka-connect-aws-s3/src/main/scala/io/lenses/streamreactor/connect/aws/s3/config/S3ConfigDef.scala
+++ b/kafka-connect-aws-s3/src/main/scala/io/lenses/streamreactor/connect/aws/s3/config/S3ConfigDef.scala
@@ -17,6 +17,7 @@
 package io.lenses.streamreactor.connect.aws.s3.config
 
 import cats.implicits.catsSyntaxEitherId
+import com.datamountaineer.streamreactor.common.config.base.traits._
 import com.typesafe.scalalogging.LazyLogging
 import io.lenses.streamreactor.connect.aws.s3.config.processors.ConfigDefProcessor
 import io.lenses.streamreactor.connect.aws.s3.config.processors.DeprecationConfigDefProcessor

--- a/kafka-connect-aws-s3/src/main/scala/io/lenses/streamreactor/connect/aws/s3/config/S3ConfigSettings.scala
+++ b/kafka-connect-aws-s3/src/main/scala/io/lenses/streamreactor/connect/aws/s3/config/S3ConfigSettings.scala
@@ -16,6 +16,8 @@
 
 package io.lenses.streamreactor.connect.aws.s3.config
 
+import com.datamountaineer.streamreactor.common.config.base.const.TraitConfigConst._
+
 object S3ConfigSettings {
 
   val CONNECTOR_PREFIX = "connect.s3"

--- a/kafka-connect-aws-s3/src/main/scala/io/lenses/streamreactor/connect/aws/s3/config/S3ConfigSettings.scala
+++ b/kafka-connect-aws-s3/src/main/scala/io/lenses/streamreactor/connect/aws/s3/config/S3ConfigSettings.scala
@@ -16,8 +16,6 @@
 
 package io.lenses.streamreactor.connect.aws.s3.config
 
-import com.datamountaineer.streamreactor.common.config.base.const.TraitConfigConst._
-
 object S3ConfigSettings {
 
   val CONNECTOR_PREFIX = "connect.s3"
@@ -100,6 +98,13 @@ object S3ConfigSettings {
   val SEEK_MAX_INDEX_FILES_DOC =
     s"Maximum index files to allow per topic/partition.  Advisable to not raise this: if a large number of files build up this means there is a problem with file deletion."
   val SEEK_MAX_INDEX_FILES_DEFAULT = 5
+
+  val SOURCE_PARTITION_EXTRACTOR_TYPE = s"$CONNECTOR_PREFIX.source.partition.extractor.type"
+  val SOURCE_PARTITION_EXTRACTOR_TYPE_DOC =
+    "If you want to read to specific partitions when running the source.  Options are 'hierarchical' (to match the sink's hierarchical file storage pattern) and 'regex' (supply a custom regex).  Any other value will ignore original partitions and they should be evenly distributed through available partitions (Kafka dependent)."
+
+  val SOURCE_PARTITION_EXTRACTOR_REGEX     = s"$CONNECTOR_PREFIX.source.partition.extractor.regex"
+  val SOURCE_PARTITION_EXTRACTOR_REGEX_DOC = "If reading filename from regex, supply the regex here."
 
   val POOL_MAX_CONNECTIONS     = s"$CONNECTOR_PREFIX.pool.max.connections"
   val POOL_MAX_CONNECTIONS_DOC = "Max connections in pool.  -1: Use default according to underlying client."

--- a/kafka-connect-aws-s3/src/main/scala/io/lenses/streamreactor/connect/aws/s3/model/PartitionExtractor.scala
+++ b/kafka-connect-aws-s3/src/main/scala/io/lenses/streamreactor/connect/aws/s3/model/PartitionExtractor.scala
@@ -1,0 +1,39 @@
+package io.lenses.streamreactor.connect.aws.s3.model
+
+import com.typesafe.scalalogging.LazyLogging
+import io.lenses.streamreactor.connect.aws.s3.config.Format
+
+/**
+  * For a source, can extract the original partition so that the message can be returned to the original partition.
+  */
+sealed trait PartitionExtractor {
+
+  def extract(remoteS3Path: String): Option[Int]
+}
+
+object PartitionExtractor extends LazyLogging {
+  def apply(extractorType: String, extractorRegex: Option[String]): Option[PartitionExtractor] =
+    extractorType.toLowerCase match {
+      case "regex" =>
+        extractorRegex.fold {
+          logger.info("No regex provided for regex mode, defaulting to NoOp mode")
+          Option.empty[PartitionExtractor]
+        }(rex => Some(new RegexPartitionExtractor(rex)))
+      case "hierarchical" => Some(new HierarchicalPartitionExtractor())
+      case _              => Option.empty[PartitionExtractor]
+    }
+}
+class RegexPartitionExtractor(
+  pathRegex: String,
+) extends PartitionExtractor
+    with LazyLogging {
+  private val rc = pathRegex.r()
+  logger.debug("Initialised RegexPartitionExtractor with regex {}", pathRegex)
+  override def extract(remoteS3Path: String): Option[Int] =
+    Option(rc.findAllIn(remoteS3Path).group(1)).flatMap(_.toIntOption)
+}
+
+class HierarchicalPartitionExtractor()
+    extends RegexPartitionExtractor(
+      s"(?i)^(?:.*)\\/([0-9]*)\\/(?:[0-9]*)[.](?:${Format.values.map(_.entryName).mkString("|")})$$",
+    ) {}

--- a/kafka-connect-aws-s3/src/main/scala/io/lenses/streamreactor/connect/aws/s3/model/PollResults.scala
+++ b/kafka-connect-aws-s3/src/main/scala/io/lenses/streamreactor/connect/aws/s3/model/PollResults.scala
@@ -7,6 +7,9 @@ case class PollResults(
   resultList:    Vector[_ <: SourceData],
   bucketAndPath: RemoteS3PathLocation,
   targetTopic:   String,
+)(
+  implicit
+  partitionFn: String => Option[Int],
 ) {
 
   def toSourceRecordList: Vector[SourceRecord] =

--- a/kafka-connect-aws-s3/src/main/scala/io/lenses/streamreactor/connect/aws/s3/source/S3SourceTask.scala
+++ b/kafka-connect-aws-s3/src/main/scala/io/lenses/streamreactor/connect/aws/s3/source/S3SourceTask.scala
@@ -80,7 +80,9 @@ class S3SourceTask extends SourceTask with LazyLogging {
             bOpts.filesLimit,
             new S3SourceLister(bOpts.format.format)(sourceStorageInterface),
           ),
-          new ReaderCreator(sourceName, bOpts.format, bOpts.targetTopic)(storageInterface).create,
+          new ReaderCreator(sourceName, bOpts.format, bOpts.targetTopic)(storageInterface,
+                                                                         bOpts.getPartitionExtractorFn,
+          ).create,
         ),
       )
     } yield readerManagers

--- a/kafka-connect-aws-s3/src/main/scala/io/lenses/streamreactor/connect/aws/s3/source/reader/ReaderCreator.scala
+++ b/kafka-connect-aws-s3/src/main/scala/io/lenses/streamreactor/connect/aws/s3/source/reader/ReaderCreator.scala
@@ -1,3 +1,6 @@
+/*
+ * Copyright 2017-2022 Celonis Ltd
+ */
 package io.lenses.streamreactor.connect.aws.s3.source.reader
 
 import com.typesafe.scalalogging.LazyLogging
@@ -5,9 +8,10 @@ import io.lenses.streamreactor.connect.aws.s3.config.FormatSelection
 import io.lenses.streamreactor.connect.aws.s3.formats.S3FormatStreamReader
 import io.lenses.streamreactor.connect.aws.s3.model.SourceData
 import io.lenses.streamreactor.connect.aws.s3.model.location.RemoteS3PathLocationWithLine
+import io.lenses.streamreactor.connect.aws.s3.sink.ThrowableEither._
 import io.lenses.streamreactor.connect.aws.s3.storage.StorageInterface
 import org.apache.kafka.common.errors.OffsetOutOfRangeException
-import io.lenses.streamreactor.connect.aws.s3.sink.ThrowableEither._
+
 import scala.util.Try
 
 class ReaderCreator(
@@ -17,6 +21,7 @@ class ReaderCreator(
 )(
   implicit
   storageInterface: StorageInterface,
+  partitionFn:      String => Option[Int],
 ) extends LazyLogging {
 
   def create(pathWithLine: RemoteS3PathLocationWithLine): Either[Throwable, ResultReader] =

--- a/kafka-connect-aws-s3/src/main/scala/io/lenses/streamreactor/connect/aws/s3/source/reader/ResultReader.scala
+++ b/kafka-connect-aws-s3/src/main/scala/io/lenses/streamreactor/connect/aws/s3/source/reader/ResultReader.scala
@@ -23,8 +23,13 @@ import io.lenses.streamreactor.connect.aws.s3.model.SourceData
 
 import scala.annotation.tailrec
 
-class ResultReader(reader: S3FormatStreamReader[_ <: SourceData], targetTopic: String)
-    extends LazyLogging
+class ResultReader(
+  reader:      S3FormatStreamReader[_ <: SourceData],
+  targetTopic: String,
+)(
+  implicit
+  partitionFn: String => Option[Int],
+) extends LazyLogging
     with AutoCloseable {
 
   /**

--- a/kafka-connect-aws-s3/src/test/scala/io/lenses/streamreactor/connect/aws/s3/config/S3ConfigDefTest.scala
+++ b/kafka-connect-aws-s3/src/test/scala/io/lenses/streamreactor/connect/aws/s3/config/S3ConfigDefTest.scala
@@ -46,7 +46,7 @@ class S3ConfigDefTest extends AnyFlatSpec with Matchers {
 
   "S3ConfigDef" should "parse original properties" in {
     val resultMap = S3ConfigDef.config.parse(DefaultProps.asJava).asScala
-    resultMap should have size 20
+    resultMap should have size 22
     DeprecatedProps.filterNot { case (k, _) => k == KCQL_CONFIG }.foreach {
       case (k, _) => resultMap.get(k) should be(None)
     }
@@ -55,7 +55,7 @@ class S3ConfigDefTest extends AnyFlatSpec with Matchers {
 
   "S3ConfigDef" should "parse deprecated properties" in {
     val resultMap = S3ConfigDef.config.parse(DeprecatedProps.asJava).asScala
-    resultMap should have size 20
+    resultMap should have size 22
     DeprecatedProps.filterNot { case (k, _) => k == KCQL_CONFIG }.foreach {
       case (k, _) => resultMap.get(k) should be(None)
     }

--- a/kafka-connect-aws-s3/src/test/scala/io/lenses/streamreactor/connect/aws/s3/config/S3ConfigSettingsTest.scala
+++ b/kafka-connect-aws-s3/src/test/scala/io/lenses/streamreactor/connect/aws/s3/config/S3ConfigSettingsTest.scala
@@ -44,7 +44,7 @@ class S3ConfigSettingsTest extends AnyFlatSpec with Matchers with LazyLogging {
         case (k, _) => ignorePropertiesWithSuffix.exists(k.contains(_))
       }
 
-    docs should have size 29
+    docs should have size 31
     docs.foreach {
       case (k, v) => {
         logger.info("method: {}, value: {}", k, v)

--- a/kafka-connect-aws-s3/src/test/scala/io/lenses/streamreactor/connect/aws/s3/model/PartitionExtractorTest.scala
+++ b/kafka-connect-aws-s3/src/test/scala/io/lenses/streamreactor/connect/aws/s3/model/PartitionExtractorTest.scala
@@ -1,0 +1,18 @@
+package io.lenses.streamreactor.connect.aws.s3.model
+
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+class PartitionExtractorTest extends AnyFlatSpec with Matchers{
+
+  //"RegexPartitionExtractor" should "extract path" in {
+    //val partitionExtractor = new RegexPartitionExtractor("")
+  //}
+
+  "HierarchicalPartitionExtractor" should "extract path" in {
+    val hierarchicalPath = "streamReactorBackups/myTopic/1/2.json"
+    val partitionExtractor = new HierarchicalPartitionExtractor()
+    partitionExtractor.extract(hierarchicalPath) should be (Some(1))
+  }
+
+}

--- a/kafka-connect-aws-s3/src/test/scala/io/lenses/streamreactor/connect/aws/s3/source/reader/ResultReaderTest.scala
+++ b/kafka-connect-aws-s3/src/test/scala/io/lenses/streamreactor/connect/aws/s3/source/reader/ResultReaderTest.scala
@@ -31,6 +31,7 @@ class ResultReaderTest extends AnyFlatSpec with MockitoSugar with Matchers {
   private val targetTopic         = "MyTargetTopic"
   private val limit               = 10
   private val reader              = mock[S3FormatStreamReader[_ <: SourceData]]
+  private implicit val partitionFn : String => Option[Int] = _ => Option.empty
 
   private val result1 = StringSourceData("myJsonStuff0", 0)
   private val result2 = StringSourceData("myJsonStuff1", 1)

--- a/kafka-connect-aws-s3/src/test/scala/io/lenses/streamreactor/connect/aws/s3/source/reader/S3ReaderManagerTest.scala
+++ b/kafka-connect-aws-s3/src/test/scala/io/lenses/streamreactor/connect/aws/s3/source/reader/S3ReaderManagerTest.scala
@@ -32,6 +32,7 @@ class S3ReaderManagerTest extends AnyFlatSpec with MockitoSugar with Matchers wi
 
   private implicit val storageInterface: StorageInterface = mock[StorageInterface]
   private implicit val sourceLister:     S3SourceLister   = mock[S3SourceLister]
+  private implicit val partitionFn : String => Option[Int] = _ => Option.empty
   private val fileQueueProcessor:        SourceFileQueue  = mock[SourceFileQueue]
   private val readerCreator = mock[ReaderCreator]
 
@@ -88,7 +89,7 @@ class S3ReaderManagerTest extends AnyFlatSpec with MockitoSugar with Matchers wi
     val pollResults = PollResults(
       resultList    = Vector(StringSourceData("abc", 0)),
       bucketAndPath = firstFileBucketAndPath,
-      targetTopic   = "target",
+      targetTopic = "target",
     )
 
     val resultReader = mock[ResultReader]


### PR DESCRIPTION
This introduces new functionality to ensure that the original partitions are passed back into Kafka Connect when reading from the source.

The following two new properties are introduced:

``connect.s3.source.partition.extractor.type`` - Can either be `heirarchical` (which matches the topic/partition/offset.json format the sink uses by default) or `regex` (where you can supply a custom regular expression to extract the partition).
``connect.s3.source.partition.extractor.regex`` - If using regex, the regex to use to parse the file path and retrieve the partition.  Only one lookup group is expected.  For an example regex please see the regex for hierarchical, which is in the [source code](https://github.com/lensesio/stream-reactor/blob/3a8d972b4f9b76997ab6e47bc7c2a10ccca8b8b9/kafka-connect-aws-s3/src/main/scala/io/lenses/streamreactor/connect/aws/s3/model/PartitionExtractor.scala#L36).

