### PR TITLE
S3 Sink: Allow backticks in KCQL partition fields

### DIFF
--- a/kafka-connect-aws-s3/src/it/scala/io/lenses/streamreactor/connect/aws/s3/sink/S3SinkTaskTest.scala
+++ b/kafka-connect-aws-s3/src/it/scala/io/lenses/streamreactor/connect/aws/s3/sink/S3SinkTaskTest.scala
@@ -1181,25 +1181,6 @@ class S3SinkTaskTest extends AnyFlatSpec with Matchers with S3ProxyContainerTest
     )
   }
 
-  "S3SinkTask" should "not get past kcql parser when contains a slash" in {
-
-    val task = new S3SinkTask()
-
-    val keyWithSlash = "_key.date/of/birth"
-
-    val props = DefaultProps
-      .combine(
-        Map(
-          "connect.s3.kcql" -> s"insert into $BucketName:$PrefixName select * from $TopicName PARTITIONBY $keyWithSlash, _key.phonePrefix STOREAS `CSV` WITH_FLUSH_COUNT = 1",
-        ),
-      ).asJava
-
-    intercept[IllegalArgumentException] {
-      task.start(props)
-    }.getMessage contains "no viable alternative at input"
-
-  }
-
   "S3SinkTask" should "allow partitioning by complex key and values" in {
 
     val task = new S3SinkTask()

--- a/kafka-connect-aws-s3/src/it/scala/io/lenses/streamreactor/connect/aws/s3/sink/S3SinkTaskTest.scala
+++ b/kafka-connect-aws-s3/src/it/scala/io/lenses/streamreactor/connect/aws/s3/sink/S3SinkTaskTest.scala
@@ -1696,6 +1696,7 @@ class S3SinkTaskTest extends AnyFlatSpec with Matchers with S3ProxyContainerTest
     val structMapSchema: Schema = SchemaBuilder.struct()
       .field("user", schema)
       .field("favourites", favsSchema)
+      .field("cost.centre.id", SchemaBuilder.string())
       .build()
 
     val nested: List[Struct] = List(
@@ -1709,6 +1710,10 @@ class S3SinkTaskTest extends AnyFlatSpec with Matchers with S3ProxyContainerTest
         .put(
           "favourites",
           Map("band" -> "the killers", "film" -> "a clockwork orange").asJava,
+        )
+        .put(
+          "cost.centre.id",
+          "100",
         ),
       new Struct(structMapSchema)
         .put("user",
@@ -1720,6 +1725,10 @@ class S3SinkTaskTest extends AnyFlatSpec with Matchers with S3ProxyContainerTest
         .put(
           "favourites",
           Map("band" -> "the strokes", "film" -> "a clockwork orange").asJava,
+        )
+        .put(
+          "cost.centre.id",
+          "200",
         ),
       new Struct(structMapSchema)
         .put("user",
@@ -1731,6 +1740,10 @@ class S3SinkTaskTest extends AnyFlatSpec with Matchers with S3ProxyContainerTest
         .put(
           "favourites",
           Map().asJava,
+        )
+        .put(
+          "cost.centre.id",
+          "100",
         ),
     )
 
@@ -1750,7 +1763,7 @@ class S3SinkTaskTest extends AnyFlatSpec with Matchers with S3ProxyContainerTest
     val props = DefaultProps
       .combine(
         Map(
-          "connect.s3.kcql" -> s"insert into $BucketName:$PrefixName select * from $TopicName PARTITIONBY _key.favourites.band WITH_FLUSH_COUNT = 1",
+          "connect.s3.kcql" -> s"insert into $BucketName:$PrefixName select * from $TopicName PARTITIONBY _key.favourites.band, _key.`cost.centre.id` WITH_FLUSH_COUNT = 1",
         ),
       ).asJava
 
@@ -1765,9 +1778,9 @@ class S3SinkTaskTest extends AnyFlatSpec with Matchers with S3ProxyContainerTest
     fileList.size should be(3)
 
     fileList should contain allOf (
-      "streamReactorBackups/favourites.band=the strokes/myTopic(000000000001_000000000000).json",
-      "streamReactorBackups/favourites.band=the killers/myTopic(000000000000_000000000000).json",
-      "streamReactorBackups/favourites.band=[missing]/myTopic(000000000001_000000000001).json",
+      "streamReactorBackups/favourites.band=the strokes/cost.centre.id=200/myTopic(000000000001_000000000000).json",
+      "streamReactorBackups/favourites.band=the killers/cost.centre.id=100/myTopic(000000000000_000000000000).json",
+      "streamReactorBackups/favourites.band=[missing]/cost.centre.id=100/myTopic(000000000001_000000000001).json",
     )
   }
 

--- a/kafka-connect-aws-s3/src/main/scala/io/lenses/streamreactor/connect/aws/s3/sink/config/PartitionField.scala
+++ b/kafka-connect-aws-s3/src/main/scala/io/lenses/streamreactor/connect/aws/s3/sink/config/PartitionField.scala
@@ -32,7 +32,7 @@ object PartitionField {
       .map(_.asScala)
       .getOrElse(Nil)
       .map { name =>
-        val split = name.split("\\.").toSeq
+        val split: Seq[String] = PartitionFieldSplitter.split(name)
         PartitionSpecifier.withNameOption(split.head).fold(PartitionField(split))(hd =>
           if (split.tail.isEmpty) PartitionField(hd) else PartitionField(hd, split.tail),
         )

--- a/kafka-connect-aws-s3/src/main/scala/io/lenses/streamreactor/connect/aws/s3/sink/config/PartitionFieldSplitter.scala
+++ b/kafka-connect-aws-s3/src/main/scala/io/lenses/streamreactor/connect/aws/s3/sink/config/PartitionFieldSplitter.scala
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2017-2023 Lenses.io Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.lenses.streamreactor.connect.aws.s3.sink.config
+
+/**
+  * A utility for splitting a string into parts while respecting backticks.
+  */
+object PartitionFieldSplitter {
+
+  /**
+    * Splits an input string into parts while respecting backticks.
+    * Backticks are treated as complete strings and not subject to splitting.
+    *
+    * @param input The input string to split.
+    * @return A sequence of strings representing the split parts.
+    */
+  def split(input: String): Seq[String] =
+    input.foldLeft((Seq.empty[String], "", false)) {
+      case ((result, currentPart, insideBacktick), char) =>
+        (char, currentPart, insideBacktick) match {
+          case ('`', "", false)   => (result, currentPart, true)
+          case ('`', part, true)  => (result :+ part, "", false)
+          case ('.', "", false)   => (result, currentPart, false)
+          case ('.', part, false) => (result :+ part, "", false)
+          case (c, part, _)       => (result, part + c, insideBacktick)
+        }
+    } match {
+      case (result, currentPart, _) =>
+        if (currentPart.nonEmpty) result :+ currentPart
+        else result
+    }
+}

--- a/kafka-connect-aws-s3/src/test/scala/io/lenses/streamreactor/connect/aws/s3/sink/config/PartitionFieldSplitterTest.scala
+++ b/kafka-connect-aws-s3/src/test/scala/io/lenses/streamreactor/connect/aws/s3/sink/config/PartitionFieldSplitterTest.scala
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2017-2023 Lenses.io Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.lenses.streamreactor.connect.aws.s3.sink.config
+
+import org.scalatest.flatspec.AnyFlatSpecLike
+import org.scalatest.matchers.should.Matchers
+
+class PartitionFieldSplitterTest extends AnyFlatSpecLike with Matchers {
+  it should "split fields" in {
+    PartitionFieldSplitter.split("_key") should be(Seq("_key"))
+
+    PartitionFieldSplitter.split("_key.field.a") should be(Seq("_key", "field", "a"))
+    PartitionFieldSplitter.split("_key.`field.a`") should be(Seq("_key", "field.a"))
+    PartitionFieldSplitter.split("_value.field.a") should be(Seq("_value", "field", "a"))
+    PartitionFieldSplitter.split("_value.`field.a`") should be(Seq("_value", "field.a"))
+    PartitionFieldSplitter.split("_value.field.a.`b.c.d`") should be(Seq("_value", "field", "a", "b.c.d"))
+    PartitionFieldSplitter.split("_value.field.a.`b.c.d`.`e.f.g`") should be(Seq("_value",
+                                                                                 "field",
+                                                                                 "a",
+                                                                                 "b.c.d",
+                                                                                 "e.f.g",
+    ))
+
+  }
+
+}

--- a/kafka-connect-query-language/src/main/antlr4/ConnectorLexer.g4
+++ b/kafka-connect-query-language/src/main/antlr4/ConnectorLexer.g4
@@ -277,11 +277,11 @@ RIGHT_PARAN
     : ')'
     ;
 
+
 FIELD
-   : ( ESCAPED_FIELD | 'a' .. 'z' | 'A' .. 'Z' | '@' |'_' | '0' .. '9' )+
+   : ( 'a' .. 'z' | 'A' .. 'Z' | '@' |'_' | '0' .. '9' )+
    ;
 
-fragment ESCAPED_FIELD    : ( '`' (~'`')+ '`');
 
 TOPICNAME
    : ( 'a' .. 'z' | 'A' .. 'Z' | '_' | '0' .. '9' | '-' | '+' | '/' |'{'|'}'|':' )+ | ESCAPED_TOPIC
@@ -295,6 +295,10 @@ KEYDELIMVALUE
 
 fragment ESCAPED_TOPIC
     : ( '`' (~'`')+ '`')
+    ;
+
+ESCAPED_FIELD
+    : FIELD DOT ( '`' (~'`')+ '`')
     ;
 
 STRING: '\'' ~('\'' | '\r' | '\n')* '\'';

--- a/kafka-connect-query-language/src/main/antlr4/ConnectorLexer.g4
+++ b/kafka-connect-query-language/src/main/antlr4/ConnectorLexer.g4
@@ -277,11 +277,11 @@ RIGHT_PARAN
     : ')'
     ;
 
-
 FIELD
-   : ( 'a' .. 'z' | 'A' .. 'Z' | '@' |'_' | '0' .. '9' )+
+   : ( ESCAPED_FIELD | 'a' .. 'z' | 'A' .. 'Z' | '@' |'_' | '0' .. '9' )+
    ;
 
+fragment ESCAPED_FIELD    : ( '`' (~'`')+ '`');
 
 TOPICNAME
    : ( 'a' .. 'z' | 'A' .. 'Z' | '_' | '0' .. '9' | '-' | '+' | '/' |'{'|'}'|':' )+ | ESCAPED_TOPIC

--- a/kafka-connect-query-language/src/main/antlr4/ConnectorParser.g4
+++ b/kafka-connect-query-language/src/main/antlr4/ConnectorParser.g4
@@ -74,6 +74,14 @@ column
    : FIELD ( DOT FIELD )* (DOT ASTERISK)? | STRING
    ;
 
+partition_column
+   : (field_or_quoted_field ( DOT field_or_quoted_field )* (DOT ASTERISK)?) | STRING
+   ;
+
+field_or_quoted_field
+   : ((ESCAPED_FIELD | FIELD)* DOT*)
+   ;
+
 column_name_alias
    : FIELD | STRING
    ;
@@ -131,7 +139,7 @@ initialize
    ;
 
 partition_name
-   : column
+   : partition_column
    ;
 
 partition_list

--- a/kafka-connect-query-language/src/test/scala/com/datamountaineer/kcql/KcqlTest.scala
+++ b/kafka-connect-query-language/src/test/scala/com/datamountaineer/kcql/KcqlTest.scala
@@ -375,6 +375,17 @@ class KcqlTest extends AnyFunSuite with OptionValues {
     partitionBy should contain allOf ("_header.col1", "_header.col2")
   }
 
+  test("partitionByShouldAllowQuotingGroupsOfFields") {
+    val topic = "TOPIC_A"
+    val table = "TABLE_A"
+    val syntax =
+      s"UPSERT INTO $table SELECT * FROM $topic IGNORE col1, 1col2 PARTITIONBY _header.cost.centre.id,_header.`cost.centre.id`  "
+    val kcql        = Kcql.parse(syntax)
+    val partitionBy = kcql.getPartitionBy.asScala.toSet
+    partitionBy should have size 2
+    partitionBy should contain allOf ("_header.cost.centre.id", "_header.`cost.centre.id`")
+  }
+
   test("handlerPartitionByWhenSpecificFieldsAreIncluded") {
     val topic       = "TOPIC_A"
     val table       = "TABLE_A"


### PR DESCRIPTION


To distinguish between flattened and nested json structures in configuration

Currently a dot is a special character in the `KCQL PARTITIONBY` statements (connector dependent)

This currently works well for nested structures.  For example:

`
"myObject": {
  "user": {
    name: "Bob"
  }
}
`

myObject.user.name will give us "Bob".

However it will not work for a flattened structure where the key contains a dot:
`
{ "myObject.user.name": "Bob" }
`
This PR ensures that you are able to specify in KCQL if the key should be respected whole by using backticks:

```
PARTITIONBY _key.`myObject.user.name`
```

where the part surrounded by backticks will be the section which must be used whole.

This fixes an issue reported via Lenses community Slack.