### PR TITLE
S3 source work distribution bug

### DIFF
--- a/kafka-connect-aws-s3/src/main/scala/io/lenses/streamreactor/connect/aws/s3/config/ConnectorTaskId.scala
+++ b/kafka-connect-aws-s3/src/main/scala/io/lenses/streamreactor/connect/aws/s3/config/ConnectorTaskId.scala
@@ -48,5 +48,7 @@ object ConnectorTaskId {
     } yield ConnectorTaskId(maybeTaskName, maxTasks, taskNumber)
   }.leftMap(new IllegalArgumentException(_))
 
-  implicit val showConnector: Show[ConnectorTaskId] = Show.show(_.name)
+  implicit val showConnector: Show[ConnectorTaskId] = Show.show { c =>
+    s"${c.name} - ${c.taskNo + 1} of ${c.maxTasks}"
+  }
 }

--- a/kafka-connect-aws-s3/src/main/scala/io/lenses/streamreactor/connect/aws/s3/sink/S3WriterManager.scala
+++ b/kafka-connect-aws-s3/src/main/scala/io/lenses/streamreactor/connect/aws/s3/sink/S3WriterManager.scala
@@ -81,7 +81,7 @@ class S3WriterManager(
   }
 
   def recommitPending(): Either[SinkError, Unit] = {
-    logger.trace(s"[{}] Retry Pending", connectorTaskId.show)
+    logger.debug(s"[{}] Retry Pending", connectorTaskId.show)
     val result = commitWritersWithFilter(_._2.hasPendingUpload())
     logger.debug(s"[{}] Retry Pending Complete", connectorTaskId.show)
     result

--- a/kafka-connect-aws-s3/src/main/scala/io/lenses/streamreactor/connect/aws/s3/sink/seek/IndexFilenames.scala
+++ b/kafka-connect-aws-s3/src/main/scala/io/lenses/streamreactor/connect/aws/s3/sink/seek/IndexFilenames.scala
@@ -15,7 +15,6 @@
  */
 package io.lenses.streamreactor.connect.aws.s3.sink.seek
 
-import cats.implicits.toShow
 import io.lenses.streamreactor.connect.aws.s3.config.ConnectorTaskId
 import io.lenses.streamreactor.connect.aws.s3.model.Offset
 
@@ -33,7 +32,7 @@ object IndexFilenames {
     * Generate the directory of the index for a given topic and partition
     */
   def indexForTopicPartition(topic: String, partition: Int)(implicit connectorTaskId: ConnectorTaskId): String =
-    f".indexes/${connectorTaskId.show}/$topic/$partition%05d/"
+    f".indexes/${connectorTaskId.name}/$topic/$partition%05d/"
 
   /**
     * Parses an index filename and returns an offset

--- a/kafka-connect-aws-s3/src/main/scala/io/lenses/streamreactor/connect/aws/s3/source/distribution/PartitionSearcher.scala
+++ b/kafka-connect-aws-s3/src/main/scala/io/lenses/streamreactor/connect/aws/s3/source/distribution/PartitionSearcher.scala
@@ -36,7 +36,7 @@ class PartitionSearcher(
   def find(
     lastFound: Seq[PartitionSearcherResponse],
   ): IO[Seq[PartitionSearcherResponse]] =
-    if (lastFound.isEmpty && roots.nonEmpty) {
+    if (lastFound.isEmpty) {
       roots.traverse(findNewPartitionsInRoot(_, settings, Set.empty))
     } else {
       lastFound.traverse {

--- a/kafka-connect-aws-s3/src/main/scala/io/lenses/streamreactor/connect/aws/s3/source/reader/PartitionDiscovery.scala
+++ b/kafka-connect-aws-s3/src/main/scala/io/lenses/streamreactor/connect/aws/s3/source/reader/PartitionDiscovery.scala
@@ -17,8 +17,10 @@ package io.lenses.streamreactor.connect.aws.s3.source.reader
 
 import cats.effect.IO
 import cats.effect.kernel.Ref
+import cats.implicits.toShow
 import cats.implicits.toTraverseOps
 import com.typesafe.scalalogging.LazyLogging
+import io.lenses.streamreactor.connect.aws.s3.config.ConnectorTaskId
 import io.lenses.streamreactor.connect.aws.s3.model.location.S3Location
 import io.lenses.streamreactor.connect.aws.s3.source.config.PartitionSearcherOptions
 import io.lenses.streamreactor.connect.aws.s3.source.distribution.PartitionSearcherResponse
@@ -29,6 +31,7 @@ object PartitionDiscovery extends LazyLogging {
   type PartitionSearcherF = Seq[PartitionSearcherResponse] => IO[Seq[PartitionSearcherResponse]]
 
   def run(
+    connectorTaskId:       ConnectorTaskId,
     settings:              PartitionSearcherOptions,
     partitionSearcher:     PartitionSearcherF,
     readerManagerCreateFn: (S3Location, String) => IO[ReaderManager],
@@ -36,14 +39,14 @@ object PartitionDiscovery extends LazyLogging {
     cancelledRef:          Ref[IO, Boolean],
   ): IO[Unit] = {
     val task = for {
-      _        <- IO(logger.info("Starting the partition discovery task"))
+      _        <- IO(logger.info(s"[${connectorTaskId.show}] Starting the partition discovery task"))
       oldState <- readerManagerState.get
       newParts <- partitionSearcher(oldState.partitionResponses)
       tuples    = newParts.flatMap(part => part.results.partitions.map(part.root -> _))
       newReaderManagers <- tuples
         .map {
           case (location, path) =>
-            logger.info("Creating a new reader manager for {} {}", location.toString, path)
+            logger.info(s"[${connectorTaskId.show}] Creating a new reader manager for ${location.toString} $path")
             readerManagerCreateFn(location, path)
         }.traverse(identity)
       newState = oldState.copy(
@@ -51,21 +54,28 @@ object PartitionDiscovery extends LazyLogging {
         readerManagers     = oldState.readerManagers ++ newReaderManagers,
       )
       _ <- readerManagerState.set(newState)
-      _ <- IO(logger.info("Finished the partition discovery task"))
+      _ <- IO(logger.info(s"[${connectorTaskId.show}] Finished the partition discovery task"))
     } yield ()
 
     if (!settings.continuous) {
-      IO.delay(logger.info("Partition discovery task will only run once")) >>
+      IO.delay(logger.info(s"[${connectorTaskId.show}] Partition discovery task will only run once")) >>
         PollLoop.oneOfIgnoreError(
           settings.interval,
           cancelledRef,
-          err => logger.error("Error in partition discovery task. Partition discovery will resume.", err),
+          err =>
+            logger.error(
+              s"[${connectorTaskId.show}] Error in partition discovery task. Partition discovery will resume.",
+              err,
+            ),
         )(() => task)
     } else {
-      IO.delay(logger.info("Partition discovery task will run continuously")) >>
+      IO.delay(logger.info(s"[${connectorTaskId.show}] Partition discovery task will run continuously")) >>
         PollLoop.run(settings.interval, cancelledRef)(() =>
           task.handleErrorWith { err =>
-            IO(logger.error("Error in partition discovery task. Partition discovery will resume.", err))
+            IO(logger.error(
+              s"[${connectorTaskId.show}] Error in partition discovery task. Partition discovery will resume.",
+              err,
+            ))
           },
         )
     }

--- a/kafka-connect-aws-s3/src/main/scala/io/lenses/streamreactor/connect/aws/s3/source/state/ReaderManagerBuilder.scala
+++ b/kafka-connect-aws-s3/src/main/scala/io/lenses/streamreactor/connect/aws/s3/source/state/ReaderManagerBuilder.scala
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2017-2023 Lenses.io Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.lenses.streamreactor.connect.aws.s3.source.state
+
+import cats.effect.IO
+import cats.effect.Ref
+import io.lenses.streamreactor.connect.aws.s3.config.ConnectorTaskId
+import io.lenses.streamreactor.connect.aws.s3.model.location.S3Location
+import io.lenses.streamreactor.connect.aws.s3.source.config.SourceBucketOptions
+import io.lenses.streamreactor.connect.aws.s3.source.files.S3SourceFileQueue
+import io.lenses.streamreactor.connect.aws.s3.source.reader.ReaderManager
+import io.lenses.streamreactor.connect.aws.s3.source.reader.ResultReader
+import io.lenses.streamreactor.connect.aws.s3.storage.StorageInterface
+import org.apache.kafka.connect.errors.ConnectException
+
+/**
+  * Responsible for creating an instance of {{{ReaderManager}}} for a given path.
+  */
+object ReaderManagerBuilder {
+  def apply(
+    root:             S3Location,
+    path:             String,
+    storageInterface: StorageInterface,
+    connectorTaskId:  ConnectorTaskId,
+    contextOffsetFn:  S3Location => Option[S3Location],
+    findSboF:         S3Location => Option[SourceBucketOptions],
+  ): IO[ReaderManager] =
+    for {
+      sbo <- IO.fromEither(
+        findSboF(root).toRight(
+          new ConnectException(s"No root found for path:$path"),
+        ),
+      )
+      ref        <- Ref[IO].of(Option.empty[ResultReader])
+      adaptedRoot = root.copy(prefix = Some(path))
+      adaptedSbo  = sbo.copy(sourceBucketAndPrefix = adaptedRoot)
+      listingFn   = adaptedSbo.createBatchListerFn(storageInterface)
+      source = contextOffsetFn(adaptedRoot).fold {
+        new S3SourceFileQueue(connectorTaskId, listingFn)
+      } { location =>
+        S3SourceFileQueue.from(
+          listingFn,
+          storageInterface.getBlobModified,
+          location,
+          connectorTaskId,
+        )
+      }
+    } yield ReaderManager(
+      sbo.recordsLimit,
+      source,
+      ResultReader.create(sbo.format, sbo.targetTopic, sbo.getPartitionExtractorFn, connectorTaskId, storageInterface),
+      connectorTaskId,
+      ref,
+    )
+
+}

--- a/kafka-connect-aws-s3/src/test/scala/io/lenses/streamreactor/connect/aws/s3/source/state/ReaderManagerBuilderTest.scala
+++ b/kafka-connect-aws-s3/src/test/scala/io/lenses/streamreactor/connect/aws/s3/source/state/ReaderManagerBuilderTest.scala
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2017-2023 Lenses.io Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.lenses.streamreactor.connect.aws.s3.source.state
+
+import cats.effect.unsafe.implicits.global
+import io.lenses.streamreactor.connect.aws.s3.config.AvroFormatSelection
+import io.lenses.streamreactor.connect.aws.s3.config.ConnectorTaskId
+import io.lenses.streamreactor.connect.aws.s3.model.location.S3Location
+import io.lenses.streamreactor.connect.aws.s3.source.config.OrderingType
+import io.lenses.streamreactor.connect.aws.s3.source.config.SourceBucketOptions
+import io.lenses.streamreactor.connect.aws.s3.storage.StorageInterface
+import org.mockito.MockitoSugar.mock
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.should.Matchers
+
+class ReaderManagerBuilderTest extends AnyFunSuite with Matchers {
+  test("Adapts the root to contain the path and calls the offsets with the adapter root") {
+    val si = mock[StorageInterface]
+    val root = S3Location(
+      "bucket",
+      Some("prefix1"),
+      None,
+      None,
+      None,
+    )
+    val path = "prefix1/subprefixA/subprefixB/"
+    var rootValue: Option[S3Location] = None
+    val contextF: S3Location => Option[S3Location] = { in =>
+      rootValue = Some(in)
+      rootValue
+    }
+    val sbo    = SourceBucketOptions(root, "topic", AvroFormatSelection, 100, 100, None, OrderingType.LastModified)
+    val taskId = ConnectorTaskId("test", 3, 1)
+    val io     = ReaderManagerBuilder(root, path, si, taskId, contextF, _ => Some(sbo))
+    io.unsafeRunSync()
+    rootValue shouldBe Some(root.copy(prefix = Some(path)))
+  }
+}


### PR DESCRIPTION
This PR addresses the bug in the S3 source not distributing the workload. The issue lies with AwsS3DirectoryLister and the check on ConnectorTaskId:owns. The check was applied at the root and intermediary paths to the location, and if it was none, the search was stopped. However, the check should happen when it reaches the recursive/nested level.


PartitionDiscovery now logs the connector task details.

ConnectorTaskId.show was also changed to output the task count to help debug when multiple tasks run on the same connect worker.

S3SourceBuilder logic has changed when a reader manager is created. The partition search provides the root S3 location and a full path to the partition. The partition path becomes the prefix to align with the S3 listing interface. Since the connector offsets keep track of the partition, the call to contextOffsetFn receives the adapted S3 location.

All of the changes ensure the work distribution and the source exactly once semantic.