### PR TITLE
Support BigDecimal

### DIFF
--- a/kafka-connect-aws-s3/src/it/scala/io/lenses/streamreactor/connect/aws/s3/sink/S3JsonWriterManagerTest.scala
+++ b/kafka-connect-aws-s3/src/it/scala/io/lenses/streamreactor/connect/aws/s3/sink/S3JsonWriterManagerTest.scala
@@ -164,4 +164,74 @@ class S3JsonWriterManagerTest extends AnyFlatSpec with Matchers with S3ProxyCont
     )
   }
 
+  "json sink" should "write bigdecimal to json" in {
+
+    val bucketAndPrefix = S3Location(BucketName, PathPrefix.some)
+    val config = S3SinkConfig(
+      S3Config(
+        None,
+        Some(Identity),
+        Some(Credential),
+        AuthMode.Credentials,
+      ),
+      bucketOptions = Seq(
+        SinkBucketOptions(
+          TopicName.some,
+          bucketAndPrefix,
+          commitPolicy    = CommitPolicy(Count(1)),
+          formatSelection = JsonFormatSelection,
+          keyNamer = new S3KeyNamer(
+            AvroFormatSelection,
+            defaultPartitionSelection(Values),
+            new OffsetS3FileNamer(
+              identity[String],
+              JsonFormatSelection.extension,
+            ),
+            new PaddingService(Map[String, PaddingStrategy](
+              "partition" -> NoOpPaddingStrategy,
+              "offset"    -> LeftPadPaddingStrategy(12, 0),
+            )),
+          ),
+          localStagingArea   = LocalStagingArea(localRoot),
+          partitionSelection = defaultPartitionSelection(Values),
+          dataStorage        = DataStorageSettings.disabled,
+        ),
+      ),
+      offsetSeekerOptions = OffsetSeekerOptions(5),
+      compressionCodec,
+      batchDelete = true,
+    )
+
+    val sink = S3WriterManager.from(config)
+
+    val topic  = Topic(TopicName)
+    val offset = Offset(1L)
+    val usersWithDecimal =
+      new Struct(UsersSchemaDecimal)
+        .put("name", "sam")
+        .put("title", "mr")
+        .put(
+          "salary",
+          BigDecimal(100.43).setScale(18).bigDecimal,
+        )
+    sink.write(
+      TopicPartitionOffset(topic, 1, offset),
+      MessageDetail(NullSinkData(None),
+                    StructSinkData(usersWithDecimal),
+                    Map.empty[String, SinkData],
+                    None,
+                    topic,
+                    0,
+                    offset,
+      ),
+    )
+
+    sink.close()
+
+    listBucketPath(BucketName, "streamReactorBackups/myTopic/1/").size should be(1)
+
+    remoteFileAsString(BucketName, "streamReactorBackups/myTopic/1/1.json") should be(
+      s"""{"name":"sam","title":"mr","salary":100.430000000000000000}""",
+    )
+  }
 }

--- a/kafka-connect-aws-s3/src/it/scala/io/lenses/streamreactor/connect/aws/s3/utils/ITSampleSchemaAndData.scala
+++ b/kafka-connect-aws-s3/src/it/scala/io/lenses/streamreactor/connect/aws/s3/utils/ITSampleSchemaAndData.scala
@@ -4,6 +4,7 @@ import io.lenses.streamreactor.connect.aws.s3.model.Topic
 import org.apache.avro.generic.GenericData
 import org.apache.avro.generic.GenericRecord
 import org.apache.avro.util.Utf8
+import org.apache.kafka.connect.data.Decimal
 import org.apache.kafka.connect.data.Schema
 import org.apache.kafka.connect.data.SchemaBuilder
 import org.apache.kafka.connect.data.Struct
