### PR TITLE
Fix division by zero bug

### DIFF
--- a/kafka-connect-aws-s3/src/it/scala/io/lenses/streamreactor/connect/aws/s3/sink/S3AvroWriterManagerTest.scala
+++ b/kafka-connect-aws-s3/src/it/scala/io/lenses/streamreactor/connect/aws/s3/sink/S3AvroWriterManagerTest.scala
@@ -20,7 +20,6 @@ import cats.implicits.catsSyntaxOptionId
 import io.lenses.streamreactor.connect.aws.s3.config.Format.Avro
 import io.lenses.streamreactor.connect.aws.s3.config.AuthMode
 import io.lenses.streamreactor.connect.aws.s3.config.ConnectorTaskId
-import io.lenses.streamreactor.connect.aws.s3.config.InitedConnectorTaskId
 import io.lenses.streamreactor.connect.aws.s3.config.AwsClient
 import io.lenses.streamreactor.connect.aws.s3.config.FormatSelection
 import io.lenses.streamreactor.connect.aws.s3.config.S3Config
@@ -53,7 +52,7 @@ class S3AvroWriterManagerTest extends AnyFlatSpec with Matchers with S3ProxyCont
   private val PathPrefix       = "streamReactorBackups"
   private val avroFormatReader = new AvroFormatReader
 
