### PR TITLE
feat: introduce release process as gh workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,7 +1,17 @@
-
 name: CI
 
-on: [pull_request]
+on:
+  pull_request:
+  workflow_call:
+    inputs:
+      version:
+        required: true
+        type: string
+    outputs:
+      modules:
+        description: "Stream reactor collection of modules"
+        value: ${{ jobs.initiate.outputs.matrix }}
+
 jobs:
   initiate:
     timeout-minutes: 5
@@ -11,7 +21,7 @@ jobs:
       it_matrix: ${{ steps.read-mods.outputs.it-matrix }}
       fun_matrix: ${{ steps.read-mods.outputs.fun-matrix }}
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v3
       - name: Set up JDK 8
         uses: actions/setup-java@v2
         with:
@@ -28,6 +38,7 @@ jobs:
         run: sbt generateModulesList generateItModulesList generateFunModulesList
         env:
           JVM_OPTS: -Xmx3200m
+
       - name: Read modules lists
         id: read-mods
         run: |
@@ -45,7 +56,7 @@ jobs:
     timeout-minutes: 5
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v3
       - name: Set up JDK 8
         uses: actions/setup-java@v2
         with:
@@ -68,7 +79,7 @@ jobs:
       matrix:
         module: ${{fromJSON(needs.initiate.outputs.matrix)}}
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v3
       - name: Set up JDK 8
         uses: actions/setup-java@v2
         with:
@@ -101,7 +112,7 @@ jobs:
       matrix:
         module: ${{fromJSON(needs.initiate.outputs.it_matrix)}}
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v3
       - name: Set up JDK 8
         uses: actions/setup-java@v2
         with:
@@ -129,6 +140,7 @@ jobs:
   build-and-cache-assembly:
     needs:
       - initiate
+      - scalafmt
       - test
       - integration-test
     timeout-minutes: 30
@@ -137,7 +149,10 @@ jobs:
       matrix:
         module: ${{fromJSON(needs.initiate.outputs.matrix)}}
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v3
+        name: Checkout repository
+        with:
+          fetch-depth: 0
       - name: Set up JDK 8
         uses: actions/setup-java@v2
         with:
@@ -150,16 +165,29 @@ jobs:
             ~/.ivy2/cache
             ~/.sbt
           key: ${{ runner.os }}-sbt-${{ hashFiles('*.sbt') }}-${{ hashFiles('project/**') }}
+
       - name: Cache assembly
         uses: actions/cache@v3
         with:
           path: |
             ~/**/target/**/libs/*.jar
           key: ${{ runner.os }}-assembly-${{ matrix.module }}-${{ github.run_id }}
+
+      - name: Get version
+        id: version
+        shell: bash
+        run: |
+          if [ "${{ inputs.version }}" != "" ]; then
+            echo "::set-output name=version::${{ inputs.version }}"
+          else
+             echo "::set-output name=version::$(git describe --tags --always)"
+          fi
+
       - name: Build assembly
-        run: sbt "project ${{ matrix.module }};set assembly / test := {}" assembly
         env:
           JVM_OPTS: -Xmx3200m
+          VERSION: ${{ steps.version.outputs.version }}
+        run: sbt "project ${{ matrix.module }};set assembly / test := {}" assembly
 
   functional-test:
     needs:
@@ -171,7 +199,7 @@ jobs:
       matrix:
         module: ${{fromJSON(needs.initiate.outputs.fun_matrix)}}
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v3
       - name: Set up JDK 8
         uses: actions/setup-java@v2
         with:
@@ -205,6 +233,7 @@ jobs:
   upload-assembly:
     needs:
       - initiate
+      - build-and-cache-assembly
       - functional-test
     timeout-minutes: 30
     runs-on: ubuntu-latest

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -142,7 +142,7 @@ jobs:
       - initiate
       - scalafmt
       - test
-      - integration-test
+    #  - integration-test
     timeout-minutes: 30
     runs-on: ubuntu-latest
     strategy:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,97 @@
+name: Publish New Release
+
+on:
+  push:
+    tags:
+      - "*"
+  workflow_dispatch:
+
+jobs:
+  validate-tag:
+    runs-on: ubuntu-latest
+    outputs:
+      draft_release: ${{ steps.get_tag.outputs.draft_release }}
+      tag: ${{ steps.get_tag.outputs.tag }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Get tag, release mode
+        shell: bash
+        id: get_tag
+        run: |
+          if [[ ${GITHUB_REF##*/} =~ ^[0-9]\.[0-9]\.[0-9]$ ]];
+          then
+              draft_release=false
+          
+          elif [[ ${GITHUB_REF##*/} =~ ^[0-9]\.[0-9]\.[0-9]+(-(alpha|beta|rc)(\.[0-9]+)?)?(\+[A-Za-z0-9.]+)?$ ]];
+          then
+              draft_release=true
+          else
+              echo "Existing, github ref needs to be a tag with format x.y.z or x.y.z+(alpha|beta|rc)"
+              exit 1
+          fi
+          echo "::set-output name=draft_release::$draft_release"
+          echo "::set-output name=tag::${GITHUB_REF##*/}"
+
+  build:
+    needs:
+      - validate-tag
+    uses: ./.github/workflows/build.yml
+    with:
+      version: ${{ needs.validate-tag.outputs.tag }}
+    secrets: inherit
+
+  create-release:
+    runs-on: ubuntu-latest
+    needs:
+      - validate-tag
+      - build
+    strategy:
+      matrix:
+        module: ${{fromJSON(needs.build.outputs.modules)}}
+    env:
+      DRAFT_RELEASE: '${{ needs.validate-tag.outputs.draft_release }}'
+      TAG: ${{ needs.validate-tag.outputs.tag }}
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+      - name: Set up JDK 8
+        uses: actions/setup-java@v2
+        with:
+          java-version: '8'
+          distribution: 'adopt'
+
+      - name: Cache SBT
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/.ivy2/cache
+            ~/.sbt
+          key: ${{ runner.os }}-sbt-${{ hashFiles('*.sbt') }}-${{ hashFiles('project/**') }}
+
+      - name: Cache assembly
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/**/target/**/libs/*.jar
+          key: ${{ runner.os }}-assembly-${{ matrix.module }}-${{ github.run_id }}
+
+      - name: Package Connector
+        shell: bash
+        run: |
+          FOLDER=kafka-connect-${{ matrix.module }}-${{ env.TAG }}
+          mkdir -p $FOLDER
+          cp **/target/**/libs/*.jar LICENSE $FOLDER/
+          zip -r "$FOLDER.zip" $FOLDER/
+
+      - name: Upload binaries to release
+        uses: svenstaro/upload-release-action@v2
+        with:
+          file: kafka-connect-${{ matrix.module }}-${{ env.TAG }}.zip
+          asset_name: "kafka-connect-${{ matrix.module }}-${{ env.TAG }}.zip"
+          release_name: 'Stream Reactor ${{ env.TAG }}'
+          prerelease: ${{ env.DRAFT_RELEASE }}


### PR DESCRIPTION
Include release workflow to create a new release when a new tag is created.

* The release workflow will call the build.yaml workflow using the `workflow_call` pattern, so all tests and builds must be a success before publishing the new release.
* Tags must follow semantic versioning `MAJOR.MINOR.PATCH` to create a new release. To create a pre-release, add `+(alpha|beta|rc).<build>`
