### PR TITLE
Connector Logging Configuration

### DIFF
--- a/kafka-connect-aws-s3/src/main/scala/io/lenses/streamreactor/connect/aws/s3/config/S3ConfigDef.scala
+++ b/kafka-connect-aws-s3/src/main/scala/io/lenses/streamreactor/connect/aws/s3/config/S3ConfigDef.scala
@@ -16,6 +16,7 @@
 package io.lenses.streamreactor.connect.aws.s3.config
 
 import cats.implicits.catsSyntaxEitherId
+import cats.implicits.toBifunctorOps
 import com.datamountaineer.streamreactor.common.config.base.traits._
 import com.typesafe.scalalogging.LazyLogging
 import io.lenses.streamreactor.connect.aws.s3.config.processors.ConfigDefProcessor
@@ -97,6 +98,13 @@ object S3ConfigDef {
       "",
       Importance.LOW,
       s"Local tmp directory for preparing the files",
+    )
+    .define(
+      LOG_LEVEL_OVERRIDE,
+      Type.STRING,
+      "DEFAULT",
+      Importance.LOW,
+      LOG_LEVEL_OVERRIDE_DOC,
     )
     .define(KCQL_CONFIG, Type.STRING, Importance.HIGH, KCQL_DOC)
     .define(
@@ -297,7 +305,10 @@ case class S3ConfigDefBuilder(sinkName: Option[String], props: util.Map[String, 
     with ConnectionSettings
     with S3FlushSettings
     with CompressionCodecSettings
-    with PaddingStrategySettings {
+    with PaddingStrategySettings
+    with LogOverrideSettings {
+
+  configureLoggingOverrides().leftMap(throw _)
 
   def getParsedValues: Map[String, _] = values().asScala.toMap
 

--- a/kafka-connect-aws-s3/src/main/scala/io/lenses/streamreactor/connect/aws/s3/config/S3ConfigSettings.scala
+++ b/kafka-connect-aws-s3/src/main/scala/io/lenses/streamreactor/connect/aws/s3/config/S3ConfigSettings.scala
@@ -128,4 +128,9 @@ object S3ConfigSettings {
   val PADDING_LENGTH         = s"$CONNECTOR_PREFIX.padding.length"
   val PADDING_LENGTH_DOC     = s"Length to pad the string up to if $PADDING_STRATEGY is set."
   val PADDING_LENGTH_DEFAULT = 8
+
+  val LOG_LEVEL_OVERRIDE = s"$CONNECTOR_PREFIX.log.level.override"
+  val LOG_LEVEL_OVERRIDE_DOC =
+    "Override the log level of the classes provided by the connector.  Useful if it can't be set in the environment (eg MSK). Options: DEFAULT, OFF, ERROR, WARN, INFO, DEBUG, TRACE, ALL"
+
 }

--- a/kafka-connect-aws-s3/src/test/scala/io/lenses/streamreactor/connect/aws/s3/config/S3ConfigDefTest.scala
+++ b/kafka-connect-aws-s3/src/test/scala/io/lenses/streamreactor/connect/aws/s3/config/S3ConfigDefTest.scala
@@ -46,7 +46,7 @@ class S3ConfigDefTest extends AnyFlatSpec with Matchers {
 
   "S3ConfigDef" should "parse original properties" in {
     val resultMap = S3ConfigDef.config.parse(DefaultProps.asJava).asScala
-    resultMap should have size 26
+    resultMap should have size 27
     DeprecatedProps.filterNot { case (k, _) => k == KCQL_CONFIG }.foreach {
       case (k, _) => resultMap.get(k) should be(None)
     }
@@ -55,7 +55,7 @@ class S3ConfigDefTest extends AnyFlatSpec with Matchers {
 
   "S3ConfigDef" should "parse deprecated properties" in {
     val resultMap = S3ConfigDef.config.parse(DeprecatedProps.asJava).asScala
-    resultMap should have size 26
+    resultMap should have size 27
     DeprecatedProps.filterNot { case (k, _) => k == KCQL_CONFIG }.foreach {
       case (k, _) => resultMap.get(k) should be(None)
     }

--- a/kafka-connect-aws-s3/src/test/scala/io/lenses/streamreactor/connect/aws/s3/config/S3ConfigSettingsTest.scala
+++ b/kafka-connect-aws-s3/src/test/scala/io/lenses/streamreactor/connect/aws/s3/config/S3ConfigSettingsTest.scala
@@ -43,7 +43,7 @@ class S3ConfigSettingsTest extends AnyFlatSpec with Matchers with LazyLogging {
         case (k, _) => ignorePropertiesWithSuffix.exists(k.contains(_))
       }
 
-    docs should have size 35
+    docs should have size 36
     docs.foreach {
       case (k, v) => {
         logger.info("method: {}, value: {}", k, v)

--- a/kafka-connect-common/src/main/scala/com/datamountaineer/streamreactor/common/config/base/const/TraitConfigConst.scala
+++ b/kafka-connect-common/src/main/scala/com/datamountaineer/streamreactor/common/config/base/const/TraitConfigConst.scala
@@ -47,5 +47,6 @@ object TraitConfigConst {
   val CONNECTION_PORTS_SUFFIX    = "ports"
   val WRITE_TIMEOUT_SUFFIX       = "write.timeout"
   val SCHEMA_REGISTRY_SUFFIX     = "schema.registry.url"
+  val LOG_LEVEL_OVERRIDE         = "log.level.override"
 
 }

--- a/kafka-connect-common/src/main/scala/com/datamountaineer/streamreactor/common/config/base/traits/LogOverrideSettings.scala
+++ b/kafka-connect-common/src/main/scala/com/datamountaineer/streamreactor/common/config/base/traits/LogOverrideSettings.scala
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2017-2023 Lenses.io Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datamountaineer.streamreactor.common.config.base.traits
+
+import cats.implicits.catsSyntaxEitherId
+import ch.qos.logback.classic.Level
+import com.datamountaineer.streamreactor.common.config.base.const.TraitConfigConst._
+import org.apache.kafka.connect.errors.ConnectException
+import org.slf4j.LoggerFactory
+
+import scala.util.Try
+
+trait LogOverrideSettings extends BaseSettings {
+
+  private val CONNECTOR_LOG_LEVEL_OVERRIDE = s"$connectorPrefix.$LOG_LEVEL_OVERRIDE"
+  private val PACKAGES                     = Set("io.lenses", "com.datamountaineer")
+
+  def configureLoggingOverrides(): Either[Throwable, Unit] = {
+    val lvl = getString(CONNECTOR_LOG_LEVEL_OVERRIDE).toUpperCase
+    if (lvl != "DEFAULT") {
+      val (bad, _) = PACKAGES.map(pkg => setLevel(lvl, pkg)).partitionMap(identity)
+      bad.headOption.map(new ConnectException("Unable to configure logging level (first err)", _)).toLeft(())
+    } else ().asRight
+  }
+  private def setLevel(level: String, pkg: String): Either[Throwable, Unit] =
+    Try {
+      val _             = LoggerFactory.getLogger(pkg)
+      val classicLogger = org.slf4j.LoggerFactory.getLogger(pkg).asInstanceOf[ch.qos.logback.classic.Logger]
+      classicLogger.setLevel(Level.toLevel(level))
+    }.toEither
+
+}

--- a/kafka-connect-common/src/test/scala/com/datamountaineer/streamreactor/common/config/base/traits/LogOverrideSettingsTest.scala
+++ b/kafka-connect-common/src/test/scala/com/datamountaineer/streamreactor/common/config/base/traits/LogOverrideSettingsTest.scala
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2017-2023 Lenses.io Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datamountaineer.streamreactor.common.config.base.traits
+
+import ch.qos.logback.classic.Logger
+import ch.qos.logback.classic.spi.ILoggingEvent
+import ch.qos.logback.core.read.ListAppender
+import com.typesafe.scalalogging.LazyLogging
+import org.scalatest.flatspec.AnyFlatSpecLike
+import org.scalatest.matchers.should.Matchers
+import org.slf4j.LoggerFactory
+
+import scala.jdk.CollectionConverters.ListHasAsScala
+import scala.util.Using
+
+class LogOverrideSettingsTest extends AnyFlatSpecLike with Matchers with LazyLogging {
+
+  "logOverrideSettings" should "be able to disable logging" in {
+    val testLoggerConfig = new TestLoggerConfig(Map("cp.log.level.override" -> "OFF"))
+    testLoggerConfig.configureLoggingOverrides()
+
+    Using.resource(new LogWatcher) {
+      lw =>
+        logSomething()
+        lw.getLogs() should be(empty)
+    }
+  }
+
+  "logOverrideSettings" should "be able to enable debug logging" in {
+    val testLoggerConfig = new TestLoggerConfig(Map("cp.log.level.override" -> "DEBUG"))
+    testLoggerConfig.configureLoggingOverrides()
+
+    Using.resource(new LogWatcher) {
+      lw =>
+        logSomething()
+        lw.getLogs() should have size 1
+        lw.getLogs().head.getMessage should be("Something")
+    }
+  }
+
+  class LogWatcher extends AutoCloseable {
+
+    private val listAppender = createListAppender()
+    getDMLogger().addAppender(listAppender)
+
+    def getLogs(): Seq[ILoggingEvent] = listAppender.list.asScala.toSeq
+
+    override def close(): Unit = listAppender.stop
+
+    private def createListAppender(): ListAppender[ILoggingEvent] = {
+      val listAppender = new ListAppender[ILoggingEvent]
+      listAppender.start()
+      listAppender
+    }
+    private def getDMLogger() = LoggerFactory.getLogger("com.datamountaineer").asInstanceOf[Logger]
+  }
+
+  private def logSomething() =
+    logger.debug("Something")
+
+}

--- a/kafka-connect-common/src/test/scala/com/datamountaineer/streamreactor/common/config/base/traits/TestLoggerConfig.scala
+++ b/kafka-connect-common/src/test/scala/com/datamountaineer/streamreactor/common/config/base/traits/TestLoggerConfig.scala
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2017-2023 Lenses.io Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datamountaineer.streamreactor.common.config.base.traits
+
+import com.typesafe.scalalogging.LazyLogging
+import org.apache.kafka.common.config.types.Password
+import org.scalatest.Assertions.fail
+
+import java.lang
+import java.util
+
+class TestLoggerConfig(props: Map[String, String]) extends LogOverrideSettings with LazyLogging {
+  override def connectorPrefix: String = "cp"
+
+  override def getString(key: String): String = props.get(key).head
+
+  override def getInt(key: String): Integer = fail("Unimplemented")
+
+  override def getBoolean(key: String): lang.Boolean = fail("Unimplemented")
+
+  override def getPassword(key: String): Password = fail("Unimplemented")
+
+  override def getList(key: String): util.List[String] = fail("Unimplemented")
+
+}


### PR DESCRIPTION
Allow configuring logging via connector configuration - (currently S3 connector only)

This introduces a new property for the AWS S3 connector:

`connect.s3.log.level.override`

The values this can take are: `DEFAULT`, `OFF`, `ERROR`, `WARN`, `INFO`, `DEBUG`, `TRACE`, `ALL`.  If not specified `DEFAULT` will be used and the logging behaviour will be unchanged from previous releases.

This impacts the log levels of the connector code (anything under the packages `io.lenses` and `com.datamountaineer`).

This allows configuration of the logging levels for systems eg MSK where the Kafka Connect logging API is not available.