-  private implicit val connectorTaskId: ConnectorTaskId = InitedConnectorTaskId("sinkName", 1, 1)
+  private implicit val connectorTaskId: ConnectorTaskId = ConnectorTaskId("sinkName", 1, 1)
   private val bucketAndPrefix = RemoteS3RootLocation(BucketName, Some(PathPrefix), allowSlash = false)
   private def avroConfig = S3SinkConfig(
     S3Config(

--- a/kafka-connect-aws-s3/src/it/scala/io/lenses/streamreactor/connect/aws/s3/sink/S3JsonWriterManagerTest.scala
+++ b/kafka-connect-aws-s3/src/it/scala/io/lenses/streamreactor/connect/aws/s3/sink/S3JsonWriterManagerTest.scala
@@ -20,7 +20,6 @@ import cats.implicits.catsSyntaxOptionId
 import io.lenses.streamreactor.connect.aws.s3.config.Format.Json
 import io.lenses.streamreactor.connect.aws.s3.config.AuthMode
 import io.lenses.streamreactor.connect.aws.s3.config.ConnectorTaskId
-import io.lenses.streamreactor.connect.aws.s3.config.InitedConnectorTaskId
 import io.lenses.streamreactor.connect.aws.s3.config.AwsClient
 import io.lenses.streamreactor.connect.aws.s3.config.FormatSelection
 import io.lenses.streamreactor.connect.aws.s3.config.S3Config
@@ -48,7 +47,7 @@ class S3JsonWriterManagerTest extends AnyFlatSpec with Matchers with S3ProxyCont
 
   private val TopicName  = "myTopic"
   private val PathPrefix = "streamReactorBackups"
-  private implicit val connectorTaskId: ConnectorTaskId = InitedConnectorTaskId("sinkName", 1, 1)
+  private implicit val connectorTaskId: ConnectorTaskId = ConnectorTaskId("sinkName", 1, 1)
 
   "json sink" should "write single json record" in {
 

--- a/kafka-connect-aws-s3/src/it/scala/io/lenses/streamreactor/connect/aws/s3/sink/S3ParquetWriterManagerTest.scala
+++ b/kafka-connect-aws-s3/src/it/scala/io/lenses/streamreactor/connect/aws/s3/sink/S3ParquetWriterManagerTest.scala
@@ -20,7 +20,6 @@ import cats.implicits.catsSyntaxOptionId
 import io.lenses.streamreactor.connect.aws.s3.config.Format.Parquet
 import io.lenses.streamreactor.connect.aws.s3.config.AuthMode
 import io.lenses.streamreactor.connect.aws.s3.config.ConnectorTaskId
-import io.lenses.streamreactor.connect.aws.s3.config.InitedConnectorTaskId
 import io.lenses.streamreactor.connect.aws.s3.config.AwsClient
 import io.lenses.streamreactor.connect.aws.s3.config.FormatSelection
 import io.lenses.streamreactor.connect.aws.s3.config.S3Config
@@ -49,7 +48,7 @@ class S3ParquetWriterManagerTest extends AnyFlatSpec with Matchers with S3ProxyC
   import helper._
 
   private val compressionCodec = UNCOMPRESSED.toCodec()
-  private implicit val connectorTaskId: ConnectorTaskId = InitedConnectorTaskId("sinkName", 1, 1)
+  private implicit val connectorTaskId: ConnectorTaskId = ConnectorTaskId("sinkName", 1, 1)
 
   private val TopicName           = "myTopic"
   private val PathPrefix          = "streamReactorBackups"

--- a/kafka-connect-aws-s3/src/it/scala/io/lenses/streamreactor/connect/aws/s3/sink/S3WriterManagerTest.scala
+++ b/kafka-connect-aws-s3/src/it/scala/io/lenses/streamreactor/connect/aws/s3/sink/S3WriterManagerTest.scala
@@ -3,7 +3,6 @@ package io.lenses.streamreactor.connect.aws.s3.sink
 import cats.implicits.catsSyntaxEitherId
 import io.lenses.streamreactor.connect.aws.s3.config.ConnectorTaskId
 import io.lenses.streamreactor.connect.aws.s3.config.FormatSelection
-import io.lenses.streamreactor.connect.aws.s3.config.InitedConnectorTaskId
 import io.lenses.streamreactor.connect.aws.s3.formats.writer.S3FormatWriter
 import io.lenses.streamreactor.connect.aws.s3.model.Topic
 import io.lenses.streamreactor.connect.aws.s3.model.location.RemoteS3PathLocation
@@ -20,7 +19,7 @@ import scala.concurrent.duration.FiniteDuration
 import scala.concurrent.duration.SECONDS
 
 class S3WriterManagerTest extends AnyFlatSpec with Matchers with S3ProxyContainerTest with MockitoSugar {
-  private implicit val connectorTaskId: ConnectorTaskId = InitedConnectorTaskId("sinkName", 1, 1)
+  private implicit val connectorTaskId: ConnectorTaskId = ConnectorTaskId("sinkName", 1, 1)
 
   private val topicPartition = Topic("topic").withPartition(10)
 

--- a/kafka-connect-aws-s3/src/it/scala/io/lenses/streamreactor/connect/aws/s3/source/S3SourceTaskTest.scala
+++ b/kafka-connect-aws-s3/src/it/scala/io/lenses/streamreactor/connect/aws/s3/source/S3SourceTaskTest.scala
@@ -46,6 +46,7 @@ class S3SourceTaskTest
     ENABLE_VIRTUAL_HOST_BUCKETS -> "true",
     AWS_CLIENT                  -> "aws",
     TASK_INDEX                  -> "1:1",
+    "name"                      -> "s3-source",
   )
 
   private val formats = Table(

--- a/kafka-connect-aws-s3/src/it/scala/io/lenses/streamreactor/connect/aws/s3/storage/AwsS3StorageInterfaceTest.scala
+++ b/kafka-connect-aws-s3/src/it/scala/io/lenses/streamreactor/connect/aws/s3/storage/AwsS3StorageInterfaceTest.scala
@@ -16,8 +16,6 @@ import software.amazon.awssdk.services.s3.model.PutObjectRequest
 
 class AwsS3StorageInterfaceTest extends AnyFlatSpec with Matchers with S3ProxyContainerTest with LazyLogging {
 
-  private implicit val connectorTaskId: ConnectorTaskId = ConnectorTaskId("sinkName", 1, 1)
-
   override def cleanUpEnabled: Boolean = false
 
   override def setUpTestData(): Unit = {
@@ -40,6 +38,7 @@ class AwsS3StorageInterfaceTest extends AnyFlatSpec with Matchers with S3ProxyCo
 
   "s3StorageInterface" should "list directories within a path" in {
 
+    implicit val connectorTaskId: ConnectorTaskId = ConnectorTaskId("sinkName", 1, 1)
     val s3StorageInterface = new AwsS3StorageInterface()(connectorTaskId, s3Client)
 
     val topicRoot = RemoteS3RootLocation(BucketName, "topic-1/".some, allowSlash = true)

--- a/kafka-connect-aws-s3/src/it/scala/io/lenses/streamreactor/connect/aws/s3/storage/AwsS3StorageInterfaceTest.scala
+++ b/kafka-connect-aws-s3/src/it/scala/io/lenses/streamreactor/connect/aws/s3/storage/AwsS3StorageInterfaceTest.scala
@@ -7,8 +7,6 @@ import cats.implicits.catsSyntaxOptionId
 import cats.implicits.none
 import com.typesafe.scalalogging.LazyLogging
 import io.lenses.streamreactor.connect.aws.s3.config.ConnectorTaskId
-import io.lenses.streamreactor.connect.aws.s3.config.DefaultConnectorTaskId
-import io.lenses.streamreactor.connect.aws.s3.config.InitedConnectorTaskId
 import io.lenses.streamreactor.connect.aws.s3.model.location.RemoteS3RootLocation
 import io.lenses.streamreactor.connect.aws.s3.utils.S3ProxyContainerTest
 import org.scalatest.flatspec.AnyFlatSpec
@@ -18,7 +16,7 @@ import software.amazon.awssdk.services.s3.model.PutObjectRequest
 
 class AwsS3StorageInterfaceTest extends AnyFlatSpec with Matchers with S3ProxyContainerTest with LazyLogging {
 
-  private implicit val connectorTaskId: ConnectorTaskId = InitedConnectorTaskId("sinkName", 1, 1)
+  private implicit val connectorTaskId: ConnectorTaskId = ConnectorTaskId("sinkName", 1, 1)
 
   override def cleanUpEnabled: Boolean = false
 
@@ -61,7 +59,7 @@ class AwsS3StorageInterfaceTest extends AnyFlatSpec with Matchers with S3ProxyCo
 
   "s3StorageInterface" should "list directories within a path recursively from bucket root" in {
 
-    val s3StorageInterface = new AwsS3StorageInterface()(DefaultConnectorTaskId, s3Client)
+    val s3StorageInterface = new AwsS3StorageInterface()(ConnectorTaskId("sinkName", 1, 0), s3Client)
 
     val bucketRoot = RemoteS3RootLocation(BucketName, none, allowSlash = true)
 

--- a/kafka-connect-aws-s3/src/it/scala/io/lenses/streamreactor/connect/aws/s3/utils/S3ProxyContainerTest.scala
+++ b/kafka-connect-aws-s3/src/it/scala/io/lenses/streamreactor/connect/aws/s3/utils/S3ProxyContainerTest.scala
@@ -6,7 +6,6 @@ import com.typesafe.scalalogging.LazyLogging
 import io.lenses.streamreactor.connect.aws.s3.auth.AuthResources
 import io.lenses.streamreactor.connect.aws.s3.config.AuthMode
 import io.lenses.streamreactor.connect.aws.s3.config.ConnectorTaskId
-import io.lenses.streamreactor.connect.aws.s3.config.InitedConnectorTaskId
 import io.lenses.streamreactor.connect.aws.s3.config.AwsClient
 import io.lenses.streamreactor.connect.aws.s3.config.S3Config
 import ThrowableEither._
@@ -25,7 +24,7 @@ import java.nio.file.Files
 import scala.util.Try
 
 trait S3ProxyContainerTest extends AnyFlatSpec with ForAllTestContainer with LazyLogging with BeforeAndAfter {
-  private implicit val connectorTaskId: ConnectorTaskId = InitedConnectorTaskId("unit-tests", 1, 1)
+  private implicit val connectorTaskId: ConnectorTaskId = ConnectorTaskId("unit-tests", 1, 1)
   val Port:                             Int             = 8080
   val Identity:                         String          = "identity"
   val Credential:                       String          = "credential"

--- a/kafka-connect-aws-s3/src/main/scala/io/lenses/streamreactor/connect/aws/s3/config/ConnectorTaskId.scala
+++ b/kafka-connect-aws-s3/src/main/scala/io/lenses/streamreactor/connect/aws/s3/config/ConnectorTaskId.scala
@@ -23,7 +23,8 @@ import java.util
 
 case class ConnectorTaskId(name: String, maxTasks: Int, taskNo: Int) {
   def ownsDir(dirPath: String): Boolean =
-    PartitionHasher.hash(maxTasks, dirPath) == taskNo
+    if (maxTasks == 1) true
+    else PartitionHasher.hash(maxTasks, dirPath) == taskNo
 }
 
 object ConnectorTaskId {

--- a/kafka-connect-aws-s3/src/main/scala/io/lenses/streamreactor/connect/aws/s3/config/ConnectorTaskId.scala
+++ b/kafka-connect-aws-s3/src/main/scala/io/lenses/streamreactor/connect/aws/s3/config/ConnectorTaskId.scala
@@ -45,5 +45,5 @@ object ConnectorTaskId {
       maybeTaskName <- Option(props.get("name")).filter(_.trim.nonEmpty).toRight("Missing connector name")
     } yield ConnectorTaskId(maybeTaskName, maxTasks, taskNumber)
 
-  implicit val showConnector: Show[ConnectorTaskId] = Show.show(v => v.name + ":" + v.taskNo)
+  implicit val showConnector: Show[ConnectorTaskId] = Show.show(_.name)
 }

--- a/kafka-connect-aws-s3/src/main/scala/io/lenses/streamreactor/connect/aws/s3/config/ConnectorTaskId.scala
+++ b/kafka-connect-aws-s3/src/main/scala/io/lenses/streamreactor/connect/aws/s3/config/ConnectorTaskId.scala
@@ -16,43 +16,34 @@
 package io.lenses.streamreactor.connect.aws.s3.config
 
 import cats.Show
-import io.lenses.streamreactor.connect.aws.s3.config.ConnectorTaskId.defaultConnectorName
 import io.lenses.streamreactor.connect.aws.s3.config.S3ConfigSettings.TASK_INDEX
 import io.lenses.streamreactor.connect.aws.s3.source.distribution.PartitionHasher
 
 import java.util
 
-sealed trait ConnectorTaskId {
-  val name: String
-
-  def hasDefaultConnectorName: Boolean = name == defaultConnectorName
-
-  def ownsDir(dirPath: String): Boolean = true
-}
-
-object DefaultConnectorTaskId extends ConnectorTaskId {
-  override val name: String = defaultConnectorName
-}
-
-case class InitedConnectorTaskId(name: String, maxTasks: Int, taskNo: Int) extends ConnectorTaskId {
-
-  override def ownsDir(dirPath: String): Boolean =
+case class ConnectorTaskId(name: String, maxTasks: Int, taskNo: Int) {
+  def ownsDir(dirPath: String): Boolean =
     PartitionHasher.hash(maxTasks, dirPath) == taskNo
 }
 
 object ConnectorTaskId {
-
-  val defaultConnectorName = "MissingConnectorName"
-
-  def fromProps(props: util.Map[String, String]): ConnectorTaskId = {
+  def fromProps(props: util.Map[String, String]): Either[String, ConnectorTaskId] =
     for {
-      taskIndexString <- Option(props.get(TASK_INDEX))
+      taskIndexString <- Option(props.get(TASK_INDEX)).toRight(s"Missing $TASK_INDEX")
       taskIndex        = taskIndexString.split(":")
-      maybeTaskName   <- Option(props.get("name")).filter(_.trim.nonEmpty)
-    } yield InitedConnectorTaskId(maybeTaskName, taskIndex.head.toInt, taskIndex.last.toInt)
-  }
-    .getOrElse(DefaultConnectorTaskId)
+      _               <- if (taskIndex.size != 2) Left(s"Invalid $TASK_INDEX. Expecting TaskNumber:MaxTask format.") else Right(())
+      maxTasks <- taskIndex(1).toIntOption.toRight(
+        s"Invalid $TASK_INDEX. Expecting an integer but found:${taskIndex(1)}",
+      )
+      _ <- if (maxTasks <= 0) Left(s"Invalid $TASK_INDEX. Expecting a positive integer but found:${taskIndex(1)}")
+      else Right(())
+      taskNumber <- taskIndex(0).toIntOption.toRight(
+        s"Invalid $TASK_INDEX. Expecting an integer but found:${taskIndex(0)}",
+      )
+      _ <- if (taskNumber < 0) Left(s"Invalid $TASK_INDEX. Expecting a positive integer but found:${taskIndex(0)}")
+      else Right(())
+      maybeTaskName <- Option(props.get("name")).filter(_.trim.nonEmpty).toRight("Missing connector name")
+    } yield ConnectorTaskId(maybeTaskName, maxTasks, taskNumber)
 
-  implicit val showConnector: Show[ConnectorTaskId] = Show.show(_.name)
-
+  implicit val showConnector: Show[ConnectorTaskId] = Show.show(v => v.name + ":" + v.taskNo)
 }

--- a/kafka-connect-aws-s3/src/main/scala/io/lenses/streamreactor/connect/aws/s3/sink/config/LocalStagingArea.scala
+++ b/kafka-connect-aws-s3/src/main/scala/io/lenses/streamreactor/connect/aws/s3/sink/config/LocalStagingArea.scala
@@ -48,15 +48,10 @@ object LocalStagingArea {
       LocalStagingArea(stagingDir)
     }.toEither
   private def useTmpDir(implicit connectorTaskId: ConnectorTaskId): Either[Throwable, LocalStagingArea] =
-    for {
-      _ <- if (connectorTaskId.hasDefaultConnectorName) {
-        new IllegalArgumentException("No connector name specified").asLeft
-      } else ().asRight
-      stagDir <- Try {
-        val stagingDir = Files.createTempDirectory(s"${connectorTaskId.show}.${UUID.randomUUID().toString}").toFile
-        LocalStagingArea(stagingDir)
-      }.toEither
-    } yield stagDir
+    Try {
+      val stagingDir = Files.createTempDirectory(s"${connectorTaskId.show}.${UUID.randomUUID().toString}").toFile
+      LocalStagingArea(stagingDir)
+    }.toEither
 
   private def getStringValue(props: Map[String, _], key: String): Option[String] =
     props.get(key).collect {

--- a/kafka-connect-aws-s3/src/main/scala/io/lenses/streamreactor/connect/aws/s3/source/distribution/PartitionHasher.scala
+++ b/kafka-connect-aws-s3/src/main/scala/io/lenses/streamreactor/connect/aws/s3/source/distribution/PartitionHasher.scala
@@ -16,7 +16,5 @@
 package io.lenses.streamreactor.connect.aws.s3.source.distribution
 
 object PartitionHasher {
-
-  def hash(maxTasks: Int, fileName: String): Int = (Math.abs(fileName.hashCode) % maxTasks) + 1
-
+  def hash(maxTasks: Int, fileName: String): Int = Math.abs(fileName.hashCode) % maxTasks
 }

--- a/kafka-connect-aws-s3/src/main/scala/io/lenses/streamreactor/connect/aws/s3/utils/TimestampUtils.scala
+++ b/kafka-connect-aws-s3/src/main/scala/io/lenses/streamreactor/connect/aws/s3/utils/TimestampUtils.scala
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2017-2023 Lenses.io Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.lenses.streamreactor.connect.aws.s3.utils
+
+import java.time.Instant
+import scala.util.Failure
+import scala.util.Success
+import scala.util.Try
+object TimestampUtils {
+  def parseTime(timestamp: Option[Long])(errorFn: Throwable => Unit): Option[Instant] =
+    Try(timestamp.map(Instant.ofEpochMilli)) match {
+      case Failure(exception) => errorFn(exception); None
+      case Success(value)     => value
+    }
+}

--- a/kafka-connect-aws-s3/src/test/scala/io/lenses/streamreactor/connect/aws/s3/config/ConnectorTaskIdTest.scala
+++ b/kafka-connect-aws-s3/src/test/scala/io/lenses/streamreactor/connect/aws/s3/config/ConnectorTaskIdTest.scala
@@ -17,6 +17,7 @@ package io.lenses.streamreactor.connect.aws.s3.config
 
 import cats.implicits.catsSyntaxEitherId
 import io.lenses.streamreactor.connect.aws.s3.config.S3ConfigSettings.TASK_INDEX
+import io.lenses.streamreactor.connect.aws.s3.source.distribution.PartitionHasher
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 
@@ -58,6 +59,75 @@ class ConnectorTaskIdTest extends AnyWordSpec with Matchers {
       ConnectorTaskId.fromProps(from.asJava) shouldBe Left(
         s"Invalid $TASK_INDEX. Expecting a positive integer but found:-1",
       )
+    }
+
+    "own the partitions when max task is 1" in {
+      val from   = Map("a" -> "1", "b" -> "2", S3ConfigSettings.TASK_INDEX -> "0:1", "name" -> connectorName)
+      val actual = ConnectorTaskId.fromProps(from.asJava).getOrElse(fail("Should be valid"))
+
+      Seq("/myTopic/", "/anotherTopic/", "/thirdTopic/")
+        .flatMap { value =>
+          (0 to 1000).map(value + _.toString)
+        }.foreach { value =>
+          val partition = PartitionHasher.hash(1, value)
+          partition shouldBe 0
+          actual.ownsDir(value) shouldBe true
+        }
+    }
+    "distribute the directory between two tasks" in {
+
+      val one = ConnectorTaskId.fromProps(Map("a" -> "1",
+                                              "b"                         -> "2",
+                                              S3ConfigSettings.TASK_INDEX -> "0:2",
+                                              "name"                      -> connectorName,
+      ).asJava).getOrElse(fail("Should be valid"))
+      val two = ConnectorTaskId.fromProps(Map("a" -> "1",
+                                              "b"                         -> "2",
+                                              S3ConfigSettings.TASK_INDEX -> "1:2",
+                                              "name"                      -> connectorName,
+      ).asJava).getOrElse(fail("Should be valid"))
+
+      PartitionHasher.hash(2, "1") shouldBe 1
+      one.ownsDir("1") shouldBe false
+      two.ownsDir("1") shouldBe true
+
+      PartitionHasher.hash(2, "2") shouldBe 0
+      one.ownsDir("2") shouldBe true
+      two.ownsDir("2") shouldBe false
+    }
+
+    "distribute the directories between three tasks" in {
+
+      val one = ConnectorTaskId.fromProps(Map("a" -> "1",
+                                              "b"                         -> "2",
+                                              S3ConfigSettings.TASK_INDEX -> "0:3",
+                                              "name"                      -> connectorName,
+      ).asJava).getOrElse(fail("Should be valid"))
+      val two = ConnectorTaskId.fromProps(Map("a" -> "1",
+                                              "b"                         -> "2",
+                                              S3ConfigSettings.TASK_INDEX -> "1:3",
+                                              "name"                      -> connectorName,
+      ).asJava).getOrElse(fail("Should be valid"))
+      val three = ConnectorTaskId.fromProps(Map("a" -> "1",
+                                                "b"                         -> "2",
+                                                S3ConfigSettings.TASK_INDEX -> "2:3",
+                                                "name"                      -> connectorName,
+      ).asJava).getOrElse(fail("Should be valid"))
+
+      PartitionHasher.hash(3, "1") shouldBe 1
+      one.ownsDir("1") shouldBe false
+      two.ownsDir("1") shouldBe true
+      three.ownsDir("1") shouldBe false
+
+      PartitionHasher.hash(3, "2") shouldBe 2
+      one.ownsDir("2") shouldBe false
+      two.ownsDir("2") shouldBe false
+      three.ownsDir("2") shouldBe true
+
+      PartitionHasher.hash(3, "3") shouldBe 0
+      one.ownsDir("3") shouldBe true
+      two.ownsDir("3") shouldBe false
+      three.ownsDir("3") shouldBe false
     }
   }
 }

--- a/kafka-connect-aws-s3/src/test/scala/io/lenses/streamreactor/connect/aws/s3/config/ConnectorTaskIdTest.scala
+++ b/kafka-connect-aws-s3/src/test/scala/io/lenses/streamreactor/connect/aws/s3/config/ConnectorTaskIdTest.scala
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2017-2023 Lenses.io Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.lenses.streamreactor.connect.aws.s3.config
+
+import cats.implicits.catsSyntaxEitherId
+import io.lenses.streamreactor.connect.aws.s3.config.S3ConfigSettings.TASK_INDEX
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+
+import scala.jdk.CollectionConverters._
+class ConnectorTaskIdTest extends AnyWordSpec with Matchers {
+  private val connectorName = "connectorName"
+  "ConnectorTaskId" should {
+    "create the instance" in {
+      val from = Map("a" -> "1", "b" -> "2", S3ConfigSettings.TASK_INDEX -> "0:2", "name" -> connectorName)
+      ConnectorTaskId.fromProps(from.asJava) shouldBe ConnectorTaskId(connectorName, 2, 0).asRight[String]
+    }
+    "fail if max tasks is not valid integer" in {
+      val from   = Map("a" -> "1", "b" -> "2", S3ConfigSettings.TASK_INDEX -> "0:2a", "name" -> connectorName)
+      val actual = ConnectorTaskId.fromProps(from.asJava)
+      actual shouldBe Left(
+        s"Invalid $TASK_INDEX. Expecting an integer but found:2a",
+      )
+    }
+    "fail if task number is not a valid integer" in {
+      val from = Map("a" -> "1", "b" -> "2", S3ConfigSettings.TASK_INDEX -> "0a:2", "name" -> connectorName)
+      ConnectorTaskId.fromProps(from.asJava) shouldBe Left(
+        s"Invalid $TASK_INDEX. Expecting an integer but found:0a",
+      )
+    }
+    "fail if task number < 0" in {
+      val from = Map("a" -> "1", "b" -> "2", S3ConfigSettings.TASK_INDEX -> "-1:2", "name" -> connectorName)
+      ConnectorTaskId.fromProps(from.asJava) shouldBe Left(
+        s"Invalid $TASK_INDEX. Expecting a positive integer but found:-1",
+      )
+    }
+    "fail if max tasks is zero" in {
+      val from = Map("a" -> "1", "b" -> "2", S3ConfigSettings.TASK_INDEX -> "0:0", "name" -> connectorName)
+      ConnectorTaskId.fromProps(from.asJava) shouldBe Left(
+        s"Invalid $TASK_INDEX. Expecting a positive integer but found:0",
+      )
+    }
+    "fail if max tasks is negative" in {
+      val from = Map("a" -> "1", "b" -> "2", S3ConfigSettings.TASK_INDEX -> "0:-1", "name" -> connectorName)
+      ConnectorTaskId.fromProps(from.asJava) shouldBe Left(
+        s"Invalid $TASK_INDEX. Expecting a positive integer but found:-1",
+      )
+    }
+  }
+}

--- a/kafka-connect-aws-s3/src/test/scala/io/lenses/streamreactor/connect/aws/s3/config/TaskDistributorTest.scala
+++ b/kafka-connect-aws-s3/src/test/scala/io/lenses/streamreactor/connect/aws/s3/config/TaskDistributorTest.scala
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2017-2023 Lenses.io Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.lenses.streamreactor.connect.aws.s3.config
+
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+
+import scala.jdk.CollectionConverters._
+class TaskDistributorTest extends AnyWordSpec with Matchers {
+  "TaskDistributor" should {
+    "distribute tasks" in {
+      val tasks =
+        TaskDistributor.distributeTasks(Map.empty[String, String].asJava, 5).asScala.map(_.asScala.toMap).toList
+      tasks shouldBe List(
+        Map(S3ConfigSettings.TASK_INDEX -> "0:5"),
+        Map(S3ConfigSettings.TASK_INDEX -> "1:5"),
+        Map(S3ConfigSettings.TASK_INDEX -> "2:5"),
+        Map(S3ConfigSettings.TASK_INDEX -> "3:5"),
+        Map(S3ConfigSettings.TASK_INDEX -> "4:5"),
+      )
+    }
+    "handle 0 max tasks" in {
+        val tasks =
+            TaskDistributor.distributeTasks(Map.empty[String, String].asJava, 0).asScala.map(_.asScala.toMap).toList
+        tasks shouldBe List()
+    }
+  }
+}

--- a/kafka-connect-aws-s3/src/test/scala/io/lenses/streamreactor/connect/aws/s3/sink/config/LocalStagingAreaTest.scala
+++ b/kafka-connect-aws-s3/src/test/scala/io/lenses/streamreactor/connect/aws/s3/sink/config/LocalStagingAreaTest.scala
@@ -60,14 +60,4 @@ class LocalStagingAreaTest extends AnyFlatSpec with Matchers with EitherValues {
       case _                      => fail("Wrong")
     }
   }
-
-  it should "not create BuildLocalOutputStreamOptions when nothing supplied" in {
-    implicit val connectorTaskId: ConnectorTaskId = ConnectorTaskId("sinkName", 1, 1)
-    val result = LocalStagingArea(adapt(Map[String, String]()))
-    result.left.value.getClass.getSimpleName should be("IllegalStateException")
-    result.left.value.getMessage should be(
-      "Either a local temporary directory (connect.s3.local.tmp.directory) or a Sink Name (name) must be configured.",
-    )
-  }
-
 }

--- a/kafka-connect-aws-s3/src/test/scala/io/lenses/streamreactor/connect/aws/s3/sink/config/LocalStagingAreaTest.scala
+++ b/kafka-connect-aws-s3/src/test/scala/io/lenses/streamreactor/connect/aws/s3/sink/config/LocalStagingAreaTest.scala
@@ -16,8 +16,6 @@
 package io.lenses.streamreactor.connect.aws.s3.sink.config
 
 import io.lenses.streamreactor.connect.aws.s3.config.ConnectorTaskId
-import io.lenses.streamreactor.connect.aws.s3.config.DefaultConnectorTaskId
-import io.lenses.streamreactor.connect.aws.s3.config.InitedConnectorTaskId
 import io.lenses.streamreactor.connect.aws.s3.config.S3ConfigSettings.LOCAL_TMP_DIRECTORY
 import org.scalatest.EitherValues
 import org.scalatest.flatspec.AnyFlatSpec
@@ -40,20 +38,20 @@ class LocalStagingAreaTest extends AnyFlatSpec with Matchers with EitherValues {
   }
 
   it should "create BuildLocalOutputStreamOptions when temp directory has been supplied" in {
-    implicit val connectorTaskId: ConnectorTaskId = DefaultConnectorTaskId
+    implicit val connectorTaskId: ConnectorTaskId = ConnectorTaskId("unusedSinkName", 1, 1)
     LocalStagingArea(adapt(Map(LOCAL_TMP_DIRECTORY -> s"$tmpDir/my/path"))) should
       be(Right(LocalStagingArea(new File(s"$tmpDir/my/path"))))
   }
 
   it should "create BuildLocalOutputStreamOptions when temp directory and sink name has been supplied" in {
-    implicit val connectorTaskId: ConnectorTaskId = InitedConnectorTaskId("unusedSinkName", 1, 1)
+    implicit val connectorTaskId: ConnectorTaskId = ConnectorTaskId("unusedSinkName", 1, 1)
     // should ignore the sinkName
     LocalStagingArea(adapt(Map(LOCAL_TMP_DIRECTORY -> s"$tmpDir/my/path"))) should
       be(Right(LocalStagingArea(new File(s"$tmpDir/my/path"))))
   }
 
   it should "create BuildLocalOutputStreamOptions when only sink name has been supplied" in {
-    implicit val connectorTaskId: ConnectorTaskId = InitedConnectorTaskId("superSleekSinkName", 1, 1)
+    implicit val connectorTaskId: ConnectorTaskId = ConnectorTaskId("superSleekSinkName", 1, 1)
     val tempDir = System.getProperty("java.io.tmpdir")
     val result  = LocalStagingArea(adapt(Map()))
     result.isRight should be(true)
@@ -64,7 +62,7 @@ class LocalStagingAreaTest extends AnyFlatSpec with Matchers with EitherValues {
   }
 
   it should "not create BuildLocalOutputStreamOptions when nothing supplied" in {
-    implicit val connectorTaskId: ConnectorTaskId = DefaultConnectorTaskId
+    implicit val connectorTaskId: ConnectorTaskId = ConnectorTaskId("sinkName", 1, 1)
     val result = LocalStagingArea(adapt(Map[String, String]()))
     result.left.value.getClass.getSimpleName should be("IllegalStateException")
     result.left.value.getMessage should be(

--- a/kafka-connect-aws-s3/src/test/scala/io/lenses/streamreactor/connect/aws/s3/sink/seek/IndexManagerTest.scala
+++ b/kafka-connect-aws-s3/src/test/scala/io/lenses/streamreactor/connect/aws/s3/sink/seek/IndexManagerTest.scala
@@ -41,8 +41,8 @@ import org.scalatest.OptionValues
 
 class IndexManagerTest extends AnyFlatSpec with MockitoSugar with EitherValues with OptionValues with BeforeAndAfter {
 
-  private implicit val connectorTaskId: ConnectorTaskId = ConnectorTaskId("sinkName", 1, 1)
-  private implicit val storageInterface = mock[StorageInterface]
+  private implicit val connectorTaskId:  ConnectorTaskId  = ConnectorTaskId("sinkName", 1, 1)
+  private implicit val storageInterface: StorageInterface = mock[StorageInterface]
 
   private val bucketName = "my-bucket"
 

--- a/kafka-connect-aws-s3/src/test/scala/io/lenses/streamreactor/connect/aws/s3/sink/seek/IndexManagerTest.scala
+++ b/kafka-connect-aws-s3/src/test/scala/io/lenses/streamreactor/connect/aws/s3/sink/seek/IndexManagerTest.scala
@@ -17,7 +17,6 @@ package io.lenses.streamreactor.connect.aws.s3.sink.seek
 
 import cats.implicits.catsSyntaxEitherId
 import io.lenses.streamreactor.connect.aws.s3.config.ConnectorTaskId
-import io.lenses.streamreactor.connect.aws.s3.config.InitedConnectorTaskId
 import io.lenses.streamreactor.connect.aws.s3.model.location.RemoteS3PathLocation
 import io.lenses.streamreactor.connect.aws.s3.model.location.RemoteS3RootLocation
 import io.lenses.streamreactor.connect.aws.s3.model.Topic
@@ -42,7 +41,7 @@ import org.scalatest.OptionValues
 
 class IndexManagerTest extends AnyFlatSpec with MockitoSugar with EitherValues with OptionValues with BeforeAndAfter {
 
-  private implicit val connectorTaskId: ConnectorTaskId = InitedConnectorTaskId("sinkName", 1, 1)
+  private implicit val connectorTaskId: ConnectorTaskId = ConnectorTaskId("sinkName", 1, 1)
   private implicit val storageInterface = mock[StorageInterface]
 
   private val bucketName = "my-bucket"

--- a/kafka-connect-aws-s3/src/test/scala/io/lenses/streamreactor/connect/aws/s3/sink/seek/LegacyOffsetSeekerTest.scala
+++ b/kafka-connect-aws-s3/src/test/scala/io/lenses/streamreactor/connect/aws/s3/sink/seek/LegacyOffsetSeekerTest.scala
@@ -18,7 +18,7 @@ package io.lenses.streamreactor.connect.aws.s3.sink.seek
 import cats.implicits.catsSyntaxEitherId
 import io.lenses.streamreactor.connect.aws.s3.config.Format.Json
 import io.lenses.streamreactor.connect.aws.s3.config.FormatSelection
-import io.lenses.streamreactor.connect.aws.s3.config.InitedConnectorTaskId
+import io.lenses.streamreactor.connect.aws.s3.config.ConnectorTaskId
 import io.lenses.streamreactor.connect.aws.s3.model.location.RemoteS3PathLocation
 import io.lenses.streamreactor.connect.aws.s3.model.location.RemoteS3RootLocation
 import io.lenses.streamreactor.connect.aws.s3.model.Offset
@@ -45,7 +45,7 @@ class LegacyOffsetSeekerTest
   private val fileNamingStrategy = new HierarchicalS3FileNamingStrategy(FormatSelection(Json), NoOpPaddingStrategy)
 
   private implicit val storageInterface: StorageInterface = mock[StorageInterface]
-  private implicit val connectorTaskId = InitedConnectorTaskId("unit-tests", 1, 1)
+  private implicit val connectorTaskId = ConnectorTaskId("unit-tests", 1, 1)
 
   private val offsetSeeker = new LegacyOffsetSeeker
 

--- a/kafka-connect-aws-s3/src/test/scala/io/lenses/streamreactor/connect/aws/s3/source/distribution/PartitionHasherTest.scala
+++ b/kafka-connect-aws-s3/src/test/scala/io/lenses/streamreactor/connect/aws/s3/source/distribution/PartitionHasherTest.scala
@@ -15,6 +15,7 @@
  */
 package io.lenses.streamreactor.connect.aws.s3.source.distribution
 
+import org.scalatest.Assertion
 import org.scalatest.flatspec.AnyFlatSpecLike
 import org.scalatest.matchers.should.Matchers
 
@@ -40,7 +41,7 @@ class PartitionHasherTest extends AnyFlatSpecLike with Matchers {
     mapPartitionsToRange(numberOfValues = 1000,
                          maxTasks       = 1,
                          topics         = Seq("/myTopic/", "/anotherTopic/", "/thirdTopic/"),
-    ).foreach(mp => mp should be(1))
+    ).foreach(mp => mp should be(0))
   }
 
   private def testHashDistribution(numberOfValues: Int, maxTasks: Int, topics: Seq[String]) = {
@@ -54,12 +55,12 @@ class PartitionHasherTest extends AnyFlatSpecLike with Matchers {
     grouped.values.sum should be(numberOfValues * topics.size)
   }
 
-  private def shouldBeInRange(count: Int, upperBounds: Int) = {
+  private def shouldBeInRange(count: Int, upperBounds: Int): Assertion = {
     count should be > 0
     count should be <= upperBounds
   }
 
-  private def mapPartitionsToRange(numberOfValues: Int, maxTasks: Int, topics: Seq[String]) = {
+  private def mapPartitionsToRange(numberOfValues: Int, maxTasks: Int, topics: Seq[String]): Seq[Int] = {
     val rangeToTest = 1 to numberOfValues
     val partitions  = topics.flatMap(t => rangeToTest.map(t + _))
 

--- a/kafka-connect-aws-s3/src/test/scala/io/lenses/streamreactor/connect/aws/s3/source/reader/ReaderManagerTest.scala
+++ b/kafka-connect-aws-s3/src/test/scala/io/lenses/streamreactor/connect/aws/s3/source/reader/ReaderManagerTest.scala
@@ -17,7 +17,7 @@ package io.lenses.streamreactor.connect.aws.s3.source.reader
 
 import cats.implicits.catsSyntaxEitherId
 import com.typesafe.scalalogging.LazyLogging
-import io.lenses.streamreactor.connect.aws.s3.config.InitedConnectorTaskId
+import io.lenses.streamreactor.connect.aws.s3.config.ConnectorTaskId
 import io.lenses.streamreactor.connect.aws.s3.formats.reader.StringSourceData
 import io.lenses.streamreactor.connect.aws.s3.model.location.RemoteS3RootLocation
 import io.lenses.streamreactor.connect.aws.s3.source.files.SourceFileQueue
@@ -35,7 +35,7 @@ class ReaderManagerTest extends AnyFlatSpec with MockitoSugar with Matchers with
   private val fileQueueProcessor:        SourceFileQueue       = mock[SourceFileQueue]
   private val readerCreator = mock[ReaderCreator]
 
-  private implicit val connectorTaskId      = InitedConnectorTaskId("mySource", 1, 1)
+  private implicit val connectorTaskId      = ConnectorTaskId("mySource", 1, 1)
   private val recordsLimit                  = 10
   private val bucketAndPrefix               = RemoteS3RootLocation("test:ing")
   private val firstFileBucketAndPath        = bucketAndPrefix.withPath("test:ing/topic/9/0.json")

--- a/kafka-connect-aws-s3/src/test/scala/io/lenses/streamreactor/connect/aws/s3/storage/AwsS3DirectoryListerTest.scala
+++ b/kafka-connect-aws-s3/src/test/scala/io/lenses/streamreactor/connect/aws/s3/storage/AwsS3DirectoryListerTest.scala
@@ -20,7 +20,6 @@ import cats.effect.IO
 import cats.effect.unsafe.implicits.global
 import cats.implicits._
 import io.lenses.streamreactor.connect.aws.s3.config.ConnectorTaskId
-import io.lenses.streamreactor.connect.aws.s3.config.DefaultConnectorTaskId
 import io.lenses.streamreactor.connect.aws.s3.model.location.RemoteS3RootLocation
 import org.scalatest.flatspec.AnyFlatSpecLike
 import org.scalatest.matchers.should.Matchers
@@ -28,7 +27,7 @@ import software.amazon.awssdk.services.s3.S3Client
 
 class AwsS3DirectoryListerTest extends AnyFlatSpecLike with Matchers {
 
-  implicit val connectorTaskId: ConnectorTaskId = DefaultConnectorTaskId
+  implicit val connectorTaskId: ConnectorTaskId = ConnectorTaskId("sinkName", 1, 1)
 
   "dirLister" should "list all directories" in {
 

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -13,3 +13,5 @@ addSbtPlugin("org.xerial.sbt" % "sbt-pack" % "0.14")
 addCompilerPlugin("com.olegpy" %% "better-monadic-for" % "0.3.1")
 
 addSbtPlugin("com.typesafe.sbt" % "sbt-license-report" % "1.2.0")
+
+//addCompilerPlugin("org.typelevel" %% "kind-projector" % "0.13.2")


### PR DESCRIPTION
## Description
Fix the bug where the ConnectorTaskId had the task number, and the maxtasks values reversed. This created a runtime exception on PartitionHasher (division by zero).

Removes the ConnectorTaskId trait and creates a case class. There was no reason to default when the name or TASK_INDEX properties were missing.

## Tests

Adds the unit test around the ConnectorTaskId to check the values for max tasks and task number.