### PR TITLE
S3 Sink - Wildcard Topics Support

### DIFF
--- a/kafka-connect-aws-s3/src/it/scala/io/lenses/streamreactor/connect/aws/s3/sink/S3AvroWriterManagerTest.scala
+++ b/kafka-connect-aws-s3/src/it/scala/io/lenses/streamreactor/connect/aws/s3/sink/S3AvroWriterManagerTest.scala
@@ -16,6 +16,7 @@
 
 package io.lenses.streamreactor.connect.aws.s3.sink
 
+import cats.implicits.catsSyntaxOptionId
 import io.lenses.streamreactor.connect.aws.s3.config.Format.Avro
 import io.lenses.streamreactor.connect.aws.s3.config.AuthMode
 import io.lenses.streamreactor.connect.aws.s3.config.AwsClient
@@ -57,7 +58,7 @@ class S3AvroWriterManagerTest extends AnyFlatSpec with Matchers with S3ProxyCont
     ),
     bucketOptions = Set(
       SinkBucketOptions(
-        TopicName,
+        TopicName.some,
         bucketAndPrefix,
         commitPolicy       = DefaultCommitPolicy(None, None, Some(2)),
         formatSelection    = FormatSelection(Avro),

--- a/kafka-connect-aws-s3/src/it/scala/io/lenses/streamreactor/connect/aws/s3/sink/S3JsonWriterManagerTest.scala
+++ b/kafka-connect-aws-s3/src/it/scala/io/lenses/streamreactor/connect/aws/s3/sink/S3JsonWriterManagerTest.scala
@@ -16,6 +16,7 @@
 
 package io.lenses.streamreactor.connect.aws.s3.sink
 
+import cats.implicits.catsSyntaxOptionId
 import io.lenses.streamreactor.connect.aws.s3.config.Format.Json
 import io.lenses.streamreactor.connect.aws.s3.config.AuthMode
 import io.lenses.streamreactor.connect.aws.s3.config.AwsClient
@@ -55,7 +56,7 @@ class S3JsonWriterManagerTest extends AnyFlatSpec with Matchers with S3ProxyCont
       ),
       bucketOptions = Set(
         SinkBucketOptions(
-          TopicName,
+          TopicName.some,
           bucketAndPrefix,
           commitPolicy       = DefaultCommitPolicy(None, None, Some(1)),
           formatSelection    = FormatSelection(Json),
@@ -94,7 +95,7 @@ class S3JsonWriterManagerTest extends AnyFlatSpec with Matchers with S3ProxyCont
       ),
       bucketOptions = Set(
         SinkBucketOptions(
-          TopicName,
+          TopicName.some,
           bucketAndPrefix,
           commitPolicy       = DefaultCommitPolicy(None, None, Some(3)),
           formatSelection    = FormatSelection(Json),

--- a/kafka-connect-aws-s3/src/it/scala/io/lenses/streamreactor/connect/aws/s3/sink/S3ParquetWriterManagerTest.scala
+++ b/kafka-connect-aws-s3/src/it/scala/io/lenses/streamreactor/connect/aws/s3/sink/S3ParquetWriterManagerTest.scala
@@ -16,6 +16,7 @@
 
 package io.lenses.streamreactor.connect.aws.s3.sink
 
+import cats.implicits.catsSyntaxOptionId
 import io.lenses.streamreactor.connect.aws.s3.config.Format.Parquet
 import io.lenses.streamreactor.connect.aws.s3.config.AuthMode
 import io.lenses.streamreactor.connect.aws.s3.config.AwsClient
@@ -58,7 +59,7 @@ class S3ParquetWriterManagerTest extends AnyFlatSpec with Matchers with S3ProxyC
     ),
     bucketOptions = Set(
       SinkBucketOptions(
-        TopicName,
+        TopicName.some,
         bucketAndPrefix,
         commitPolicy       = DefaultCommitPolicy(None, None, Some(2)),
         fileNamingStrategy = new HierarchicalS3FileNamingStrategy(FormatSelection(Parquet)),

--- a/kafka-connect-aws-s3/src/main/scala/io/lenses/streamreactor/connect/aws/s3/sink/S3WriterManager.scala
+++ b/kafka-connect-aws-s3/src/main/scala/io/lenses/streamreactor/connect/aws/s3/sink/S3WriterManager.scala
@@ -376,6 +376,6 @@ object S3WriterManager extends LazyLogging {
   }
 
   private def bucketOptsForTopic(config: S3SinkConfig, topic: Topic): Option[SinkBucketOptions] =
-    config.bucketOptions.find(_.sourceTopic == topic.value)
+    config.bucketOptions.find(bo => bo.sourceTopic.isEmpty || bo.sourceTopic.contains(topic.value))
 
 }

--- a/kafka-connect-aws-s3/src/main/scala/io/lenses/streamreactor/connect/aws/s3/sink/config/S3SinkConfig.scala
+++ b/kafka-connect-aws-s3/src/main/scala/io/lenses/streamreactor/connect/aws/s3/sink/config/S3SinkConfig.scala
@@ -77,7 +77,7 @@ object SinkBucketOptions extends LazyLogging {
       val stagingArea = LocalStagingArea(config)
       stagingArea match {
         case Right(value) => SinkBucketOptions(
-            kcql.getSource,
+            Option(kcql.getSource).filterNot(Set("*", "`*`").contains(_)),
             RemoteS3RootLocation(kcql.getTarget),
             formatSelection    = formatSelection,
             fileNamingStrategy = namingStrategy,
@@ -92,13 +92,13 @@ object SinkBucketOptions extends LazyLogging {
 }
 
 case class SinkBucketOptions(
-  sourceTopic:        String,
+  sourceTopic:        Option[String],
   bucketAndPrefix:    RemoteS3RootLocation,
   formatSelection:    FormatSelection,
   fileNamingStrategy: S3FileNamingStrategy,
   partitionSelection: Option[PartitionSelection] = None,
   commitPolicy: CommitPolicy = DefaultCommitPolicy(Some(defaultFlushSize.toLong), Some(defaultFlushInterval),
-    Some(defaultFlushCount.toLong)),
+    Some(defaultFlushCount)),
   localStagingArea: LocalStagingArea,
 )
 


### PR DESCRIPTION
Enable wildcard syntax to support multiple topics without additional configuration via KCQL.

Following this PR you will be able to do:

**`connect.s3.kcql`** 
```
 insert into $BucketName:$PrefixName select * from `*`
```
