### PR TITLE
adding test and Null conversion

### DIFF
--- a/kafka-connect-aws-s3/src/main/scala/io/lenses/streamreactor/connect/aws/s3/sink/conversion/ToJsonDataConverter.scala
+++ b/kafka-connect-aws-s3/src/main/scala/io/lenses/streamreactor/connect/aws/s3/sink/conversion/ToJsonDataConverter.scala
@@ -30,6 +30,7 @@ object ToJsonDataConverter {
     case MapSinkData(map, _)          => convertMap(map)
     case ArraySinkData(iArray, _)     => convertArray(iArray)
     case ByteArraySinkData(bArray, _) => ByteBuffer.wrap(bArray)
+    case NullSinkData(_)              => null
     case _                            => throw new IllegalArgumentException("Complex array writing not currently supported")
   }.asJava
 

--- a/kafka-connect-aws-s3/src/test/scala/io/lenses/streamreactor/connect/aws/s3/sink/conversion/ToJsonDataConverterTest.scala
+++ b/kafka-connect-aws-s3/src/test/scala/io/lenses/streamreactor/connect/aws/s3/sink/conversion/ToJsonDataConverterTest.scala
@@ -16,9 +16,7 @@
 
 package io.lenses.streamreactor.connect.aws.s3.sink.conversion
 
-import io.lenses.streamreactor.connect.aws.s3.model.ArraySinkData
-import io.lenses.streamreactor.connect.aws.s3.model.MapSinkData
-import io.lenses.streamreactor.connect.aws.s3.model.StringSinkData
+import io.lenses.streamreactor.connect.aws.s3.model.{ArraySinkData, MapSinkData, NullSinkData, StringSinkData}
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 
@@ -54,6 +52,19 @@ class ToJsonDataConverterTest extends AnyFlatSpec with Matchers {
         ),
       ),
     ) should be(List(Map("abc" -> "def").asJava).asJava)
+
+  }
+
+  "convertArray" should "be able to handle null elements in an Array" in {
+
+    ToJsonDataConverter.convertArray(
+      Seq(
+        MapSinkData(
+          Map(StringSinkData("abc") -> StringSinkData("def")),
+        ),
+        NullSinkData(None)
+      ),
+    ) should be(List(Map("abc" -> "def").asJava, null).asJava)
 
   }
 }


### PR DESCRIPTION
During the deployment of a mongo cdc using the `MongoSourceConnector` we found that certain generated records where containing null elements in the generated array. 
This caused the S3 Sink connector to fail and we managed to solve the problem by patching the connector with the provided conversion to our fork. 
Porting here the fix that we used