### PR TITLE
RB-336

### DIFF
--- a/kafka-connect-aws-s3/src/main/scala/io/lenses/streamreactor/connect/aws/s3/source/config/ReadTextMode.scala
+++ b/kafka-connect-aws-s3/src/main/scala/io/lenses/streamreactor/connect/aws/s3/source/config/ReadTextMode.scala
@@ -55,7 +55,8 @@ object ReadTextMode {
         for {
           startLine <- props.getString(S3PropsKeyEnum.ReadStartLine)
           endLine   <- props.getString(S3PropsKeyEnum.ReadEndLine)
-        } yield StartEndLineReadTextMode(startLine, endLine)
+          trim      <- props.getOptionalBoolean(S3PropsKeyEnum.ReadTrimLine).orElse(Some(false))
+        } yield StartEndLineReadTextMode(startLine, endLine, trim)
       case None => Option.empty
     }
   }
@@ -76,7 +77,7 @@ case class StartEndTagReadTextMode(startTag: String, endTag: String, buffer: Int
   }
 }
 
-case class StartEndLineReadTextMode(startLine: String, endLine: String) extends ReadTextMode {
+case class StartEndLineReadTextMode(startLine: String, endLine: String, trim: Boolean) extends ReadTextMode {
   override def createStreamReader(
     inputStream:   InputStream,
     bucketAndPath: S3Location,
@@ -85,6 +86,7 @@ case class StartEndLineReadTextMode(startLine: String, endLine: String) extends 
       inputStream,
       startLine,
       endLine,
+      trim,
     )
     new CustomTextFormatStreamReader(bucketAndPath, () => lineReader.next(), () => lineReader.close())
   }

--- a/kafka-connect-aws-s3/src/main/scala/io/lenses/streamreactor/connect/aws/s3/source/config/kcqlprops/S3PropsKeyEnum.scala
+++ b/kafka-connect-aws-s3/src/main/scala/io/lenses/streamreactor/connect/aws/s3/source/config/kcqlprops/S3PropsKeyEnum.scala
@@ -35,4 +35,6 @@ object S3PropsKeyEnum extends Enum[S3PropsKeyEntry] {
 
   case object ReadStartLine extends S3PropsKeyEntry("read.text.start.line")
   case object ReadEndLine   extends S3PropsKeyEntry("read.text.end.line")
+
+  case object ReadTrimLine extends S3PropsKeyEntry("read.text.trim")
 }

--- a/kafka-connect-aws-s3/src/main/scala/io/lenses/streamreactor/connect/aws/s3/source/config/kcqlprops/S3PropsSchema.scala
+++ b/kafka-connect-aws-s3/src/main/scala/io/lenses/streamreactor/connect/aws/s3/source/config/kcqlprops/S3PropsSchema.scala
@@ -16,6 +16,7 @@
 package io.lenses.streamreactor.connect.aws.s3.source.config.kcqlprops
 
 import io.lenses.streamreactor.connect.aws.s3.source.config.kcqlprops.S3PropsKeyEnum._
+import io.lenses.streamreactor.connect.config.kcqlprops.BooleanPropsSchema
 import io.lenses.streamreactor.connect.config.kcqlprops.EnumPropsSchema
 import io.lenses.streamreactor.connect.config.kcqlprops.IntPropsSchema
 import io.lenses.streamreactor.connect.config.kcqlprops.KcqlPropsSchema
@@ -32,6 +33,7 @@ object S3PropsSchema {
     ReadStartLine -> StringPropsSchema,
     ReadEndLine   -> StringPropsSchema,
     BufferSize    -> IntPropsSchema,
+    ReadTrimLine  -> BooleanPropsSchema,
   )
 
   val schema = KcqlPropsSchema(S3PropsKeyEnum, keys)

--- a/kafka-connect-aws-s3/src/test/scala/io/lenses/streamreactor/connect/aws/s3/source/config/ReadTextModeTestFormatSelection.scala
+++ b/kafka-connect-aws-s3/src/test/scala/io/lenses/streamreactor/connect/aws/s3/source/config/ReadTextModeTestFormatSelection.scala
@@ -100,7 +100,20 @@ class ReadTextModeTestFormatSelection extends AnyFlatSpec with Matchers {
           S3PropsKeyEnum.ReadEndLine.entryName   -> "",
         ),
       ),
