### PR TITLE
Return the manifest to its former glory.

### DIFF
--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -170,7 +170,10 @@ object Settings extends Dependencies {
     def configureAssembly(): Project =
       project.settings(
         settings ++ Seq(
-          assembly / assemblyOutputPath := file(target.value + "/libs/" + (assembly / assemblyJarName).value),
+          assembly / assemblyOutputPath := {
+            file(target.value + "/libs/").mkdirs()
+            file(target.value + "/libs/" + (assembly / assemblyJarName).value)
+          },
           assembly / assemblyExcludedJars := {
             val cp: Classpath = (assembly / fullClasspath).value
             cp filter { f =>

--- a/project/assembly.sbt
+++ b/project/assembly.sbt
@@ -1,1 +1,1 @@
-addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "1.2.0")
+addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "2.1.1")


### PR DESCRIPTION
This is the contents of the manifest (testing locally)

```
Manifest-Version: 1.0
Specification-Title: kafka-connect-common
Specification-Version: 1.1-SNAPSHOT
Specification-Vendor: io.lenses
Implementation-Title: kafka-connect-common
Implementation-Version: 1.1-SNAPSHOT
Implementation-Vendor: io.lenses
Implementation-Vendor-Id: io.lenses
Git-Commit-Hash: 0be0c01b7e2347c9e969422b61ecdf8bab90e852
Git-Repo: git@github.com:lensesio/stream-reactor.git
Git-Tag: n/a
Kafka-Version: 3.3.0
StreamReactor-Version: 1.1-SNAPSHOT
StreamReactor-Docs: https://docs.lenses.io/5.0/integrations/connectors/s
 tream-reactor/

```