### PR TITLE
Build system updates and improvements

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -37,7 +37,6 @@ object Dependencies {
     "confluent" at "https://packages.confluent.io/maven/",
     "typesafe" at "https://repo.typesafe.com/typesafe/releases/",
     "cloudera" at "https://repository.cloudera.com/artifactory/cloudera-repos/",
-    "conjars" at "https://conjars.org/repo",
     "jitpack" at "https://jitpack.io",
     "twitter" at "https://maven.twttr.com/",
   )
@@ -109,7 +108,7 @@ object Dependencies {
 
     val azureDocumentDbVersion          = "2.6.5"
     val scalaParallelCollectionsVersion = "1.0.4"
-    val testcontainersScalaVersion      = "0.40.12"
+    val testcontainersScalaVersion      = "0.40.14"
     val testcontainersVersion           = "1.17.6"
 
     val hazelCastVersion          = "4.2.7"

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -25,8 +25,8 @@ import scala.sys.process._
 object Settings extends Dependencies {
 
   // keep the SNAPSHOT version numerically higher than the latest release.
-  val majorVersion        = "1.0"
-  val nextSnapshotVersion = "1.1"
+  val majorVersion        = "4.2"
+  val nextSnapshotVersion = "4.3"
 
   val artifactVersion: String = {
     val maybeGithubRunId = sys.env.get("github_run_id")
@@ -41,7 +41,7 @@ object Settings extends Dependencies {
 
   val licenseHeader: String = {
     val currentYear = Calendar.getInstance().get(Calendar.YEAR)
-    s"Copyright 2017-$currentYear Celonis Ltd"
+    s"Copyright 2017-$currentYear Lenses.io Ltd"
   }
 
   object ScalacFlags {

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -9,3 +9,5 @@ addSbtPlugin("com.typesafe.sbt"  % "sbt-license-report" % "1.2.0")
 addSbtPlugin("net.vonbuchholtz" % "sbt-dependency-check" % "4.0.0")
 
 addSbtPlugin("org.xerial.sbt" % "sbt-pack" % "0.14")
+
+addSbtPlugin("com.typesafe.sbt" % "sbt-license-report" % "1.2.0")


### PR DESCRIPTION
- Remove obsolete repository "codejars"
- Add sbt-license-report plugin so we can provide BOM for 3rd party libraries and their licenses
- Set version to 4.2 as it had remained to 1.0 to assist with local builds
- Switch back copyright to Lenses.io Ltd

[OPS-2177]

[OPS-2177]: https://landoop.atlassian.net/browse/OPS-2177?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