### PR TITLE
S3 source default records per poll 

### DIFF
--- a/kafka-connect-aws-s3/src/main/scala/io/lenses/streamreactor/connect/aws/s3/source/config/S3SourceConfig.scala
+++ b/kafka-connect-aws-s3/src/main/scala/io/lenses/streamreactor/connect/aws/s3/source/config/S3SourceConfig.scala
@@ -96,7 +96,7 @@ case class SourceBucketOptions(
 }
 
 object SourceBucketOptions {
-  private val DEFAULT_RECORDS_LIMIT = 1024
+  private val DEFAULT_RECORDS_LIMIT = 10000
   private val DEFAULT_FILES_LIMIT   = 1000
 
   def apply(


### PR DESCRIPTION
If not specified in the KCQL statement, the s3 source limits the number of records returned on each poll to 1024. This is a small number and impacts throughput. The change changes the default to 10000