### PR TITLE
Add connection pool config to S3 Connector

### DIFF
--- a/kafka-connect-aws-s3/src/main/scala/io/lenses/streamreactor/connect/aws/s3/auth/AwsS3ClientCreator.scala
+++ b/kafka-connect-aws-s3/src/main/scala/io/lenses/streamreactor/connect/aws/s3/auth/AwsS3ClientCreator.scala
@@ -67,9 +67,7 @@ class AwsS3ClientCreator(config: S3Config) {
       config.timeouts.connectionTimeout.foreach(t =>
         apacheHttpClientBuilder.connectionTimeout(Duration.ofMillis(t.toLong)),
       )
-      config.connectionPoolConfig.foreach(t =>
-        apacheHttpClientBuilder.maxConnections(t.maxConnections)
-      )
+      config.connectionPoolConfig.foreach(t => apacheHttpClientBuilder.maxConnections(t.maxConnections))
 
       val s3ClientBuilder = credentialsProvider match {
         case Left(err) => return err.asLeft

--- a/kafka-connect-aws-s3/src/main/scala/io/lenses/streamreactor/connect/aws/s3/auth/AwsS3ClientCreator.scala
+++ b/kafka-connect-aws-s3/src/main/scala/io/lenses/streamreactor/connect/aws/s3/auth/AwsS3ClientCreator.scala
@@ -67,6 +67,9 @@ class AwsS3ClientCreator(config: S3Config) {
       config.timeouts.connectionTimeout.foreach(t =>
         apacheHttpClientBuilder.connectionTimeout(Duration.ofMillis(t.toLong)),
       )
+      config.connectionPoolConfig.foreach(t =>
+        apacheHttpClientBuilder.maxConnections(t.maxConnections)
+      )
 
       val s3ClientBuilder = credentialsProvider match {
         case Left(err) => return err.asLeft

--- a/kafka-connect-aws-s3/src/main/scala/io/lenses/streamreactor/connect/aws/s3/auth/JCloudsS3ContextCreator.scala
+++ b/kafka-connect-aws-s3/src/main/scala/io/lenses/streamreactor/connect/aws/s3/auth/JCloudsS3ContextCreator.scala
@@ -98,6 +98,9 @@ class JCloudsS3ContextCreator(credentialsProviderFn: () => AwsCredentialsProvide
     awsConfig.timeouts.connectionTimeout.foreach {
       overrides.put(org.jclouds.Constants.PROPERTY_CONNECTION_TIMEOUT, _)
     }
+    awsConfig.connectionPoolConfig.foreach { t =>
+      overrides.put(org.jclouds.Constants.PROPERTY_MAX_CONNECTIONS_PER_CONTEXT, t.maxConnections)
+    }
     overrides
   }
 

--- a/kafka-connect-aws-s3/src/main/scala/io/lenses/streamreactor/connect/aws/s3/config/S3Config.scala
+++ b/kafka-connect-aws-s3/src/main/scala/io/lenses/streamreactor/connect/aws/s3/config/S3Config.scala
@@ -218,6 +218,9 @@ object S3Config {
       getInt(props, HTTP_SOCKET_TIMEOUT),
       getLong(props, HTTP_CONNECTION_TIMEOUT),
     ),
+    ConnectionPoolConfig(
+      getInt(props, POOL_MAX_CONNECTIONS)
+    )
   )
 
   private def getErrorPolicy(props: Map[String, _]) =
@@ -229,6 +232,14 @@ object S3Config {
 case class RetryConfig(numberOfRetries: Int, errorRetryInterval: Long)
 
 case class HttpTimeoutConfig(socketTimeout: Option[Int], connectionTimeout: Option[Long])
+
+case class ConnectionPoolConfig(maxConnections: Int)
+
+object ConnectionPoolConfig {
+  def apply(maxConns: Option[Int]): Option[ConnectionPoolConfig] = {
+    maxConns.filterNot(_ == -1).map(ConnectionPoolConfig(_))
+  }
+}
 
 case class S3Config(
   region:                   Option[String],
@@ -242,4 +253,5 @@ case class S3Config(
   connectorRetryConfig:     RetryConfig       = RetryConfig(NBR_OF_RETIRES_DEFAULT, ERROR_RETRY_INTERVAL_DEFAULT),
   httpRetryConfig:          RetryConfig       = RetryConfig(HTTP_NBR_OF_RETIRES_DEFAULT, HTTP_ERROR_RETRY_INTERVAL_DEFAULT),
   timeouts:                 HttpTimeoutConfig = HttpTimeoutConfig(None, None),
-)
+  connectionPoolConfig:     Option[ConnectionPoolConfig] = Option.empty
+                   )

--- a/kafka-connect-aws-s3/src/main/scala/io/lenses/streamreactor/connect/aws/s3/config/S3Config.scala
+++ b/kafka-connect-aws-s3/src/main/scala/io/lenses/streamreactor/connect/aws/s3/config/S3Config.scala
@@ -219,8 +219,8 @@ object S3Config {
       getLong(props, HTTP_CONNECTION_TIMEOUT),
     ),
     ConnectionPoolConfig(
-      getInt(props, POOL_MAX_CONNECTIONS)
-    )
+      getInt(props, POOL_MAX_CONNECTIONS),
+    ),
   )
 
   private def getErrorPolicy(props: Map[String, _]) =
@@ -236,9 +236,8 @@ case class HttpTimeoutConfig(socketTimeout: Option[Int], connectionTimeout: Opti
 case class ConnectionPoolConfig(maxConnections: Int)
 
 object ConnectionPoolConfig {
-  def apply(maxConns: Option[Int]): Option[ConnectionPoolConfig] = {
+  def apply(maxConns: Option[Int]): Option[ConnectionPoolConfig] =
     maxConns.filterNot(_ == -1).map(ConnectionPoolConfig(_))
-  }
 }
 
 case class S3Config(
@@ -247,11 +246,11 @@ case class S3Config(
   secretKey:                Option[String],
   awsClient:                AwsClient,
   authMode:                 AuthMode,
-  customEndpoint:           Option[String]    = None,
-  enableVirtualHostBuckets: Boolean           = false,
-  errorPolicy:              ErrorPolicy       = ThrowErrorPolicy(),
-  connectorRetryConfig:     RetryConfig       = RetryConfig(NBR_OF_RETIRES_DEFAULT, ERROR_RETRY_INTERVAL_DEFAULT),
-  httpRetryConfig:          RetryConfig       = RetryConfig(HTTP_NBR_OF_RETIRES_DEFAULT, HTTP_ERROR_RETRY_INTERVAL_DEFAULT),
-  timeouts:                 HttpTimeoutConfig = HttpTimeoutConfig(None, None),
-  connectionPoolConfig:     Option[ConnectionPoolConfig] = Option.empty
-                   )
+  customEndpoint:           Option[String]               = None,
+  enableVirtualHostBuckets: Boolean                      = false,
+  errorPolicy:              ErrorPolicy                  = ThrowErrorPolicy(),
+  connectorRetryConfig:     RetryConfig                  = RetryConfig(NBR_OF_RETIRES_DEFAULT, ERROR_RETRY_INTERVAL_DEFAULT),
+  httpRetryConfig:          RetryConfig                  = RetryConfig(HTTP_NBR_OF_RETIRES_DEFAULT, HTTP_ERROR_RETRY_INTERVAL_DEFAULT),
+  timeouts:                 HttpTimeoutConfig            = HttpTimeoutConfig(None, None),
+  connectionPoolConfig:     Option[ConnectionPoolConfig] = Option.empty,
+)

--- a/kafka-connect-aws-s3/src/main/scala/io/lenses/streamreactor/connect/aws/s3/config/S3ConfigDef.scala
+++ b/kafka-connect-aws-s3/src/main/scala/io/lenses/streamreactor/connect/aws/s3/config/S3ConfigDef.scala
@@ -178,13 +178,19 @@ object S3ConfigDef {
       Type.INT,
       SEEK_MAX_INDEX_FILES_DEFAULT,
       Importance.LOW,
-      SEEK_MIGRATION_DOC,
+      SEEK_MAX_INDEX_FILES_DOC,
       "Sink Seek",
       2,
       ConfigDef.Width.LONG,
       SEEK_MAX_INDEX_FILES,
     )
-
+    .define(
+      POOL_MAX_CONNECTIONS,
+      Type.INT,
+      POOL_MAX_CONNECTIONS_DEFAULT,
+      Importance.LOW,
+      POOL_MAX_CONNECTIONS_DOC,
+    )
 }
 
 class S3ConfigDef() extends ConfigDef with LazyLogging {

--- a/kafka-connect-aws-s3/src/main/scala/io/lenses/streamreactor/connect/aws/s3/config/S3ConfigSettings.scala
+++ b/kafka-connect-aws-s3/src/main/scala/io/lenses/streamreactor/connect/aws/s3/config/S3ConfigSettings.scala
@@ -101,4 +101,8 @@ object S3ConfigSettings {
     s"Maximum index files to allow per topic/partition.  Advisable to not raise this: if a large number of files build up this means there is a problem with file deletion."
   val SEEK_MAX_INDEX_FILES_DEFAULT = 5
 
+  val POOL_MAX_CONNECTIONS = s"$CONNECTOR_PREFIX.pool.max.connections"
+  val POOL_MAX_CONNECTIONS_DOC = "Max connections in pool.  -1: Use default according to underlying client."
+  val POOL_MAX_CONNECTIONS_DEFAULT: Int = -1
+
 }

--- a/kafka-connect-aws-s3/src/main/scala/io/lenses/streamreactor/connect/aws/s3/config/S3ConfigSettings.scala
+++ b/kafka-connect-aws-s3/src/main/scala/io/lenses/streamreactor/connect/aws/s3/config/S3ConfigSettings.scala
@@ -101,7 +101,7 @@ object S3ConfigSettings {
     s"Maximum index files to allow per topic/partition.  Advisable to not raise this: if a large number of files build up this means there is a problem with file deletion."
   val SEEK_MAX_INDEX_FILES_DEFAULT = 5
 
-  val POOL_MAX_CONNECTIONS = s"$CONNECTOR_PREFIX.pool.max.connections"
+  val POOL_MAX_CONNECTIONS     = s"$CONNECTOR_PREFIX.pool.max.connections"
   val POOL_MAX_CONNECTIONS_DOC = "Max connections in pool.  -1: Use default according to underlying client."
   val POOL_MAX_CONNECTIONS_DEFAULT: Int = -1
 

--- a/kafka-connect-aws-s3/src/test/scala/io/lenses/streamreactor/connect/aws/s3/config/ConnectionPoolConfigTest.scala
+++ b/kafka-connect-aws-s3/src/test/scala/io/lenses/streamreactor/connect/aws/s3/config/ConnectionPoolConfigTest.scala
@@ -1,0 +1,20 @@
+package io.lenses.streamreactor.connect.aws.s3.config
+
+import cats.implicits.catsSyntaxOptionId
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+class ConnectionPoolConfigTest extends AnyFlatSpec with Matchers {
+
+  "ConnectionPoolConfig" should "ignore -1" in {
+    ConnectionPoolConfig(Option(-1)) should be (Option.empty)
+  }
+
+  "ConnectionPoolConfig" should "ignore empty" in {
+    ConnectionPoolConfig(Option.empty) should be(Option.empty)
+  }
+
+  "ConnectionPoolConfig" should "be good with a positive int" in {
+    ConnectionPoolConfig(Some(5)) should be(ConnectionPoolConfig(5).some)
+  }
+}

--- a/kafka-connect-aws-s3/src/test/scala/io/lenses/streamreactor/connect/aws/s3/config/ConnectionPoolConfigTest.scala
+++ b/kafka-connect-aws-s3/src/test/scala/io/lenses/streamreactor/connect/aws/s3/config/ConnectionPoolConfigTest.scala
@@ -7,7 +7,7 @@ import org.scalatest.matchers.should.Matchers
 class ConnectionPoolConfigTest extends AnyFlatSpec with Matchers {
 
   "ConnectionPoolConfig" should "ignore -1" in {
-    ConnectionPoolConfig(Option(-1)) should be (Option.empty)
+    ConnectionPoolConfig(Option(-1)) should be(Option.empty)
   }
 
   "ConnectionPoolConfig" should "ignore empty" in {

--- a/kafka-connect-aws-s3/src/test/scala/io/lenses/streamreactor/connect/aws/s3/config/S3ConfigDefTest.scala
+++ b/kafka-connect-aws-s3/src/test/scala/io/lenses/streamreactor/connect/aws/s3/config/S3ConfigDefTest.scala
@@ -46,7 +46,7 @@ class S3ConfigDefTest extends AnyFlatSpec with Matchers {
 
   "S3ConfigDef" should "parse original properties" in {
     val resultMap = S3ConfigDef.config.parse(DefaultProps.asJava).asScala
-    resultMap should have size 19
+    resultMap should have size 20
     DeprecatedProps.filterNot { case (k, _) => k == KCQL_CONFIG }.foreach {
       case (k, _) => resultMap.get(k) should be(None)
     }
@@ -55,7 +55,7 @@ class S3ConfigDefTest extends AnyFlatSpec with Matchers {
 
   "S3ConfigDef" should "parse deprecated properties" in {
     val resultMap = S3ConfigDef.config.parse(DeprecatedProps.asJava).asScala
-    resultMap should have size 19
+    resultMap should have size 20
     DeprecatedProps.filterNot { case (k, _) => k == KCQL_CONFIG }.foreach {
       case (k, _) => resultMap.get(k) should be(None)
     }

--- a/kafka-connect-aws-s3/src/test/scala/io/lenses/streamreactor/connect/aws/s3/config/S3ConfigSettingsTest.scala
+++ b/kafka-connect-aws-s3/src/test/scala/io/lenses/streamreactor/connect/aws/s3/config/S3ConfigSettingsTest.scala
@@ -44,7 +44,7 @@ class S3ConfigSettingsTest extends AnyFlatSpec with Matchers with LazyLogging {
         case (k, _) => ignorePropertiesWithSuffix.exists(k.contains(_))
       }
 
-    docs should have size 28
+    docs should have size 29
     docs.foreach {
       case (k, v) => {
         logger.info("method: {}, value: {}", k, v)


### PR DESCRIPTION
This adds the following property to the S3 connector:

`connect.s3.pool.max.connections`

This can be set to a value to control the connection pool's max connections value.

The default value varies according to the library used.  For the AWS library it is 50, for Jclouds it is 30.

To use the default you can avoid defining this property, alternatively define it as -1.

