### PR TITLE
Allow toggling the skipping of MQTT Duplicates

### DIFF
--- a/kafka-connect-mqtt/src/main/scala/com/datamountaineer/streamreactor/connect/mqtt/config/MqttConfig.scala
+++ b/kafka-connect-mqtt/src/main/scala/com/datamountaineer/streamreactor/connect/mqtt/config/MqttConfig.scala
@@ -16,19 +16,12 @@
 
 package com.datamountaineer.streamreactor.connect.mqtt.config
 
-import com.datamountaineer.streamreactor.common.config.base.traits.BaseConfig
-import com.datamountaineer.streamreactor.common.config.base.traits.ConnectionSettings
-import com.datamountaineer.streamreactor.common.config.base.traits.ErrorPolicySettings
-import com.datamountaineer.streamreactor.common.config.base.traits.KcqlSettings
-import com.datamountaineer.streamreactor.common.config.base.traits.NumberRetriesSettings
-import com.datamountaineer.streamreactor.common.config.base.traits.SSLSettings
-import com.datamountaineer.streamreactor.common.config.base.traits.UserSettings
-
-import java.util
-
+import com.datamountaineer.streamreactor.common.config.base.traits._
 import org.apache.kafka.common.config.ConfigDef
 import org.apache.kafka.common.config.ConfigDef.Importance
 import org.apache.kafka.common.config.ConfigDef.Type
+
+import java.util
 
 /**
   * Created by andrew@datamountaineer.com on 27/08/2017.
@@ -238,6 +231,17 @@ object MqttSourceConfig {
       1,
       ConfigDef.Width.MEDIUM,
       MqttConfigConstants.LOG_MESSAGE_ARRIVED_DISPLAY,
+    )
+    .define(
+      MqttConfigConstants.PROCESS_DUPES_CONFIG,
+      Type.BOOLEAN,
+      false,
+      Importance.LOW,
+      MqttConfigConstants.PROCESS_DUPES_DOC,
+      "Connection",
+      1,
+      ConfigDef.Width.SHORT,
+      MqttConfigConstants.PROCESS_DUPES_DISPLAY,
     )
 }
 

--- a/kafka-connect-mqtt/src/main/scala/com/datamountaineer/streamreactor/connect/mqtt/config/MqttConfigConstants.scala
+++ b/kafka-connect-mqtt/src/main/scala/com/datamountaineer/streamreactor/connect/mqtt/config/MqttConfigConstants.scala
@@ -146,4 +146,10 @@ object MqttConfigConstants {
   val LOG_MESSAGE_ARRIVED_KEY     = s"$CONNECTOR_PREFIX.log.message"
   val LOG_MESSAGE_ARRIVED_DISPLAY = "Logs received MQTT messages"
   val LOG_MESSAGE_ARRIVED_DEFAULT = false
+
+  val PROCESS_DUPES_CONFIG = s"$CONNECTOR_PREFIX.process.duplicates"
+  val PROCESS_DUPES_DOC =
+    "Process MQTT messages that are marked as duplicates"
+  val PROCESS_DUPES_DISPLAY = "Process Duplicates"
+
 }

--- a/kafka-connect-mqtt/src/main/scala/com/datamountaineer/streamreactor/connect/mqtt/config/MqttSourceSettings.scala
+++ b/kafka-connect-mqtt/src/main/scala/com/datamountaineer/streamreactor/connect/mqtt/config/MqttSourceSettings.scala
@@ -45,6 +45,7 @@ case class MqttSourceSettings(
   enableProgress:       Boolean = MqttConfigConstants.PROGRESS_COUNTER_ENABLED_DEFAULT,
   logMessageReceived:   Boolean = false,
   avro:                 Boolean = false,
+  processDuplicates:    Boolean = false,
 ) {
 
   def asMap(): java.util.Map[String, String] = {
@@ -63,6 +64,7 @@ case class MqttSourceSettings(
     map.put(MqttConfigConstants.QS_CONFIG, mqttQualityOfService.toString)
     map.put(MqttConfigConstants.KCQL_CONFIG, kcql.mkString(";"))
     map.put(MqttConfigConstants.LOG_MESSAGE_ARRIVED_KEY, logMessageReceived.toString)
+    map.put(MqttConfigConstants.PROCESS_DUPES_CONFIG, processDuplicates.toString)
     map
   }
 }
@@ -142,7 +144,8 @@ object MqttSourceSettings {
       replicateShared,
       progressEnabled,
       config.getBoolean(MqttConfigConstants.LOG_MESSAGE_ARRIVED_KEY),
-      avro = avro,
+      avro              = avro,
+      processDuplicates = config.getBoolean(MqttConfigConstants.PROCESS_DUPES_CONFIG),
     )
   }
 }

--- a/kafka-connect-mqtt/src/main/scala/com/datamountaineer/streamreactor/connect/mqtt/source/MqttManager.scala
+++ b/kafka-connect-mqtt/src/main/scala/com/datamountaineer/streamreactor/connect/mqtt/source/MqttManager.scala
@@ -16,10 +16,6 @@
 
 package com.datamountaineer.streamreactor.connect.mqtt.source
 
-import java.util
-import java.util.Base64
-import java.util.concurrent.LinkedBlockingQueue
-import java.util.concurrent.TimeUnit
 import com.datamountaineer.kcql.Kcql
 import com.datamountaineer.streamreactor.connect.converters.source.Converter
 import com.datamountaineer.streamreactor.connect.mqtt.config.MqttSourceSettings
@@ -29,6 +25,10 @@ import org.apache.kafka.connect.source.SourceRecord
 import org.eclipse.paho.client.mqttv3._
 import org.eclipse.paho.client.mqttv3.persist.MemoryPersistence
 
+import java.util
+import java.util.Base64
+import java.util.concurrent.LinkedBlockingQueue
+import java.util.concurrent.TimeUnit
 import scala.jdk.CollectionConverters.ListHasAsScala
 
 class MqttManager(
@@ -114,7 +114,7 @@ class MqttManager(
     // is we are dealing with avro we need the wildcard to lookup the avro schema
     val sourceTopic = if (settings.avro) wildcard else topic
 
-    if (!message.isDuplicate) {
+    if (!message.isDuplicate || (settings.processDuplicates && message.isDuplicate)) {
       try {
         val keys = Option(kcql.getWithKeys).map { l =>
           val scalaList: Seq[String] = l.asScala.toSeq


### PR DESCRIPTION
This should resolve issue: #766 

This introduces a new configuration parameter:
`connect.mqtt.process.duplicates`

By default this is set to false (the current behaviour).

By setting to 'true' you instruct the MQTT source connector to process duplicates.