### PR TITLE
Upgrade to Influxdb2 client

### DIFF
--- a/kafka-connect-common/src/main/scala/com/datamountaineer/streamreactor/common/config/base/traits/ConsistencyLevelSettings.scala
+++ b/kafka-connect-common/src/main/scala/com/datamountaineer/streamreactor/common/config/base/traits/ConsistencyLevelSettings.scala
@@ -33,7 +33,13 @@ trait ConsistencyLevelSettings[T <: Enum[T]] extends BaseSettings {
     val consistencyLevel = getString(consistencyLevelConstant) match {
       case "" => None
       case other =>
-        Try(Enum.valueOf[T](enum, other)) match {
+        Try(Enum.valueOf[T](enum, other))
+          .orElse(
+            Try(Enum.valueOf[T](enum, other.toLowerCase)),
+          )
+          .orElse(
+            Try(Enum.valueOf[T](enum, other.toUpperCase)),
+          ) match {
           case Failure(_) =>
             throw new ConfigException(s"'$other' is not a valid $consistencyLevelConstant. " +
               s"Available values are:${`enum`.getEnumConstants.map(_.toString).mkString(",")}")

--- a/kafka-connect-influxdb/src/main/scala/com/datamountaineer/streamreactor/connect/influx/config/InfluxConfig.scala
+++ b/kafka-connect-influxdb/src/main/scala/com/datamountaineer/streamreactor/connect/influx/config/InfluxConfig.scala
@@ -28,7 +28,7 @@ import java.util
 import org.apache.kafka.common.config.ConfigDef
 import org.apache.kafka.common.config.ConfigDef.Importance
 import org.apache.kafka.common.config.ConfigDef.Type
-import org.influxdb.InfluxDB.ConsistencyLevel
+import com.influxdb.client.domain.WriteConsistency
 
 object InfluxConfig {
 
@@ -163,5 +163,5 @@ case class InfluxConfig(props: util.Map[String, String])
     with ErrorPolicySettings
     with NumberRetriesSettings
     with DatabaseSettings
-    with ConsistencyLevelSettings[ConsistencyLevel]
+    with ConsistencyLevelSettings[WriteConsistency]
     with UserSettings

--- a/kafka-connect-influxdb/src/main/scala/com/datamountaineer/streamreactor/connect/influx/config/InfluxSettings.scala
+++ b/kafka-connect-influxdb/src/main/scala/com/datamountaineer/streamreactor/connect/influx/config/InfluxSettings.scala
@@ -19,7 +19,7 @@ import com.datamountaineer.kcql.Kcql
 import com.datamountaineer.streamreactor.common.errors.ErrorPolicy
 import com.datamountaineer.streamreactor.common.errors.ThrowErrorPolicy
 import org.apache.kafka.common.config.ConfigException
-import org.influxdb.InfluxDB.ConsistencyLevel
+import com.influxdb.client.domain.WriteConsistency
 
 case class InfluxSettings(
   connectionUrl:    String,
@@ -27,7 +27,7 @@ case class InfluxSettings(
   password:         String,
   database:         String,
   retentionPolicy:  String,
-  consistencyLevel: ConsistencyLevel,
+  consistencyLevel: WriteConsistency,
   /*topicToMeasurementMap: Map[String, String],
                           fieldsExtractorMap: Map[String, StructFieldsExtractor],
                           topicToTagsMap: Map[String, Seq[Tag]]*/

--- a/kafka-connect-influxdb/src/test/scala/com/datamountaineer/streamreactor/connect/influx/config/InfluxSettingsTest.scala
+++ b/kafka-connect-influxdb/src/test/scala/com/datamountaineer/streamreactor/connect/influx/config/InfluxSettingsTest.scala
@@ -17,8 +17,8 @@ package com.datamountaineer.streamreactor.connect.influx.config
 
 import com.datamountaineer.kcql.Kcql
 import com.datamountaineer.streamreactor.common.errors.ThrowErrorPolicy
+import com.influxdb.client.domain.WriteConsistency
 import org.apache.kafka.common.config.ConfigException
-import org.influxdb.InfluxDB.ConsistencyLevel
 import org.mockito.MockitoSugar
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
@@ -112,7 +112,7 @@ class InfluxSettingsTest extends AnyWordSpec with Matchers with MockitoSugar {
       InfluxConfigConstants.INFLUX_DATABASE_CONFIG        -> database,
       InfluxConfigConstants.INFLUX_CONNECTION_USER_CONFIG -> user,
       InfluxConfigConstants.KCQL_CONFIG                   -> QUERY_ALL,
-      InfluxConfigConstants.CONSISTENCY_CONFIG            -> ConsistencyLevel.QUORUM.toString,
+      InfluxConfigConstants.CONSISTENCY_CONFIG            -> WriteConsistency.QUORUM.toString,
     ).asJava
 
     val config = InfluxConfig(props)
@@ -139,7 +139,7 @@ class InfluxSettingsTest extends AnyWordSpec with Matchers with MockitoSugar {
       InfluxConfigConstants.INFLUX_CONNECTION_USER_CONFIG     -> user,
       InfluxConfigConstants.INFLUX_CONNECTION_PASSWORD_CONFIG -> pass,
       InfluxConfigConstants.KCQL_CONFIG                       -> QUERY_SELECT,
-      InfluxConfigConstants.CONSISTENCY_CONFIG                -> ConsistencyLevel.ANY.toString,
+      InfluxConfigConstants.CONSISTENCY_CONFIG                -> WriteConsistency.ANY.toString,
     ).asJava
 
     val config = InfluxConfig(props)
@@ -167,7 +167,7 @@ class InfluxSettingsTest extends AnyWordSpec with Matchers with MockitoSugar {
       InfluxConfigConstants.INFLUX_CONNECTION_USER_CONFIG     -> user,
       InfluxConfigConstants.INFLUX_CONNECTION_PASSWORD_CONFIG -> pass,
       InfluxConfigConstants.KCQL_CONFIG                       -> QUERY_SELECT_AND_TIMESTAMP,
-      InfluxConfigConstants.CONSISTENCY_CONFIG                -> ConsistencyLevel.ONE.toString,
+      InfluxConfigConstants.CONSISTENCY_CONFIG                -> WriteConsistency.ONE.toString,
     ).asJava
 
     val config = InfluxConfig(props)
@@ -181,7 +181,7 @@ class InfluxSettingsTest extends AnyWordSpec with Matchers with MockitoSugar {
     settings.kcqls.size shouldBe 1
     settings.kcqls.head.getFields.asScala.exists(_.getName == "*") shouldBe true
     settings.kcqls.head.getTimestamp shouldBe "ts"
-    settings.consistencyLevel shouldBe ConsistencyLevel.ONE
+    settings.consistencyLevel shouldBe WriteConsistency.ONE
   }
 
   "create a settings with selected fields with timestamp set to a sys_timestamp" in {
@@ -196,7 +196,7 @@ class InfluxSettingsTest extends AnyWordSpec with Matchers with MockitoSugar {
       InfluxConfigConstants.INFLUX_CONNECTION_USER_CONFIG     -> user,
       InfluxConfigConstants.INFLUX_CONNECTION_PASSWORD_CONFIG -> pass,
       InfluxConfigConstants.KCQL_CONFIG                       -> QUERY_SELECT_AND_TIMESTAMP_SYSTEM,
-      InfluxConfigConstants.CONSISTENCY_CONFIG                -> ConsistencyLevel.ONE.toString,
+      InfluxConfigConstants.CONSISTENCY_CONFIG                -> WriteConsistency.ONE.toString,
     ).asJava
 
     val config = InfluxConfig(props)

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -119,7 +119,7 @@ object Dependencies {
 
     val javaxCacheVersion = "1.1.1"
 
-    val influxVersion = "2.23"
+    val influxVersion = "6.8.0"
 
     val jmsApiVersion                 = "2.0.1"
     val activeMqVersion               = "5.17.0"
@@ -384,8 +384,8 @@ object Dependencies {
 
   lazy val hazelCastAll = "com.hazelcast" % "hazelcast-all" % hazelCastVersion
 
-  lazy val javaxCache = "javax.cache"  % "cache-api"     % javaxCacheVersion
-  lazy val influx     = "org.influxdb" % "influxdb-java" % influxVersion
+  lazy val javaxCache = "javax.cache"  % "cache-api"            % javaxCacheVersion
+  lazy val influx     = "com.influxdb" % "influxdb-client-java" % influxVersion
 
   lazy val jmsApi         = "javax.jms"           % "javax.jms-api"   % jmsApiVersion
   lazy val activeMq       = "org.apache.activemq" % "activemq-client" % activeMqVersion


### PR DESCRIPTION
Upgrading to use the InfluxDB2 client.

Note: This doesn't yet support Influxdb2 connections but uses the InfluxDB1 compatibility.
This lays the groundwork for supporting both InfluxDB releases within the same module.