-    ) should be(Some(StartEndLineReadTextMode("SSM", "")))
+    ) should be(Some(StartEndLineReadTextMode("SSM", "", false)))
+  }
+
+  "ReadTextMode" should "return start and end line when configured with trim enabled" in {
+    ReadTextMode(
+      readProps(
+        Map(
+          S3PropsKeyEnum.ReadTextMode.entryName  -> ReadTextModeEnum.StartEndLine.entryName,
+          S3PropsKeyEnum.ReadStartLine.entryName -> "SSM",
+          S3PropsKeyEnum.ReadEndLine.entryName   -> "",
+          S3PropsKeyEnum.ReadTrimLine.entryName  -> "true",
+        ),
+      ),
+    ) should be(Some(StartEndLineReadTextMode("SSM", "", true)))
   }
 
   "ReadTextMode" should "return none when no start or end line is configured" in {

--- a/kafka-connect-common/src/main/scala/io/lenses/streamreactor/connect/config/kcqlprops/KcqlProperties.scala
+++ b/kafka-connect-common/src/main/scala/io/lenses/streamreactor/connect/config/kcqlprops/KcqlProperties.scala
@@ -49,6 +49,17 @@ case class KcqlProperties[U <: EnumEntry, T <: Enum[U]](
       i <- Try(value.toInt).toOption
     } yield i
 
+  def getOptionalBoolean(key: U): Option[Boolean] =
+    for {
+      value:  String <- map.get(key)
+      schema: PropsSchema <- schema.schema.get(key)
+      _ <- schema match {
+        case BooleanPropsSchema => value.some
+        case _                  => Option.empty[String]
+      }
+      b <- Try(value.toBoolean).toOption
+    } yield b
+
   /*
   PKE - props enum (contains the prop keys)
   VE - target enum

--- a/kafka-connect-common/src/main/scala/io/lenses/streamreactor/connect/config/kcqlprops/PropsSchema.scala
+++ b/kafka-connect-common/src/main/scala/io/lenses/streamreactor/connect/config/kcqlprops/PropsSchema.scala
@@ -24,3 +24,5 @@ case class EnumPropsSchema[T <: Enum[_]](t: T) extends PropsSchema
 object StringPropsSchema extends PropsSchema
 
 object IntPropsSchema extends PropsSchema
+
+object BooleanPropsSchema extends PropsSchema

--- a/kafka-connect-common/src/main/scala/io/lenses/streamreactor/connect/io/text/LineStartLineEndReader.scala
+++ b/kafka-connect-common/src/main/scala/io/lenses/streamreactor/connect/io/text/LineStartLineEndReader.scala
@@ -28,13 +28,16 @@ import java.io.InputStreamReader
   * @param start
   * @param end
   */
-class LineStartLineEndReader(input: InputStream, start: String, end: String) extends LineReader {
+class LineStartLineEndReader(input: InputStream, start: String, end: String, trim: Boolean = false) extends LineReader {
   private val br = new BufferedReader(new InputStreamReader(input))
 
   //Returns the next record or None if there are no more
   def next(): Option[String] =
     if (readUntilStart()) {
-      readUntilEndOrNone()
+      if (trim) {
+        readUntilEndOrNone().map(_.trim())
+      } else
+        readUntilEndOrNone()
     } else None
 
   def close(): Unit =

--- a/kafka-connect-common/src/test/scala/io/lenses/streamreactor/connect/io/text/LineStartLineEndReaderTest.scala
+++ b/kafka-connect-common/src/test/scala/io/lenses/streamreactor/connect/io/text/LineStartLineEndReaderTest.scala
@@ -206,5 +206,33 @@ class LineStartLineEndReaderTest extends AnyFunSuite with Matchers {
         |end""".stripMargin,
     )
   }
+  test("handle trim=true") {
+    val reader = new LineStartLineEndReader(createInputStream(
+                                              """
+                                                |start
+                                                |a
+                                                |b
+                                                |c
+                                                |
+                                                |start
+                                                |x
+                                                |
+                                                |""".stripMargin,
+                                            ),
+                                            "start",
+                                            "",
+                                            trim = true,
+    )
+    reader.next() shouldBe Some(
+      """start
+        |a
+        |b
+        |c""".stripMargin,
+    )
+    reader.next() shouldBe Some(
+      """start
+        |x""".stripMargin,
+    )
+  }
   private def createInputStream(data: String): InputStream = new ByteArrayInputStream(data.getBytes)
 }


### PR DESCRIPTION
Support trim on read start-end-line mode.

Adds the support for reading a boolean configuration and extends the line-start-end line reader to consider the flag.