### PR TITLE
S3 source default partition recursive level

### DIFF
--- a/kafka-connect-aws-s3/src/main/scala/io/lenses/streamreactor/connect/aws/s3/config/S3ConfigSettings.scala
+++ b/kafka-connect-aws-s3/src/main/scala/io/lenses/streamreactor/connect/aws/s3/config/S3ConfigSettings.scala
@@ -124,7 +124,7 @@ object S3ConfigSettings {
   val SOURCE_PARTITION_SEARCH_RECURSE_LEVELS: String = s"$CONNECTOR_PREFIX.partition.search.recurse.levels"
   val SOURCE_PARTITION_SEARCH_RECURSE_LEVELS_DOC: String =
     "When searching for new partitions on the S3 filesystem, how many levels deep to recurse."
-  val SOURCE_PARTITION_SEARCH_RECURSE_LEVELS_DEFAULT: Int = 3
+  val SOURCE_PARTITION_SEARCH_RECURSE_LEVELS_DEFAULT: Int = 0
 
   val SOURCE_PARTITION_SEARCH_INTERVAL_MILLIS: String = s"$CONNECTOR_PREFIX.partition.search.interval"
   val SOURCE_PARTITION_SEARCH_INTERVAL_MILLIS_DOC: String =

--- a/kafka-connect-aws-s3/src/test/scala/io/lenses/streamreactor/connect/aws/s3/source/config/S3SourceConfigTests.scala
+++ b/kafka-connect-aws-s3/src/test/scala/io/lenses/streamreactor/connect/aws/s3/source/config/S3SourceConfigTests.scala
@@ -23,6 +23,19 @@ import scala.concurrent.duration._
 import scala.jdk.CollectionConverters._
 
 class S3SourceConfigTests extends AnyFunSuite with Matchers {
+  test("default recursive levels is 0") {
+    S3SourceConfig.fromProps(
+      Map(
+        SOURCE_PARTITION_SEARCH_MODE            -> "false",
+        SOURCE_PARTITION_SEARCH_INTERVAL_MILLIS -> "1000",
+        TASK_INDEX                              -> "1:0",
+        KCQL_CONFIG                             -> "INSERT INTO topic SELECT * FROM bucket:/a/b/c",
+      ).asJava,
+    ) match {
+      case Left(value)  => fail(value.toString)
+      case Right(value) => value.partitionSearcher shouldBe PartitionSearcherOptions(0, false, 1.seconds)
+    }
+  }
   test("partition search options disables the continuous search") {
     S3SourceConfig.fromProps(
       Map(


### PR DESCRIPTION
The default is changed from 3 to 0. This is done because most of the time the S3 location points to the parent partition "folder"