### PR TITLE
RB-476 - Take a branch and rename the classes

### DIFF
--- a/kafka-connect-aws-s3/README-sink.md
+++ b/kafka-connect-aws-s3/README-sink.md
@@ -7,7 +7,7 @@ Before reading this document it is recommended to be familiar with the [general 
 An example configuration is provided:
 
     name=S3SinkConnectorParquet # this can be anything
-    connector.class=io.lenses.streamreactor.connect.aws.s3.sink.S3SinkConnector
+    connector.class=io.lenses.streamreactor.connect.aws.s3.sink.S3SinkConnectorDeprecated
     topics=$TOPIC_NAME
     tasks.max=1
     connect.s3.kcql=insert into $BUCKET_NAME:$PREFIX_NAME select * from $TOPIC_NAME STOREAS `parquet` WITH_FLUSH_COUNT = 5000 

--- a/kafka-connect-aws-s3/README-source.md
+++ b/kafka-connect-aws-s3/README-source.md
@@ -12,7 +12,7 @@ The source files may have been written by the Lenses.io S3 Sink or other produce
 An example configuration is provided:
 
     name=S3SourceConnectorParquet # this can be anything
-    connector.class=io.lenses.streamreactor.connect.aws.s3.source.S3SourceConnector
+    connector.class=io.lenses.streamreactor.connect.aws.s3.source.S3SourceConnectorDeprecated
     tasks.max=1
     connect.s3.kcql=insert into $TOPIC_NAME select * from $BUCKET_NAME:$PREFIX_NAME STOREAS `parquet`
     connect.s3.aws.secret.key=SECRET_KEY

--- a/kafka-connect-aws-s3/src/fun/scala/io/lenses/streamreactor/connect/Configuration.scala
+++ b/kafka-connect-aws-s3/src/fun/scala/io/lenses/streamreactor/connect/Configuration.scala
@@ -19,7 +19,7 @@ object Configuration {
     ConnectorConfiguration(
       "connector" + randomTestId,
       Map(
-        "connector.class"            -> ConfigValue("io.lenses.streamreactor.connect.aws.s3.sink.S3SinkConnector"),
+        "connector.class"            -> ConfigValue("io.lenses.streamreactor.connect.aws.s3.sink.S3SinkConnectorDeprecated"),
         "tasks.max"                  -> ConfigValue(1),
         "topics"                     -> ConfigValue(topicName),
         "connect.s3.aws.access.key"  -> ConfigValue(auth.identity),

--- a/kafka-connect-aws-s3/src/it/scala/io/lenses/streamreactor/connect/aws/s3/sink/S3SinkTaskAvroEnvelopeTest.scala
+++ b/kafka-connect-aws-s3/src/it/scala/io/lenses/streamreactor/connect/aws/s3/sink/S3SinkTaskAvroEnvelopeTest.scala
@@ -98,7 +98,7 @@ class S3SinkTaskAvroEnvelopeTest
 
   "S3SinkTask" should "write to avro format" in {
 
-    val task = new S3SinkTask()
+    val task = new S3SinkTaskDeprecated()
 
     val props = DefaultProps
       .combine(
@@ -232,7 +232,7 @@ class S3SinkTaskAvroEnvelopeTest
 
   "S3SinkTask" should "write to avro format when input is java Map" in {
 
-    val task = new S3SinkTask()
+    val task = new S3SinkTaskDeprecated()
 
     val props = DefaultProps
       .combine(

--- a/kafka-connect-aws-s3/src/it/scala/io/lenses/streamreactor/connect/aws/s3/sink/S3SinkTaskDeprecatedTest.scala
+++ b/kafka-connect-aws-s3/src/it/scala/io/lenses/streamreactor/connect/aws/s3/sink/S3SinkTaskDeprecatedTest.scala
@@ -57,7 +57,7 @@ import scala.jdk.CollectionConverters.MapHasAsScala
 import scala.jdk.CollectionConverters.SeqHasAsJava
 import scala.util.Try
 
-class S3SinkTaskTest extends AnyFlatSpec with Matchers with S3ProxyContainerTest with MockitoSugar with LazyLogging {
+class S3SinkTaskDeprecatedTest extends AnyFlatSpec with Matchers with S3ProxyContainerTest with MockitoSugar with LazyLogging {
 
   import helper._
   import io.lenses.streamreactor.connect.aws.s3.utils.ITSampleSchemaAndData._
@@ -162,7 +162,7 @@ class S3SinkTaskTest extends AnyFlatSpec with Matchers with S3ProxyContainerTest
 
   "S3SinkTask" should "flush on configured flush time intervals" in {
 
-    val task = new S3SinkTask()
+    val task = new S3SinkTaskDeprecated()
 
     val props = DeprecatedProps
       .combine(
@@ -195,7 +195,7 @@ class S3SinkTaskTest extends AnyFlatSpec with Matchers with S3ProxyContainerTest
 
   "S3SinkTask" should "throw error if prefix contains a slash" in {
 
-    val task = new S3SinkTask()
+    val task = new S3SinkTaskDeprecated()
 
     val prefixWithSlashes = "my/prefix/that/is/a/path"
     val props = DefaultProps
@@ -215,7 +215,7 @@ class S3SinkTaskTest extends AnyFlatSpec with Matchers with S3ProxyContainerTest
 
   "S3SinkTask" should "flush for every record when configured flush count size of 1" in {
 
-    val task = new S3SinkTask()
+    val task = new S3SinkTaskDeprecated()
 
     val props = DefaultProps
       .combine(
@@ -249,7 +249,7 @@ class S3SinkTaskTest extends AnyFlatSpec with Matchers with S3ProxyContainerTest
     */
   "S3SinkTask" should "flush on configured file size" in {
 
-    val task = new S3SinkTask()
+    val task = new S3SinkTaskDeprecated()
 
     val props = DefaultProps
       .combine(
@@ -274,7 +274,7 @@ class S3SinkTaskTest extends AnyFlatSpec with Matchers with S3ProxyContainerTest
 
   "S3SinkTask" should "flush on configured file size for Parquet" in {
 
-    val task = new S3SinkTask()
+    val task = new S3SinkTaskDeprecated()
 
     val props = DefaultProps
       .combine(
@@ -309,9 +309,9 @@ class S3SinkTaskTest extends AnyFlatSpec with Matchers with S3ProxyContainerTest
 
   }
 
-  def createTask(context: SinkTaskContext, props: util.Map[String, String]): S3SinkTask = {
+  def createTask(context: SinkTaskContext, props: util.Map[String, String]): S3SinkTaskDeprecated = {
     reset(context)
-    val task: S3SinkTask = new S3SinkTask()
+    val task: S3SinkTaskDeprecated = new S3SinkTaskDeprecated()
     task.initialize(context)
     task.start(props)
     task
@@ -323,7 +323,7 @@ class S3SinkTaskTest extends AnyFlatSpec with Matchers with S3ProxyContainerTest
     */
   "S3SinkTask" should "put existing offsets to the context" in {
 
-    val task = new S3SinkTask()
+    val task = new S3SinkTaskDeprecated()
 
     val props = DefaultProps
       .combine(
@@ -366,7 +366,7 @@ class S3SinkTaskTest extends AnyFlatSpec with Matchers with S3ProxyContainerTest
       ).asJava
     val context = mock[SinkTaskContext]
 
-    var task: S3SinkTask = createTask(context, props)
+    var task: S3SinkTaskDeprecated = createTask(context, props)
 
     task.open(Seq(new TopicPartition(TopicName, 1)).asJava)
     verify(context, never).offset(new TopicPartition("myTopic", 1), 0)
@@ -437,7 +437,7 @@ class S3SinkTaskTest extends AnyFlatSpec with Matchers with S3ProxyContainerTest
 
   "S3SinkTask" should "write to parquet format" in {
 
-    val task = new S3SinkTask()
+    val task = new S3SinkTaskDeprecated()
 
     val props = DefaultProps
       .combine(
@@ -464,7 +464,7 @@ class S3SinkTaskTest extends AnyFlatSpec with Matchers with S3ProxyContainerTest
 
   "S3SinkTask" should "write to avro format" in {
 
-    val task = new S3SinkTask()
+    val task = new S3SinkTaskDeprecated()
 
     val props = DefaultProps
       .combine(
@@ -491,7 +491,7 @@ class S3SinkTaskTest extends AnyFlatSpec with Matchers with S3ProxyContainerTest
 
   "S3SinkTask" should "error when trying to write AVRO to text format" in {
 
-    val task = new S3SinkTask()
+    val task = new S3SinkTaskDeprecated()
 
     val props = DefaultProps
       .combine(
@@ -518,7 +518,7 @@ class S3SinkTaskTest extends AnyFlatSpec with Matchers with S3ProxyContainerTest
       new SinkRecord(TopicName, 1, null, null, null, "Peas", 2),
       new SinkRecord(TopicName, 1, null, null, null, "Gravy", 3),
     )
-    val task = new S3SinkTask()
+    val task = new S3SinkTaskDeprecated()
 
     val props = DefaultProps
       .combine(
@@ -545,7 +545,7 @@ class S3SinkTaskTest extends AnyFlatSpec with Matchers with S3ProxyContainerTest
 
   "S3SinkTask" should "write to csv format with headers" in {
 
-    val task = new S3SinkTask()
+    val task = new S3SinkTaskDeprecated()
 
     val extraRecord = toSinkRecord(new Struct(schema).put("name", "bob").put("title", "mr").put("salary", 200.86), 3)
 
@@ -589,7 +589,7 @@ class S3SinkTaskTest extends AnyFlatSpec with Matchers with S3ProxyContainerTest
 
   "S3SinkTask" should "write to csv format without headers" in {
 
-    val task = new S3SinkTask()
+    val task = new S3SinkTaskDeprecated()
 
     val extraRecord = toSinkRecord(new Struct(schema).put("name", "bob").put("title", "mr").put("salary", 200.86), 3)
 
@@ -631,7 +631,7 @@ class S3SinkTaskTest extends AnyFlatSpec with Matchers with S3ProxyContainerTest
 
   "S3SinkTask" should "use custom partitioning scheme and flush for every record" in {
 
-    val task = new S3SinkTask()
+    val task = new S3SinkTaskDeprecated()
 
     val props = DefaultProps
       .combine(
@@ -682,7 +682,7 @@ class S3SinkTaskTest extends AnyFlatSpec with Matchers with S3ProxyContainerTest
     */
   "S3SinkTask" should "use custom partitioning scheme and flush after two written records" in {
 
-    val task = new S3SinkTask()
+    val task = new S3SinkTaskDeprecated()
 
     val partitionedData: List[Struct] = List(
       new Struct(schema).put("name", "first").put("title", "primary").put("salary", null),
@@ -738,7 +738,7 @@ class S3SinkTaskTest extends AnyFlatSpec with Matchers with S3ProxyContainerTest
 
   "S3SinkTask" should "use custom partitioning with value display only" in {
 
-    val task = new S3SinkTask()
+    val task = new S3SinkTaskDeprecated()
 
     val props = DefaultProps
       .combine(
@@ -798,7 +798,7 @@ class S3SinkTaskTest extends AnyFlatSpec with Matchers with S3ProxyContainerTest
       new SinkRecord(TopicName, 1, null, null, null, bytes1, 0),
       new SinkRecord(TopicName, 1, null, null, null, bytes2, 1),
     )
-    val task = new S3SinkTask()
+    val task = new S3SinkTaskDeprecated()
 
     val props = DefaultProps
       .combine(
@@ -857,7 +857,7 @@ class S3SinkTaskTest extends AnyFlatSpec with Matchers with S3ProxyContainerTest
                      createHeaders(("phonePrefix", "+49"), ("region", "5")),
       ),
     )
-    val task = new S3SinkTask()
+    val task = new S3SinkTaskDeprecated()
 
     val props = DefaultProps
       .combine(
@@ -892,7 +892,7 @@ class S3SinkTaskTest extends AnyFlatSpec with Matchers with S3ProxyContainerTest
 
   "S3SinkTask" should "combine header and value-extracted partition" in {
 
-    val task = new S3SinkTask()
+    val task = new S3SinkTaskDeprecated()
 
     val props = DefaultProps
       .combine(
@@ -927,7 +927,7 @@ class S3SinkTaskTest extends AnyFlatSpec with Matchers with S3ProxyContainerTest
       createSinkRecord(1, users(1), 0, createHeaders(("hair", "blue"), ("feet", "5"))),
     )
 
-    val task = new S3SinkTask()
+    val task = new S3SinkTaskDeprecated()
 
     val props = DefaultProps
       .combine(
@@ -958,7 +958,7 @@ class S3SinkTaskTest extends AnyFlatSpec with Matchers with S3ProxyContainerTest
       createSinkRecord(1, users(1), 1, createHeaders[AnyVal](("longheader", 2L), ("intheader", 2))),
       createSinkRecord(2, users(2), 2, createHeaders[AnyVal](("intheader", 1), ("longheader", 1L))),
     )
-    val task = new S3SinkTask()
+    val task = new S3SinkTaskDeprecated()
 
     val props = DefaultProps
       .combine(
@@ -990,7 +990,7 @@ class S3SinkTaskTest extends AnyFlatSpec with Matchers with S3ProxyContainerTest
         new SinkRecord(TopicName, 1, null, (k % 2).toString, schema, user, k.toLong, null, null)
     }
 
-    val task = new S3SinkTask()
+    val task = new S3SinkTaskDeprecated()
 
     val props = DefaultProps
       .combine(
@@ -1025,7 +1025,7 @@ class S3SinkTaskTest extends AnyFlatSpec with Matchers with S3ProxyContainerTest
         new SinkRecord(TopicName, 1, null, (k % 2).toString, schema, user, k.toLong, null, null)
     }
 
-    val task = new S3SinkTask()
+    val task = new S3SinkTaskDeprecated()
 
     val props = DefaultProps
       .combine(
@@ -1060,7 +1060,7 @@ class S3SinkTaskTest extends AnyFlatSpec with Matchers with S3ProxyContainerTest
         new SinkRecord(TopicName, 1, null, (k % 2).toString, schema, user, k.toLong, null, null)
     }
 
-    val task = new S3SinkTask()
+    val task = new S3SinkTaskDeprecated()
 
     val props = DefaultProps
       .combine(
@@ -1095,7 +1095,7 @@ class S3SinkTaskTest extends AnyFlatSpec with Matchers with S3ProxyContainerTest
         new SinkRecord(TopicName, 1, null, user, schema, user, k.toLong, null, null)
     }
 
-    val task = new S3SinkTask()
+    val task = new S3SinkTaskDeprecated()
 
     val props = DefaultProps
       .combine(
@@ -1126,7 +1126,7 @@ class S3SinkTaskTest extends AnyFlatSpec with Matchers with S3ProxyContainerTest
         new SinkRecord(TopicName, 1, null, k % 2, schema, user, k.toLong, null, null)
     }
 
-    val task = new S3SinkTask()
+    val task = new S3SinkTaskDeprecated()
 
     val props = DefaultProps
       .combine(
@@ -1156,7 +1156,7 @@ class S3SinkTaskTest extends AnyFlatSpec with Matchers with S3ProxyContainerTest
 
   "S3SinkTask" should "allow partitioning by complex key" in {
 
-    val task = new S3SinkTask()
+    val task = new S3SinkTaskDeprecated()
 
     val props = DefaultProps
       .combine(
@@ -1183,7 +1183,7 @@ class S3SinkTaskTest extends AnyFlatSpec with Matchers with S3ProxyContainerTest
 
   "S3SinkTask" should "not get past kcql parser when contains a slash" in {
 
-    val task = new S3SinkTask()
+    val task = new S3SinkTaskDeprecated()
 
     val keyWithSlash = "_key.date/of/birth"
 
@@ -1202,7 +1202,7 @@ class S3SinkTaskTest extends AnyFlatSpec with Matchers with S3ProxyContainerTest
 
   "S3SinkTask" should "allow partitioning by complex key and values" in {
 
-    val task = new S3SinkTask()
+    val task = new S3SinkTaskDeprecated()
 
     val props = DefaultProps
       .combine(
@@ -1243,7 +1243,7 @@ class S3SinkTaskTest extends AnyFlatSpec with Matchers with S3ProxyContainerTest
       new TopicPartition(TopicName, 1),
     ).asJava
 
-    val task = new S3SinkTask()
+    val task = new S3SinkTaskDeprecated()
 
     val props = DefaultProps
       .combine(
@@ -1288,7 +1288,7 @@ class S3SinkTaskTest extends AnyFlatSpec with Matchers with S3ProxyContainerTest
       new TopicPartition(TopicName, 0),
     ).asJava
 
-    val task = new S3SinkTask()
+    val task = new S3SinkTaskDeprecated()
 
     val props = DefaultProps
       .combine(
@@ -1328,7 +1328,7 @@ class S3SinkTaskTest extends AnyFlatSpec with Matchers with S3ProxyContainerTest
       new TopicPartition(TopicName, 0),
     ).asJava
 
-    val task = new S3SinkTask()
+    val task = new S3SinkTaskDeprecated()
 
     val props = DefaultProps
       .combine(
@@ -1367,7 +1367,7 @@ class S3SinkTaskTest extends AnyFlatSpec with Matchers with S3ProxyContainerTest
       new TopicPartition(TopicName, 0),
     ).asJava
 
-    val task = new S3SinkTask()
+    val task = new S3SinkTaskDeprecated()
 
     val props = DefaultProps
       .combine(
@@ -1408,7 +1408,7 @@ class S3SinkTaskTest extends AnyFlatSpec with Matchers with S3ProxyContainerTest
       new TopicPartition(TopicName, 0),
     ).asJava
 
-    val task = new S3SinkTask()
+    val task = new S3SinkTaskDeprecated()
 
     val props = DefaultProps
       .combine(
@@ -1461,7 +1461,7 @@ class S3SinkTaskTest extends AnyFlatSpec with Matchers with S3ProxyContainerTest
       new TopicPartition(TopicName, 0),
     ).asJava
 
-    val task = new S3SinkTask()
+    val task = new S3SinkTaskDeprecated()
 
     val props = DefaultProps
       .combine(
@@ -1518,7 +1518,7 @@ class S3SinkTaskTest extends AnyFlatSpec with Matchers with S3ProxyContainerTest
       new TopicPartition(TopicName, 0),
     ).asJava
 
-    val task = new S3SinkTask()
+    val task = new S3SinkTaskDeprecated()
 
     val props = DefaultProps
       .combine(
@@ -1565,7 +1565,7 @@ class S3SinkTaskTest extends AnyFlatSpec with Matchers with S3ProxyContainerTest
       new TopicPartition(TopicName, 0),
     ).asJava
 
-    val task = new S3SinkTask()
+    val task = new S3SinkTaskDeprecated()
 
     val props = DefaultProps
       .combine(
@@ -1660,7 +1660,7 @@ class S3SinkTaskTest extends AnyFlatSpec with Matchers with S3ProxyContainerTest
       new TopicPartition(TopicName, 1),
     ).asJava
 
-    val task = new S3SinkTask()
+    val task = new S3SinkTaskDeprecated()
 
     val props = DefaultProps
       .combine(
@@ -1745,7 +1745,7 @@ class S3SinkTaskTest extends AnyFlatSpec with Matchers with S3ProxyContainerTest
       new TopicPartition(TopicName, 1),
     ).asJava
 
-    val task = new S3SinkTask()
+    val task = new S3SinkTaskDeprecated()
 
     val props = DefaultProps
       .combine(
@@ -1817,7 +1817,7 @@ class S3SinkTaskTest extends AnyFlatSpec with Matchers with S3ProxyContainerTest
       new TopicPartition(TopicName, 1),
     ).asJava
 
-    val task = new S3SinkTask()
+    val task = new S3SinkTaskDeprecated()
 
     val props = DefaultProps
       .combine(
@@ -1845,7 +1845,7 @@ class S3SinkTaskTest extends AnyFlatSpec with Matchers with S3ProxyContainerTest
 
   "S3SinkTask" should "flush for every record when configured flush count size of 1 with build local write mode" in {
 
-    val task = new S3SinkTask()
+    val task = new S3SinkTaskDeprecated()
 
     val props = DefaultProps
       .combine(
@@ -1877,7 +1877,7 @@ class S3SinkTaskTest extends AnyFlatSpec with Matchers with S3ProxyContainerTest
 
   "S3SinkTask" should "be able to stop when there is no state" in {
 
-    val task = new S3SinkTask()
+    val task = new S3SinkTaskDeprecated()
     task.stop()
   }
 
@@ -1885,7 +1885,7 @@ class S3SinkTaskTest extends AnyFlatSpec with Matchers with S3ProxyContainerTest
 
     val tempDir = Files.createTempDirectory("tempdirtest")
 
-    val task = new S3SinkTask()
+    val task = new S3SinkTaskDeprecated()
 
     val props = DefaultProps
       .combine(
@@ -1922,7 +1922,7 @@ class S3SinkTaskTest extends AnyFlatSpec with Matchers with S3ProxyContainerTest
     val profileDir = getResourcesDirectory()
       .getOrElse(fail("cannot get resources dir"))
 
-    val task = new S3SinkTask()
+    val task = new S3SinkTaskDeprecated()
 
     val props = Map(
       "name"                       -> "sinkName",
@@ -1953,7 +1953,7 @@ class S3SinkTaskTest extends AnyFlatSpec with Matchers with S3ProxyContainerTest
 
   "S3SinkTask" should "not write duplicate offsets" in {
 
-    val task = new S3SinkTask()
+    val task = new S3SinkTaskDeprecated()
 
     val props = DefaultProps
       .combine(
@@ -1982,7 +1982,7 @@ class S3SinkTaskTest extends AnyFlatSpec with Matchers with S3ProxyContainerTest
 
   "S3SinkTask" should "recover after a failure" in {
 
-    val task    = new S3SinkTask()
+    val task    = new S3SinkTaskDeprecated()
     val context = mock[SinkTaskContext]
     task.initialize(context)
 
@@ -2026,7 +2026,7 @@ class S3SinkTaskTest extends AnyFlatSpec with Matchers with S3ProxyContainerTest
 
   "S3SinkTask" should "recover after a failure for single record commits" in {
 
-    val task    = new S3SinkTask()
+    val task    = new S3SinkTaskDeprecated()
     val context = mock[SinkTaskContext]
     task.initialize(context)
 
@@ -2070,7 +2070,7 @@ class S3SinkTaskTest extends AnyFlatSpec with Matchers with S3ProxyContainerTest
 
   "S3SinkTask" should "continue processing records when a source file has been deleted" in {
 
-    val task    = new S3SinkTask()
+    val task    = new S3SinkTaskDeprecated()
     val context = mock[SinkTaskContext]
     task.initialize(context)
 
@@ -2131,7 +2131,7 @@ class S3SinkTaskTest extends AnyFlatSpec with Matchers with S3ProxyContainerTest
         toSinkRecord(user, k, topic2Name)
     }
 
-    val task = new S3SinkTask()
+    val task = new S3SinkTaskDeprecated()
 
     val props = DefaultProps
       .combine(
@@ -2179,7 +2179,7 @@ class S3SinkTaskTest extends AnyFlatSpec with Matchers with S3ProxyContainerTest
         new SinkRecord(TopicName, 1, null, null, schema, user, k.toLong, timestamp, TimestampType.CREATE_TIME)
     }
 
-    val task = new S3SinkTask()
+    val task = new S3SinkTaskDeprecated()
 
     val props = DefaultProps
       .combine(
@@ -2203,7 +2203,7 @@ class S3SinkTaskTest extends AnyFlatSpec with Matchers with S3ProxyContainerTest
 
   "S3SinkTask" should "write files with topic partition without padding when requested" in {
 
-    val task = new S3SinkTask()
+    val task = new S3SinkTaskDeprecated()
 
     val props = DefaultProps
       .combine(
@@ -2259,7 +2259,7 @@ class S3SinkTaskTest extends AnyFlatSpec with Matchers with S3ProxyContainerTest
   }
 
   private def getResourcesDirectory(): Try[String] = {
-    val url = classOf[S3SinkTaskTest].getResource("/profiles/")
+    val url = classOf[S3SinkTaskDeprecatedTest].getResource("/profiles/")
     Try {
       val uri = url.toURI
       logger.info("Profile uri: {}", uri)

--- a/kafka-connect-aws-s3/src/it/scala/io/lenses/streamreactor/connect/aws/s3/sink/S3SinkTaskJsonEnvelopeTest.scala
+++ b/kafka-connect-aws-s3/src/it/scala/io/lenses/streamreactor/connect/aws/s3/sink/S3SinkTaskJsonEnvelopeTest.scala
@@ -97,7 +97,7 @@ class S3SinkTaskJsonEnvelopeTest
 
   "S3SinkTask" should "write to json format" in {
 
-    val task = new S3SinkTask()
+    val task = new S3SinkTaskDeprecated()
 
     val props = DefaultProps
       .combine(
@@ -168,7 +168,7 @@ class S3SinkTaskJsonEnvelopeTest
 
   "S3SinkTask" should "write to JSON format when input is java Map" in {
 
-    val task = new S3SinkTask()
+    val task = new S3SinkTaskDeprecated()
 
     val props = DefaultProps
       .combine(
@@ -242,7 +242,7 @@ class S3SinkTaskJsonEnvelopeTest
 
   "S3SinkTask" should "write to JSON format when input is java Map and escape new line text" in {
 
-    val task = new S3SinkTask()
+    val task = new S3SinkTaskDeprecated()
 
     val props = DefaultProps
       .combine(
@@ -317,7 +317,7 @@ class S3SinkTaskJsonEnvelopeTest
 
   "S3SinkTask" should "write to JSON format when input is java Map escapes new line when envelope is disabled" in {
 
-    val task = new S3SinkTask()
+    val task = new S3SinkTaskDeprecated()
 
     val props = DefaultProps
       .combine(
@@ -385,7 +385,7 @@ class S3SinkTaskJsonEnvelopeTest
 
   "S3SinkTask" should "write to JSON format when input is array of bytes representing text with new line" in {
 
-    val task = new S3SinkTask()
+    val task = new S3SinkTaskDeprecated()
 
     val props = DefaultProps
       .combine(

--- a/kafka-connect-aws-s3/src/it/scala/io/lenses/streamreactor/connect/aws/s3/sink/S3SinkTaskParquetEnvelopeTest.scala
+++ b/kafka-connect-aws-s3/src/it/scala/io/lenses/streamreactor/connect/aws/s3/sink/S3SinkTaskParquetEnvelopeTest.scala
@@ -79,7 +79,7 @@ class S3SinkTaskParquetEnvelopeTest
 
   "S3SinkTask" should "write to avro format" in {
 
-    val task = new S3SinkTask()
+    val task = new S3SinkTaskDeprecated()
 
     val props = DefaultProps
       .combine(

--- a/kafka-connect-aws-s3/src/it/scala/io/lenses/streamreactor/connect/aws/s3/source/S3SourceAvroEnvelopeTest.scala
+++ b/kafka-connect-aws-s3/src/it/scala/io/lenses/streamreactor/connect/aws/s3/source/S3SourceAvroEnvelopeTest.scala
@@ -122,7 +122,7 @@ class S3SourceAvroEnvelopeTest extends S3ProxyContainerTest with AnyFlatSpecLike
 
   "task" should "extract from avro files containing the envelope" in {
 
-    val task = new S3SourceTask()
+    val task = new S3SourceTaskDeprecated()
 
     val props = DefaultProps
       .combine(

--- a/kafka-connect-aws-s3/src/it/scala/io/lenses/streamreactor/connect/aws/s3/source/S3SourceJsonEnvelopeTest.scala
+++ b/kafka-connect-aws-s3/src/it/scala/io/lenses/streamreactor/connect/aws/s3/source/S3SourceJsonEnvelopeTest.scala
@@ -55,7 +55,7 @@ class S3SourceJsonEnvelopeTest extends S3ProxyContainerTest with AnyFlatSpecLike
 
   "task" should "extract from json files containing the envelope" in {
 
-    val task = new S3SourceTask()
+    val task = new S3SourceTaskDeprecated()
 
     val props = DefaultProps
       .combine(

--- a/kafka-connect-aws-s3/src/it/scala/io/lenses/streamreactor/connect/aws/s3/source/S3SourceParquetEnvelopeTest.scala
+++ b/kafka-connect-aws-s3/src/it/scala/io/lenses/streamreactor/connect/aws/s3/source/S3SourceParquetEnvelopeTest.scala
@@ -133,7 +133,7 @@ class S3SourceParquetEnvelopeTest extends S3ProxyContainerTest with AnyFlatSpecL
 
   "task" should "extract from parquet files containing the envelope" in {
 
-    val task = new S3SourceTask()
+    val task = new S3SourceTaskDeprecated()
 
     val props = DefaultProps
       .combine(

--- a/kafka-connect-aws-s3/src/it/scala/io/lenses/streamreactor/connect/aws/s3/source/S3SourceTaskDeprecatedTest.scala
+++ b/kafka-connect-aws-s3/src/it/scala/io/lenses/streamreactor/connect/aws/s3/source/S3SourceTaskDeprecatedTest.scala
@@ -32,7 +32,7 @@ import scala.jdk.CollectionConverters.IteratorHasAsScala
 import scala.jdk.CollectionConverters.ListHasAsScala
 import scala.jdk.CollectionConverters.MapHasAsJava
 
-class S3SourceTaskTest
+class S3SourceTaskDeprecatedTest
     extends AnyFlatSpec
     with Matchers
     with S3ProxyContainerTest
@@ -101,7 +101,7 @@ class S3SourceTaskTest
         withClue(s"Format:$format") {
           val t1 = System.currentTimeMillis()
 
-          val task = new S3SourceTask()
+          val task = new S3SourceTaskDeprecated()
 
           val formatExtensionString = bucketSetup.generateFormatString(formatOptions)
 
@@ -159,7 +159,7 @@ class S3SourceTaskTest
         withClue(s"Format:$format") {
           val t1 = System.currentTimeMillis()
 
-          val task = new S3SourceTask()
+          val task = new S3SourceTaskDeprecated()
 
           val formatExtensionString = bucketSetup.generateFormatString(formatOptions)
 
@@ -216,7 +216,7 @@ class S3SourceTaskTest
       (format, formatOptions, dir) =>
         val formatExtensionString = bucketSetup.generateFormatString(formatOptions)
 
-        val task = new S3SourceTask()
+        val task = new S3SourceTaskDeprecated()
 
         val context = new SourceTaskContext {
           override def configs(): util.Map[String, String] = Map.empty[String, String].asJava
@@ -284,7 +284,7 @@ class S3SourceTaskTest
     val (format, formatOptions) = (Format.Bytes, Some(FormatOptions.ValueOnly))
     val dir                     = "bytesval"
 
-    val task = new S3SourceTask()
+    val task = new S3SourceTaskDeprecated()
 
     val formatExtensionString = bucketSetup.generateFormatString(formatOptions)
 
@@ -321,7 +321,7 @@ class S3SourceTaskTest
     val (format, formatOptions) = (Format.Bytes, Some(FormatOptions.KeyAndValueWithSizes))
 
     val dir  = "byteskv"
-    val task = new S3SourceTask()
+    val task = new S3SourceTaskDeprecated()
 
     val formatExtensionString = bucketSetup.generateFormatString(formatOptions)
 
@@ -374,7 +374,7 @@ class S3SourceTaskTest
     val (format, formatOptions) = (Format.Bytes, Some(FormatOptions.KeyAndValueWithSizes))
 
     val dir  = "nested/byteskv"
-    val task = new S3SourceTask()
+    val task = new S3SourceTaskDeprecated()
 
     val formatExtensionString = bucketSetup.generateFormatString(formatOptions)
 

--- a/kafka-connect-aws-s3/src/it/scala/io/lenses/streamreactor/connect/aws/s3/source/S3SourceTaskXmlReaderTest.scala
+++ b/kafka-connect-aws-s3/src/it/scala/io/lenses/streamreactor/connect/aws/s3/source/S3SourceTaskXmlReaderTest.scala
@@ -46,7 +46,7 @@ class S3SourceTaskXmlReaderTest extends S3ProxyContainerTest with AnyFlatSpecLik
 
   "task" should "extract from xml files" in {
 
-    val task = new S3SourceTask()
+    val task = new S3SourceTaskDeprecated()
 
     val props = DefaultProps
       .combine(

--- a/kafka-connect-aws-s3/src/main/scala/io/lenses/streamreactor/connect/aws/s3/sink/S3SinkConnectorDeprecated.scala
+++ b/kafka-connect-aws-s3/src/main/scala/io/lenses/streamreactor/connect/aws/s3/sink/S3SinkConnectorDeprecated.scala
@@ -13,32 +13,31 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.lenses.streamreactor.connect.aws.s3.source
+package io.lenses.streamreactor.connect.aws.s3.sink
 
 import com.datamountaineer.streamreactor.common.utils.JarManifest
 import com.typesafe.scalalogging.LazyLogging
+import io.lenses.streamreactor.connect.aws.s3.sink.config.S3SinkConfigDef
 import io.lenses.streamreactor.connect.aws.s3.config.TaskDistributor.distributeTasks
-import io.lenses.streamreactor.connect.aws.s3.source.config.S3SourceConfigDef
 import org.apache.kafka.common.config.ConfigDef
 import org.apache.kafka.connect.connector.Task
-import org.apache.kafka.connect.source.ExactlyOnceSupport
-import org.apache.kafka.connect.source.SourceConnector
+import org.apache.kafka.connect.sink.SinkConnector
 
 import java.util
 
-class S3SourceConnector extends SourceConnector with LazyLogging {
+class S3SinkConnectorDeprecated extends SinkConnector with LazyLogging {
 
   private val manifest = JarManifest(getClass.getProtectionDomain.getCodeSource.getLocation)
   private val props: util.Map[String, String] = new util.HashMap[String, String]()
 
   override def version(): String = manifest.version()
 
-  override def taskClass(): Class[_ <: Task] = classOf[S3SourceTask]
+  override def taskClass(): Class[_ <: Task] = classOf[S3SinkTaskDeprecated]
 
-  override def config(): ConfigDef = S3SourceConfigDef.config
+  override def config(): ConfigDef = S3SinkConfigDef.config
 
   override def start(props: util.Map[String, String]): Unit = {
-    logger.info(s"Creating S3 source connector")
+    logger.info(s"Creating S3 sink connector")
     this.props.putAll(props)
   }
 
@@ -48,7 +47,4 @@ class S3SourceConnector extends SourceConnector with LazyLogging {
     logger.info(s"Creating $maxTasks tasks config")
     distributeTasks(props, maxTasks)
   }
-
-  override def exactlyOnceSupport(connectorConfig: util.Map[String, String]): ExactlyOnceSupport =
-    ExactlyOnceSupport.SUPPORTED
 }

--- a/kafka-connect-aws-s3/src/main/scala/io/lenses/streamreactor/connect/aws/s3/sink/S3SinkTaskDeprecated.scala
+++ b/kafka-connect-aws-s3/src/main/scala/io/lenses/streamreactor/connect/aws/s3/sink/S3SinkTaskDeprecated.scala
@@ -43,7 +43,7 @@ import scala.jdk.CollectionConverters.MapHasAsJava
 import scala.jdk.CollectionConverters.MapHasAsScala
 import scala.util.Try
 
-class S3SinkTask extends SinkTask with ErrorHandler {
+class S3SinkTaskDeprecated extends SinkTask with ErrorHandler {
 
   private val manifest = JarManifest(getClass.getProtectionDomain.getCodeSource.getLocation)
 

--- a/kafka-connect-aws-s3/src/main/scala/io/lenses/streamreactor/connect/aws/s3/source/S3SourceConnectorDeprecated.scala
+++ b/kafka-connect-aws-s3/src/main/scala/io/lenses/streamreactor/connect/aws/s3/source/S3SourceConnectorDeprecated.scala
@@ -13,31 +13,32 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.lenses.streamreactor.connect.aws.s3.sink
+package io.lenses.streamreactor.connect.aws.s3.source
 
 import com.datamountaineer.streamreactor.common.utils.JarManifest
 import com.typesafe.scalalogging.LazyLogging
-import io.lenses.streamreactor.connect.aws.s3.sink.config.S3SinkConfigDef
 import io.lenses.streamreactor.connect.aws.s3.config.TaskDistributor.distributeTasks
+import io.lenses.streamreactor.connect.aws.s3.source.config.S3SourceConfigDef
 import org.apache.kafka.common.config.ConfigDef
 import org.apache.kafka.connect.connector.Task
-import org.apache.kafka.connect.sink.SinkConnector
+import org.apache.kafka.connect.source.ExactlyOnceSupport
+import org.apache.kafka.connect.source.SourceConnector
 
 import java.util
 
-class S3SinkConnector extends SinkConnector with LazyLogging {
+class S3SourceConnectorDeprecated extends SourceConnector with LazyLogging {
 
   private val manifest = JarManifest(getClass.getProtectionDomain.getCodeSource.getLocation)
   private val props: util.Map[String, String] = new util.HashMap[String, String]()
 
   override def version(): String = manifest.version()
 
-  override def taskClass(): Class[_ <: Task] = classOf[S3SinkTask]
+  override def taskClass(): Class[_ <: Task] = classOf[S3SourceTaskDeprecated]
 
-  override def config(): ConfigDef = S3SinkConfigDef.config
+  override def config(): ConfigDef = S3SourceConfigDef.config
 
   override def start(props: util.Map[String, String]): Unit = {
-    logger.info(s"Creating S3 sink connector")
+    logger.info(s"Creating S3 source connector")
     this.props.putAll(props)
   }
 
@@ -47,4 +48,7 @@ class S3SinkConnector extends SinkConnector with LazyLogging {
     logger.info(s"Creating $maxTasks tasks config")
     distributeTasks(props, maxTasks)
   }
+
+  override def exactlyOnceSupport(connectorConfig: util.Map[String, String]): ExactlyOnceSupport =
+    ExactlyOnceSupport.SUPPORTED
 }

--- a/kafka-connect-aws-s3/src/main/scala/io/lenses/streamreactor/connect/aws/s3/source/S3SourceTaskDeprecated.scala
+++ b/kafka-connect-aws-s3/src/main/scala/io/lenses/streamreactor/connect/aws/s3/source/S3SourceTaskDeprecated.scala
@@ -33,7 +33,7 @@ import org.apache.kafka.connect.source.SourceTask
 import java.util
 import java.util.Collections
 import scala.jdk.CollectionConverters._
-class S3SourceTask extends SourceTask with LazyLogging {
+class S3SourceTaskDeprecated extends SourceTask with LazyLogging {
 
   private val contextOffsetFn: S3Location => Option[S3Location] =
     SourceContextReader.getCurrentOffset(() => context)

--- a/kafka-connect-aws-s3/src/test/scala/io/lenses/streamreactor/connect/aws/s3/source/S3SourceConnectorDeprecatedTest.scala
+++ b/kafka-connect-aws-s3/src/test/scala/io/lenses/streamreactor/connect/aws/s3/source/S3SourceConnectorDeprecatedTest.scala
@@ -23,11 +23,11 @@ import org.scalatest.matchers.should.Matchers
 import java.util
 import scala.jdk.CollectionConverters.MapHasAsScala
 
-class S3SourceConnectorTest extends AnyFlatSpecLike with Matchers with OptionValues {
+class S3SourceConnectorDeprecatedTest extends AnyFlatSpecLike with Matchers with OptionValues {
 
   "taskConfigs" should "deliver correct number of task configs" in {
 
-    val sourceConnector = new S3SourceConnector()
+    val sourceConnector = new S3SourceConnectorDeprecated()
     val taskConfigs: util.List[util.Map[String, String]] = sourceConnector.taskConfigs(5)
 
     taskConfigs.get(0).asScala.get(TASK_INDEX).value shouldBe "0:5"


### PR DESCRIPTION
Some of the options for byte storage will be replaced with an envelope method in future versions.  See #975 

This release branch will serve as a final release of this functionality before deprecated functionality (bytes write mode) is removed from the codebase.

The connectors will now be named
```
S3SinkTaskDeprecated
S3SourceTaskDeprecated
```
so that users will be aware they are using non-recommended/deprecated functionality.