@@ -17,6 +18,12 @@ object ITSampleSchemaAndData extends Matchers {
     .field("name", SchemaBuilder.string().required().build())
     .field("title", SchemaBuilder.string().optional().build())
     .field("salary", SchemaBuilder.float64().optional().build())
+    .build()
+
+  val UsersSchemaDecimal: Schema = SchemaBuilder.struct()
+    .field("name", SchemaBuilder.string().required().build())
+    .field("title", SchemaBuilder.string().optional().build())
+    .field("salary", Decimal.builder(18).optional().build())
     .build()
 
   val users: List[Struct] = List(

--- a/kafka-connect-aws-s3/src/main/scala/io/lenses/streamreactor/connect/aws/s3/sink/S3WriterManager.scala
+++ b/kafka-connect-aws-s3/src/main/scala/io/lenses/streamreactor/connect/aws/s3/sink/S3WriterManager.scala
@@ -187,6 +187,12 @@ class S3WriterManager(
       // commitException can not be recovered from
       _ <- rollOverTopicPartitionWriters(writer, topicPartitionOffset.toTopicPartition, messageDetail)
       // a processErr can potentially be recovered from in the next iteration.  Can be due to network problems
+      _ = logger.info(
+        s"""
+           |Writer:
+           |${writer}
+           |""".stripMargin,
+      )
       _         <- writer.write(messageDetail)
       commitRes <- commitWriters(writer, topicPartitionOffset.toTopicPartition)
     } yield commitRes

--- a/kafka-connect-aws-s3/src/main/scala/io/lenses/streamreactor/connect/aws/s3/sink/conversion/ValueToSinkDataConverter.scala
+++ b/kafka-connect-aws-s3/src/main/scala/io/lenses/streamreactor/connect/aws/s3/sink/conversion/ValueToSinkDataConverter.scala
@@ -42,7 +42,11 @@ object ValueToSinkDataConverter {
     case bytesVal:  Array[Byte]    => ByteArraySinkData(bytesVal, schema.orElse(Some(Schema.OPTIONAL_BYTES_SCHEMA)))
     case bytesVal:  ByteBuffer     => ByteArraySinkData(bytesVal.array(), schema.orElse(Some(Schema.OPTIONAL_BYTES_SCHEMA)))
     case arrayVal:  Array[_]       => ArraySinkData(arrayVal.toList.asJava, schema)
-    case listVal:   util.List[_]   => ArraySinkData(listVal, schema)
+    case listVal:   util.List[_] => ArraySinkData(listVal, schema)
+    case decimal:   BigDecimal =>
+      DecimalSinkData.from(decimal.bigDecimal, schema.orElse(Some(DecimalSinkData.schemaFor(decimal.bigDecimal))))
+    case decimal: java.math.BigDecimal =>
+      DecimalSinkData.from(decimal, schema.orElse(Some(DecimalSinkData.schemaFor(decimal))))
     case null     => NullSinkData(schema)
     case otherVal => throw new ConnectException(s"Unsupported record $otherVal:${otherVal.getClass.getCanonicalName}")
   }

--- a/kafka-connect-aws-s3/src/main/scala/io/lenses/streamreactor/connect/aws/s3/sink/extractors/SinkDataExtractor.scala
+++ b/kafka-connect-aws-s3/src/main/scala/io/lenses/streamreactor/connect/aws/s3/sink/extractors/SinkDataExtractor.scala
@@ -33,8 +33,8 @@ object SinkDataExtractor extends LazyLogging {
   )(fieldNameOpt: Option[PartitionNamePath],
   ): Either[ExtractorError, String] =
     sinkData match {
-      case data: PrimitiveSinkData => data.safeValue.toString.asRight[ExtractorError]
-      case ByteArraySinkData(array, _) => new String(array).asRight[ExtractorError]
+      case data: PrimitiveSinkData => Option(data.safeValue).map(_.toString).orNull.asRight[ExtractorError]
+      case ByteArraySinkData(array, _) => Option(array).map(new String(_)).orNull.asRight[ExtractorError]
       case other =>
         fieldNameOpt.fold(ExtractorError(ExtractorErrorType.FieldNameNotSpecified).asLeft[String])(fieldName =>
           other match {

--- a/kafka-connect-aws-s3/src/test/scala/io/lenses/streamreactor/connect/aws/s3/formats/AvroFormatWriterTest.scala
+++ b/kafka-connect-aws-s3/src/test/scala/io/lenses/streamreactor/connect/aws/s3/formats/AvroFormatWriterTest.scala
@@ -62,6 +62,28 @@ class AvroFormatWriterTest extends AnyFlatSpec with Matchers with EitherValues {
     checkRecord(genericRecords.head, "sam", "mr", 100.43)
   }
 
+  "convert" should "write decimal data from the header" in {
+
+    val outputStream     = new S3ByteArrayOutputStream()
+    val avroFormatWriter = new AvroFormatWriter(outputStream)
+    avroFormatWriter.write(
+      MessageDetail(NullSinkData(None),
+                    StructSinkData(SampleData.UsersWithDecimal.head),
+                    Map.empty,
+                    Some(Instant.now()),
+                    topic,
+                    0,
+                    Offset(0),
+      ),
+    )
+    avroFormatWriter.complete()
+
+    val genericRecords = avroFormatReader.read(outputStream.toByteArray)
+
+    genericRecords.size should be(1)
+    checkRecord(genericRecords.head, "sam", Some("mr"), BigDecimal(100.43).setScale(18).bigDecimal)
+  }
+
   "convert" should "write byte output stream with avro for multiple records" in {
 
     val outputStream     = new S3ByteArrayOutputStream()


### PR DESCRIPTION
The PR introduces the support for S3 sink for BigDecimal.  A new case class extending SinkData is introduced. For text storage the safeValue function is overwritten to return the java BigDecimal. The JsonConverter is changed to store decimals as numbers, not base64 (default). While a breaking change, this should not be a cause of concern since BigDecimal was not handled before, so it should have created an error if that was the case.

Unit test and integration tests were added to ensure the storage can handle BigDecimal.