### PR TITLE
Fix for NoClassDefFoundError caused by lack of avro4s libraries in the jar produced by sbt assembly

### DIFF
--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -204,7 +204,7 @@ object Settings extends Dependencies {
           assembly / assemblyExcludedJars := {
             val cp: Classpath = (assembly / fullClasspath).value
             cp filter { f =>
-              excludePatterns.exists(f.data.getName.contains)
+              excludePatterns.exists(f.data.getName.contains) && !f.data.getName.contains("avro4s")
             }
           },
           assembly / assemblyMergeStrategy := {


### PR DESCRIPTION
A partial fix for https://github.com/lensesio/stream-reactor/issues/839

One of the reasons for NoClassDefFoundError in MQTT connector is caused by the filtering of dependencies to be included in jar produced by `sbt assembly`. 

Since the filtering is based on `String.contains` and the list of excluded patterns include `avro` all the `avro4s` jars are also excluded despite the fact that they are needed at runtime.