### PR TITLE
RB-326

### DIFF
--- a/kafka-connect-aws-s3/src/main/scala/io/lenses/streamreactor/connect/aws/s3/source/distribution/PartitionSearcher.scala
+++ b/kafka-connect-aws-s3/src/main/scala/io/lenses/streamreactor/connect/aws/s3/source/distribution/PartitionSearcher.scala
@@ -26,14 +26,21 @@ import io.lenses.streamreactor.connect.aws.s3.storage.DirectoryFindCompletionCon
 import software.amazon.awssdk.services.s3.model.ListObjectsV2Request
 import software.amazon.awssdk.services.s3.model.ListObjectsV2Response
 
-class PartitionSearcher(
+trait PartitionSearcher {
+  def find(
+    lastFound: Seq[PartitionSearcherResponse],
+  ): IO[Seq[PartitionSearcherResponse]]
+}
+
+class PartitionSearcherImpl(
   roots:           Seq[S3Location],
   settings:        PartitionSearcherOptions,
   connectorTaskId: ConnectorTaskId,
   listS3ObjF:      ListObjectsV2Request => Iterator[ListObjectsV2Response],
-) extends LazyLogging {
+) extends PartitionSearcher
+    with LazyLogging {
 
-  def findNewPartitions(
+  def find(
     lastFound: Seq[PartitionSearcherResponse],
   ): IO[Seq[PartitionSearcherResponse]] =
     if (lastFound.isEmpty && roots.nonEmpty) {

--- a/kafka-connect-aws-s3/src/main/scala/io/lenses/streamreactor/connect/aws/s3/source/distribution/PartitionSearcher.scala
+++ b/kafka-connect-aws-s3/src/main/scala/io/lenses/streamreactor/connect/aws/s3/source/distribution/PartitionSearcher.scala
@@ -26,19 +26,12 @@ import io.lenses.streamreactor.connect.aws.s3.storage.DirectoryFindCompletionCon
 import software.amazon.awssdk.services.s3.model.ListObjectsV2Request
 import software.amazon.awssdk.services.s3.model.ListObjectsV2Response
 
-trait PartitionSearcher {
-  def find(
-    lastFound: Seq[PartitionSearcherResponse],
-  ): IO[Seq[PartitionSearcherResponse]]
-}
-
-class PartitionSearcherImpl(
+class PartitionSearcher(
   roots:           Seq[S3Location],
   settings:        PartitionSearcherOptions,
   connectorTaskId: ConnectorTaskId,
   listS3ObjF:      ListObjectsV2Request => Iterator[ListObjectsV2Response],
-) extends PartitionSearcher
-    with LazyLogging {
+) extends LazyLogging {
 
   def find(
     lastFound: Seq[PartitionSearcherResponse],

--- a/kafka-connect-aws-s3/src/main/scala/io/lenses/streamreactor/connect/aws/s3/source/state/S3SourceBuilder.scala
+++ b/kafka-connect-aws-s3/src/main/scala/io/lenses/streamreactor/connect/aws/s3/source/state/S3SourceBuilder.scala
@@ -90,7 +90,6 @@ object S3SourceState {
                                                           readerManagerCreateFn,
                                                           readerManagerState,
                                                           cancelledRef,
-                                                          Some(_ => IO.unit),
       )
       BuilderResult(new S3SourceTaskState(() => readerManagerState.get.map(_.readerManagers)),
                     cancelledRef,

--- a/kafka-connect-aws-s3/src/main/scala/io/lenses/streamreactor/connect/aws/s3/source/state/S3SourceBuilder.scala
+++ b/kafka-connect-aws-s3/src/main/scala/io/lenses/streamreactor/connect/aws/s3/source/state/S3SourceBuilder.scala
@@ -21,7 +21,7 @@ import io.lenses.streamreactor.connect.aws.s3.auth.AwsS3ClientCreator
 import io.lenses.streamreactor.connect.aws.s3.config.ConnectorTaskId
 import io.lenses.streamreactor.connect.aws.s3.model.location.S3Location
 import io.lenses.streamreactor.connect.aws.s3.source.config.S3SourceConfig
-import io.lenses.streamreactor.connect.aws.s3.source.distribution.PartitionSearcher
+import io.lenses.streamreactor.connect.aws.s3.source.distribution.PartitionSearcherImpl
 import io.lenses.streamreactor.connect.aws.s3.source.files.S3SourceFileQueue
 import io.lenses.streamreactor.connect.aws.s3.source.reader.PartitionDiscovery
 import io.lenses.streamreactor.connect.aws.s3.source.reader.ReaderManager
@@ -44,7 +44,7 @@ object S3SourceState {
       s3Client         <- IO.fromEither(AwsS3ClientCreator.make(config.s3Config))
       storageInterface <- IO.delay(new AwsS3StorageInterface(connectorTaskId, s3Client))
       partitionSearcher <- IO.delay(
-        new PartitionSearcher(
+        new PartitionSearcherImpl(
           config.bucketOptions.map(_.sourceBucketAndPrefix),
           config.partitionSearcher,
           connectorTaskId,
@@ -90,6 +90,7 @@ object S3SourceState {
                                                           readerManagerCreateFn,
                                                           readerManagerState,
                                                           cancelledRef,
+                                                          Some(_ => IO.unit),
       )
       BuilderResult(new S3SourceTaskState(() => readerManagerState.get.map(_.readerManagers)),
                     cancelledRef,

--- a/kafka-connect-aws-s3/src/main/scala/io/lenses/streamreactor/connect/aws/s3/source/state/S3SourceBuilder.scala
+++ b/kafka-connect-aws-s3/src/main/scala/io/lenses/streamreactor/connect/aws/s3/source/state/S3SourceBuilder.scala
@@ -21,7 +21,7 @@ import io.lenses.streamreactor.connect.aws.s3.auth.AwsS3ClientCreator
 import io.lenses.streamreactor.connect.aws.s3.config.ConnectorTaskId
 import io.lenses.streamreactor.connect.aws.s3.model.location.S3Location
 import io.lenses.streamreactor.connect.aws.s3.source.config.S3SourceConfig
-import io.lenses.streamreactor.connect.aws.s3.source.distribution.PartitionSearcherImpl
+import io.lenses.streamreactor.connect.aws.s3.source.distribution.PartitionSearcher
 import io.lenses.streamreactor.connect.aws.s3.source.files.S3SourceFileQueue
 import io.lenses.streamreactor.connect.aws.s3.source.reader.PartitionDiscovery
 import io.lenses.streamreactor.connect.aws.s3.source.reader.ReaderManager
@@ -44,7 +44,7 @@ object S3SourceState {
       s3Client         <- IO.fromEither(AwsS3ClientCreator.make(config.s3Config))
       storageInterface <- IO.delay(new AwsS3StorageInterface(connectorTaskId, s3Client))
       partitionSearcher <- IO.delay(
-        new PartitionSearcherImpl(
+        new PartitionSearcher(
           config.bucketOptions.map(_.sourceBucketAndPrefix),
           config.partitionSearcher,
           connectorTaskId,
@@ -86,7 +86,7 @@ object S3SourceState {
         )
       }
       val partitionDiscoveryLoop = PartitionDiscovery.run(config.partitionSearcher,
-                                                          partitionSearcher,
+                                                          partitionSearcher.find,
                                                           readerManagerCreateFn,
                                                           readerManagerState,
                                                           cancelledRef,

--- a/kafka-connect-aws-s3/src/test/scala/io/lenses/streamreactor/connect/aws/s3/source/reader/PartitionDiscoveryTest.scala
+++ b/kafka-connect-aws-s3/src/test/scala/io/lenses/streamreactor/connect/aws/s3/source/reader/PartitionDiscoveryTest.scala
@@ -23,6 +23,7 @@ import io.lenses.streamreactor.connect.aws.s3.config.ConnectorTaskId
 import io.lenses.streamreactor.connect.aws.s3.model.location.S3Location
 import io.lenses.streamreactor.connect.aws.s3.source.config.PartitionSearcherOptions
 import io.lenses.streamreactor.connect.aws.s3.source.distribution.PartitionSearcher
+import io.lenses.streamreactor.connect.aws.s3.source.distribution.PartitionSearcherImpl
 import io.lenses.streamreactor.connect.aws.s3.source.distribution.PartitionSearcherResponse
 import io.lenses.streamreactor.connect.aws.s3.source.files.SourceFileQueue
 import io.lenses.streamreactor.connect.aws.s3.storage.DirectoryFindResults
@@ -37,6 +38,65 @@ import scala.jdk.CollectionConverters.IteratorHasAsScala
 
 class PartitionDiscoveryTest extends AnyFlatSpecLike with Matchers with MockitoSugar {
   private val connectorTaskId: ConnectorTaskId = ConnectorTaskId("sinkName", 1, 1)
+  "PartitionDiscovery" should "handle failure on PartitionSearcher and resume" in {
+    val fileQueueProcessor: SourceFileQueue = mock[SourceFileQueue]
+    val limit   = 10
+    val options = PartitionSearcherOptions(1, 100.millis)
+
+    trait Count {
+      def getCount: IO[Int]
+    }
+    val searcherMock = new PartitionSearcher with Count {
+      private val count = Ref[IO].of(0).unsafeRunSync()
+      def getCount: IO[Int] = count.get
+
+      def find(
+        lastFound: Seq[PartitionSearcherResponse],
+      ): IO[Seq[PartitionSearcherResponse]] =
+        for {
+          c <- count.getAndUpdate(_ + 1)
+          _ <- if (c == 0) IO.raiseError(new RuntimeException("error")) else IO.unit
+        } yield List(
+          PartitionSearcherResponse(S3Location("bucket", None),
+                                    Set("prefix1/", "prefix2/"),
+                                    DirectoryFindResults(Set("prefix1/", "prefix2/")),
+                                    None,
+          ),
+        )
+    }
+
+    val io = for {
+      cancelledRef <- Ref[IO].of(false)
+      readerRef    <- Ref[IO].of(Option.empty[ResultReader])
+      state        <- Ref[IO].of(ReaderManagerState(Seq.empty, Seq.empty))
+      fiber <- PartitionDiscovery.run(
+        options,
+        searcherMock,
+        (_, _) =>
+          IO(ReaderManager(limit, fileQueueProcessor, _ => Left(new RuntimeException()), connectorTaskId, readerRef)),
+        state,
+        cancelledRef,
+      ).start
+      _              <- IO.sleep(400.millis)
+      _              <- cancelledRef.set(true)
+      _              <- fiber.join
+      readerMgrState <- state.get
+      callsMade      <- searcherMock.getCount
+    } yield readerMgrState -> callsMade
+
+    val (state, callsMade) = io.unsafeRunSync()
+    assert(
+      state.partitionResponses == List(
+        PartitionSearcherResponse(
+          S3Location("bucket", None),
+          Set("prefix1/", "prefix2/"),
+          DirectoryFindResults(Set.empty),
+          None,
+        ),
+      ),
+    )
+    callsMade >= 1
+  }
   "PartitionDiscovery" should "discover all partitions" in {
     val fileQueueProcessor: SourceFileQueue = mock[SourceFileQueue]
     val limit = 10
@@ -55,12 +115,12 @@ class PartitionDiscoveryTest extends AnyFlatSpecLike with Matchers with MockitoS
       state        <- Ref[IO].of(ReaderManagerState(Seq.empty, Seq.empty))
       fiber <- PartitionDiscovery.run(
         options,
-        new PartitionSearcher(List(
-                                S3Location("bucket", None),
-                              ),
-                              options,
-                              connectorTaskId,
-                              s3Client.listObjectsV2Paginator(_).iterator().asScala,
+        new PartitionSearcherImpl(List(
+                                    S3Location("bucket", None),
+                                  ),
+                                  options,
+                                  connectorTaskId,
+                                  s3Client.listObjectsV2Paginator(_).iterator().asScala,
         ),
         (_, _) =>
           IO(ReaderManager(limit, fileQueueProcessor, _ => Left(new RuntimeException()), connectorTaskId, readerRef)),
@@ -114,12 +174,12 @@ class PartitionDiscoveryTest extends AnyFlatSpecLike with Matchers with MockitoS
       )
       fiber <- PartitionDiscovery.run(
         options,
-        new PartitionSearcher(List(
-                                S3Location("bucket", None),
-                              ),
-                              options,
-                              connectorTaskId,
-                              s3Client.listObjectsV2Paginator(_).iterator().asScala,
+        new PartitionSearcherImpl(List(
+                                    S3Location("bucket", None),
+                                  ),
+                                  options,
+                                  connectorTaskId,
+                                  s3Client.listObjectsV2Paginator(_).iterator().asScala,
         ),
         (_, _) =>
           IO(ReaderManager(limit, fileQueueProcessor, _ => Left(new RuntimeException()), connectorTaskId, readerRef)),
@@ -165,12 +225,12 @@ class PartitionDiscoveryTest extends AnyFlatSpecLike with Matchers with MockitoS
       state        <- Ref[IO].of(ReaderManagerState(Seq.empty, Seq.empty))
       fiber <- PartitionDiscovery.run(
         options,
-        new PartitionSearcher(List(
-                                S3Location("bucket", "prefix1/".some),
-                              ),
-                              options,
-                              connectorTaskId,
-                              s3Client.listObjectsV2Paginator(_).iterator().asScala,
+        new PartitionSearcherImpl(List(
+                                    S3Location("bucket", "prefix1/".some),
+                                  ),
+                                  options,
+                                  connectorTaskId,
+                                  s3Client.listObjectsV2Paginator(_).iterator().asScala,
         ),
         (_, _) =>
           IO(ReaderManager(limit, fileQueueProcessor, _ => Left(new RuntimeException()), connectorTaskId, readerRef)),

--- a/kafka-connect-aws-s3/src/test/scala/io/lenses/streamreactor/connect/aws/s3/source/reader/PartitionDiscoveryTest.scala
+++ b/kafka-connect-aws-s3/src/test/scala/io/lenses/streamreactor/connect/aws/s3/source/reader/PartitionDiscoveryTest.scala
@@ -90,7 +90,7 @@ class PartitionDiscoveryTest extends AnyFlatSpecLike with Matchers with MockitoS
         PartitionSearcherResponse(
           S3Location("bucket", None),
           Set("prefix1/", "prefix2/"),
-          DirectoryFindResults(Set.empty),
+          DirectoryFindResults(Set("prefix1/", "prefix2/")),
           None,
         ),
       ),


### PR DESCRIPTION
Handle scenarios where the partition discovery fails (i.e. connectivity issues). The partition discovery should not stop and resume.

The code changes PartitionDiscovery.run to handle errors on task:IO[Unit] ensuring the loop won't stop.