### PR TITLE
Parquet INT96 support

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -75,7 +75,7 @@ object Dependencies {
     val classGraphVersions  = "4.8.157"
 
     val wiremockJre8Version = "2.35.0"
-    val parquetVersion      = "1.12.3"
+    val parquetVersion      = "1.13.1"
 
     val jerseyCommonVersion = "3.1.1"
 


### PR DESCRIPTION
Allows Parquet INT96 to be read as a fixed size array. Otherwise, it fails at runtime.

Updates the dependency on parquet to 1.13.1