### PR TITLE
Prevent Twitter Dependency

### DIFF
--- a/kafka-connect-aws-s3/src/fun/scala/io/lenses/streamreactor/connect/ProvidedJars.scala
+++ b/kafka-connect-aws-s3/src/fun/scala/io/lenses/streamreactor/connect/ProvidedJars.scala
@@ -1,7 +1,6 @@
 package io.lenses.streamreactor.connect
 
 import com.github.luben.zstd.NoPool
-import com.hadoop.compression.lzo.LzopCodec
 import com.typesafe.scalalogging.LazyLogging
 import org.apache.hadoop.io.compress.CompressionCodec
 import org.tukaani.xz.FilterOptions
@@ -13,7 +12,6 @@ object ProvidedJars extends LazyLogging {
 
   private val classesWithinJarsToProvide = Seq(
     classOf[FilterOptions],
-    classOf[LzopCodec],
     classOf[NoPool],
     classOf[CompressionCodec],
   )

--- a/kafka-connect-aws-s3/src/fun/scala/io/lenses/streamreactor/connect/S3CompressionTest.scala
+++ b/kafka-connect-aws-s3/src/fun/scala/io/lenses/streamreactor/connect/S3CompressionTest.scala
@@ -63,7 +63,7 @@ class S3CompressionTest
     ("parquet", "uncompressed", false),
     ("parquet", "snappy", false),
     ("parquet", "gzip", false),
-    ("parquet", "lz4", false),
+    //("parquet", "lz4", false),
     ("parquet", "zstd", false),
   )
 

--- a/kafka-connect-azure-documentdb/src/main/scala/io/lenses/streamreactor/connect/azure/documentdb/DocumentClientProvider.scala
+++ b/kafka-connect-azure-documentdb/src/main/scala/io/lenses/streamreactor/connect/azure/documentdb/DocumentClientProvider.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2023 Lenses.io Ltd
+ * Copyright 2017-2024 Lenses.io Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-connect-azure-documentdb/src/main/scala/io/lenses/streamreactor/connect/azure/documentdb/Json.scala
+++ b/kafka-connect-azure-documentdb/src/main/scala/io/lenses/streamreactor/connect/azure/documentdb/Json.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2023 Lenses.io Ltd
+ * Copyright 2017-2024 Lenses.io Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-connect-azure-documentdb/src/main/scala/io/lenses/streamreactor/connect/azure/documentdb/config/DocumentDbConfig.scala
+++ b/kafka-connect-azure-documentdb/src/main/scala/io/lenses/streamreactor/connect/azure/documentdb/config/DocumentDbConfig.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2023 Lenses.io Ltd
+ * Copyright 2017-2024 Lenses.io Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-connect-azure-documentdb/src/main/scala/io/lenses/streamreactor/connect/azure/documentdb/config/DocumentDbConfigConstants.scala
+++ b/kafka-connect-azure-documentdb/src/main/scala/io/lenses/streamreactor/connect/azure/documentdb/config/DocumentDbConfigConstants.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2023 Lenses.io Ltd
+ * Copyright 2017-2024 Lenses.io Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-connect-azure-documentdb/src/main/scala/io/lenses/streamreactor/connect/azure/documentdb/config/DocumentDbSinkSettings.scala
+++ b/kafka-connect-azure-documentdb/src/main/scala/io/lenses/streamreactor/connect/azure/documentdb/config/DocumentDbSinkSettings.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2023 Lenses.io Ltd
+ * Copyright 2017-2024 Lenses.io Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-connect-azure-documentdb/src/main/scala/io/lenses/streamreactor/connect/azure/documentdb/converters/SinkRecordConverter.scala
+++ b/kafka-connect-azure-documentdb/src/main/scala/io/lenses/streamreactor/connect/azure/documentdb/converters/SinkRecordConverter.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2023 Lenses.io Ltd
+ * Copyright 2017-2024 Lenses.io Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-connect-azure-documentdb/src/main/scala/io/lenses/streamreactor/connect/azure/documentdb/sink/CreateDatabaseFn.scala
+++ b/kafka-connect-azure-documentdb/src/main/scala/io/lenses/streamreactor/connect/azure/documentdb/sink/CreateDatabaseFn.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2023 Lenses.io Ltd
+ * Copyright 2017-2024 Lenses.io Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-connect-azure-documentdb/src/main/scala/io/lenses/streamreactor/connect/azure/documentdb/sink/DocumentDbSinkConnector.scala
+++ b/kafka-connect-azure-documentdb/src/main/scala/io/lenses/streamreactor/connect/azure/documentdb/sink/DocumentDbSinkConnector.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2023 Lenses.io Ltd
+ * Copyright 2017-2024 Lenses.io Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-connect-azure-documentdb/src/main/scala/io/lenses/streamreactor/connect/azure/documentdb/sink/DocumentDbSinkTask.scala
+++ b/kafka-connect-azure-documentdb/src/main/scala/io/lenses/streamreactor/connect/azure/documentdb/sink/DocumentDbSinkTask.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2023 Lenses.io Ltd
+ * Copyright 2017-2024 Lenses.io Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-connect-azure-documentdb/src/main/scala/io/lenses/streamreactor/connect/azure/documentdb/sink/DocumentDbWriter.scala
+++ b/kafka-connect-azure-documentdb/src/main/scala/io/lenses/streamreactor/connect/azure/documentdb/sink/DocumentDbWriter.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2023 Lenses.io Ltd
+ * Copyright 2017-2024 Lenses.io Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-connect-azure-documentdb/src/main/scala/io/lenses/streamreactor/connect/azure/documentdb/sink/KeysExtractor.scala
+++ b/kafka-connect-azure-documentdb/src/main/scala/io/lenses/streamreactor/connect/azure/documentdb/sink/KeysExtractor.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2023 Lenses.io Ltd
+ * Copyright 2017-2024 Lenses.io Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-connect-azure-documentdb/src/main/scala/io/lenses/streamreactor/connect/azure/documentdb/sink/SinkRecordToDocument.scala
+++ b/kafka-connect-azure-documentdb/src/main/scala/io/lenses/streamreactor/connect/azure/documentdb/sink/SinkRecordToDocument.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2023 Lenses.io Ltd
+ * Copyright 2017-2024 Lenses.io Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-connect-azure-documentdb/src/test/scala/io/lenses/streamreactor/connect/azure/documentdb/config/DocumentDbSinkSettingsTest.scala
+++ b/kafka-connect-azure-documentdb/src/test/scala/io/lenses/streamreactor/connect/azure/documentdb/config/DocumentDbSinkSettingsTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2023 Lenses.io Ltd
+ * Copyright 2017-2024 Lenses.io Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-connect-azure-documentdb/src/test/scala/io/lenses/streamreactor/connect/azure/documentdb/sink/DocumentDbSinkConnectorTest.scala
+++ b/kafka-connect-azure-documentdb/src/test/scala/io/lenses/streamreactor/connect/azure/documentdb/sink/DocumentDbSinkConnectorTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2023 Lenses.io Ltd
+ * Copyright 2017-2024 Lenses.io Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-connect-azure-documentdb/src/test/scala/io/lenses/streamreactor/connect/azure/documentdb/sink/DocumentDbSinkTaskJsonTest.scala
+++ b/kafka-connect-azure-documentdb/src/test/scala/io/lenses/streamreactor/connect/azure/documentdb/sink/DocumentDbSinkTaskJsonTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2023 Lenses.io Ltd
+ * Copyright 2017-2024 Lenses.io Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-connect-azure-documentdb/src/test/scala/io/lenses/streamreactor/connect/azure/documentdb/sink/DocumentDbSinkTaskMapTest.scala
+++ b/kafka-connect-azure-documentdb/src/test/scala/io/lenses/streamreactor/connect/azure/documentdb/sink/DocumentDbSinkTaskMapTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2023 Lenses.io Ltd
+ * Copyright 2017-2024 Lenses.io Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-connect-azure-documentdb/src/test/scala/io/lenses/streamreactor/connect/azure/documentdb/sink/DocumentDbSinkTaskStructTest.scala
+++ b/kafka-connect-azure-documentdb/src/test/scala/io/lenses/streamreactor/connect/azure/documentdb/sink/DocumentDbSinkTaskStructTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2023 Lenses.io Ltd
+ * Copyright 2017-2024 Lenses.io Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-connect-azure-documentdb/src/test/scala/io/lenses/streamreactor/connect/azure/documentdb/sink/Input.scala
+++ b/kafka-connect-azure-documentdb/src/test/scala/io/lenses/streamreactor/connect/azure/documentdb/sink/Input.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2023 Lenses.io Ltd
+ * Copyright 2017-2024 Lenses.io Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-connect-azure-documentdb/src/test/scala/io/lenses/streamreactor/connect/azure/documentdb/sink/KeysExtractorTest.scala
+++ b/kafka-connect-azure-documentdb/src/test/scala/io/lenses/streamreactor/connect/azure/documentdb/sink/KeysExtractorTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2023 Lenses.io Ltd
+ * Copyright 2017-2024 Lenses.io Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-connect-azure-documentdb/src/test/scala/io/lenses/streamreactor/connect/azure/documentdb/sink/MatchingArgument.scala
+++ b/kafka-connect-azure-documentdb/src/test/scala/io/lenses/streamreactor/connect/azure/documentdb/sink/MatchingArgument.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2023 Lenses.io Ltd
+ * Copyright 2017-2024 Lenses.io Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-connect-azure-documentdb/src/test/scala/io/lenses/streamreactor/connect/azure/documentdb/sink/Output.scala
+++ b/kafka-connect-azure-documentdb/src/test/scala/io/lenses/streamreactor/connect/azure/documentdb/sink/Output.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2023 Lenses.io Ltd
+ * Copyright 2017-2024 Lenses.io Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-connect-azure-documentdb/src/test/scala/io/lenses/streamreactor/connect/azure/documentdb/sink/SinkRecordToDocumentTest.scala
+++ b/kafka-connect-azure-documentdb/src/test/scala/io/lenses/streamreactor/connect/azure/documentdb/sink/SinkRecordToDocumentTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2023 Lenses.io Ltd
+ * Copyright 2017-2024 Lenses.io Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-connect-azure-documentdb/src/test/scala/io/lenses/streamreactor/connect/azure/documentdb/sink/Transaction.scala
+++ b/kafka-connect-azure-documentdb/src/test/scala/io/lenses/streamreactor/connect/azure/documentdb/sink/Transaction.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2023 Lenses.io Ltd
+ * Copyright 2017-2024 Lenses.io Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-connect-cassandra/src/main/scala/io/lenses/streamreactor/connect/cassandra/CassandraConnection.scala
+++ b/kafka-connect-cassandra/src/main/scala/io/lenses/streamreactor/connect/cassandra/CassandraConnection.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2023 Lenses.io Ltd
+ * Copyright 2017-2024 Lenses.io Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-connect-cassandra/src/main/scala/io/lenses/streamreactor/connect/cassandra/config/CassandraConfig.scala
+++ b/kafka-connect-cassandra/src/main/scala/io/lenses/streamreactor/connect/cassandra/config/CassandraConfig.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2023 Lenses.io Ltd
+ * Copyright 2017-2024 Lenses.io Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-connect-cassandra/src/main/scala/io/lenses/streamreactor/connect/cassandra/config/CassandraConfigConstants.scala
+++ b/kafka-connect-cassandra/src/main/scala/io/lenses/streamreactor/connect/cassandra/config/CassandraConfigConstants.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2023 Lenses.io Ltd
+ * Copyright 2017-2024 Lenses.io Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-connect-cassandra/src/main/scala/io/lenses/streamreactor/connect/cassandra/config/CassandraSettings.scala
+++ b/kafka-connect-cassandra/src/main/scala/io/lenses/streamreactor/connect/cassandra/config/CassandraSettings.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2023 Lenses.io Ltd
+ * Copyright 2017-2024 Lenses.io Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-connect-cassandra/src/main/scala/io/lenses/streamreactor/connect/cassandra/sink/CassandraJsonWriter.scala
+++ b/kafka-connect-cassandra/src/main/scala/io/lenses/streamreactor/connect/cassandra/sink/CassandraJsonWriter.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2023 Lenses.io Ltd
+ * Copyright 2017-2024 Lenses.io Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-connect-cassandra/src/main/scala/io/lenses/streamreactor/connect/cassandra/sink/CassandraSinkConnector.scala
+++ b/kafka-connect-cassandra/src/main/scala/io/lenses/streamreactor/connect/cassandra/sink/CassandraSinkConnector.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2023 Lenses.io Ltd
+ * Copyright 2017-2024 Lenses.io Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-connect-cassandra/src/main/scala/io/lenses/streamreactor/connect/cassandra/sink/CassandraSinkTask.scala
+++ b/kafka-connect-cassandra/src/main/scala/io/lenses/streamreactor/connect/cassandra/sink/CassandraSinkTask.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2023 Lenses.io Ltd
+ * Copyright 2017-2024 Lenses.io Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-connect-cassandra/src/main/scala/io/lenses/streamreactor/connect/cassandra/sink/CassandraWriter.scala
+++ b/kafka-connect-cassandra/src/main/scala/io/lenses/streamreactor/connect/cassandra/sink/CassandraWriter.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2023 Lenses.io Ltd
+ * Copyright 2017-2024 Lenses.io Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-connect-cassandra/src/main/scala/io/lenses/streamreactor/connect/cassandra/source/CassandraSourceConnector.scala
+++ b/kafka-connect-cassandra/src/main/scala/io/lenses/streamreactor/connect/cassandra/source/CassandraSourceConnector.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2023 Lenses.io Ltd
+ * Copyright 2017-2024 Lenses.io Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-connect-cassandra/src/main/scala/io/lenses/streamreactor/connect/cassandra/source/CassandraSourceTask.scala
+++ b/kafka-connect-cassandra/src/main/scala/io/lenses/streamreactor/connect/cassandra/source/CassandraSourceTask.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2023 Lenses.io Ltd
+ * Copyright 2017-2024 Lenses.io Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-connect-cassandra/src/main/scala/io/lenses/streamreactor/connect/cassandra/source/CassandraTableReader.scala
+++ b/kafka-connect-cassandra/src/main/scala/io/lenses/streamreactor/connect/cassandra/source/CassandraTableReader.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2023 Lenses.io Ltd
+ * Copyright 2017-2024 Lenses.io Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-connect-cassandra/src/main/scala/io/lenses/streamreactor/connect/cassandra/source/CassandraTypeConverter.scala
+++ b/kafka-connect-cassandra/src/main/scala/io/lenses/streamreactor/connect/cassandra/source/CassandraTypeConverter.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2023 Lenses.io Ltd
+ * Copyright 2017-2024 Lenses.io Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-connect-cassandra/src/main/scala/io/lenses/streamreactor/connect/cassandra/source/CqlGenerator.scala
+++ b/kafka-connect-cassandra/src/main/scala/io/lenses/streamreactor/connect/cassandra/source/CqlGenerator.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2023 Lenses.io Ltd
+ * Copyright 2017-2024 Lenses.io Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-connect-cassandra/src/main/scala/io/lenses/streamreactor/connect/cassandra/utils/CassandraResultSetWrapper.scala
+++ b/kafka-connect-cassandra/src/main/scala/io/lenses/streamreactor/connect/cassandra/utils/CassandraResultSetWrapper.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2023 Lenses.io Ltd
+ * Copyright 2017-2024 Lenses.io Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-connect-cassandra/src/main/scala/io/lenses/streamreactor/connect/cassandra/utils/CassandraUtils.scala
+++ b/kafka-connect-cassandra/src/main/scala/io/lenses/streamreactor/connect/cassandra/utils/CassandraUtils.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2023 Lenses.io Ltd
+ * Copyright 2017-2024 Lenses.io Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-connect-cassandra/src/main/scala/io/lenses/streamreactor/connect/cassandra/utils/KeyUtils.scala
+++ b/kafka-connect-cassandra/src/main/scala/io/lenses/streamreactor/connect/cassandra/utils/KeyUtils.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2023 Lenses.io Ltd
+ * Copyright 2017-2024 Lenses.io Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-connect-cassandra/src/test/scala/io/lenses/streamreactor/connect/cassandra/TestConfig.scala
+++ b/kafka-connect-cassandra/src/test/scala/io/lenses/streamreactor/connect/cassandra/TestConfig.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2023 Lenses.io Ltd
+ * Copyright 2017-2024 Lenses.io Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-connect-cassandra/src/test/scala/io/lenses/streamreactor/connect/cassandra/config/TestCassandraConstants.scala
+++ b/kafka-connect-cassandra/src/test/scala/io/lenses/streamreactor/connect/cassandra/config/TestCassandraConstants.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2023 Lenses.io Ltd
+ * Copyright 2017-2024 Lenses.io Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-connect-cassandra/src/test/scala/io/lenses/streamreactor/connect/cassandra/config/TestCassandraSinkConfig.scala
+++ b/kafka-connect-cassandra/src/test/scala/io/lenses/streamreactor/connect/cassandra/config/TestCassandraSinkConfig.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2023 Lenses.io Ltd
+ * Copyright 2017-2024 Lenses.io Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-connect-cassandra/src/test/scala/io/lenses/streamreactor/connect/cassandra/config/TestCassandraSinkSettings.scala
+++ b/kafka-connect-cassandra/src/test/scala/io/lenses/streamreactor/connect/cassandra/config/TestCassandraSinkSettings.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2023 Lenses.io Ltd
+ * Copyright 2017-2024 Lenses.io Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-connect-cassandra/src/test/scala/io/lenses/streamreactor/connect/cassandra/config/TestCassandraSourceSettings.scala
+++ b/kafka-connect-cassandra/src/test/scala/io/lenses/streamreactor/connect/cassandra/config/TestCassandraSourceSettings.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2023 Lenses.io Ltd
+ * Copyright 2017-2024 Lenses.io Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-connect-cassandra/src/test/scala/io/lenses/streamreactor/connect/cassandra/sink/Input.scala
+++ b/kafka-connect-cassandra/src/test/scala/io/lenses/streamreactor/connect/cassandra/sink/Input.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2023 Lenses.io Ltd
+ * Copyright 2017-2024 Lenses.io Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-connect-cassandra/src/test/scala/io/lenses/streamreactor/connect/cassandra/sink/Json.scala
+++ b/kafka-connect-cassandra/src/test/scala/io/lenses/streamreactor/connect/cassandra/sink/Json.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2023 Lenses.io Ltd
+ * Copyright 2017-2024 Lenses.io Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-connect-cassandra/src/test/scala/io/lenses/streamreactor/connect/cassandra/sink/Output.scala
+++ b/kafka-connect-cassandra/src/test/scala/io/lenses/streamreactor/connect/cassandra/sink/Output.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2023 Lenses.io Ltd
+ * Copyright 2017-2024 Lenses.io Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-connect-cassandra/src/test/scala/io/lenses/streamreactor/connect/cassandra/sink/SinkRecordToJsonTest.scala
+++ b/kafka-connect-cassandra/src/test/scala/io/lenses/streamreactor/connect/cassandra/sink/SinkRecordToJsonTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2023 Lenses.io Ltd
+ * Copyright 2017-2024 Lenses.io Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-connect-cassandra/src/test/scala/io/lenses/streamreactor/connect/cassandra/sink/TestCassandraJsonWriterUnset.scala
+++ b/kafka-connect-cassandra/src/test/scala/io/lenses/streamreactor/connect/cassandra/sink/TestCassandraJsonWriterUnset.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2023 Lenses.io Ltd
+ * Copyright 2017-2024 Lenses.io Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-connect-cassandra/src/test/scala/io/lenses/streamreactor/connect/cassandra/sink/TestCassandraSinkConnector.scala
+++ b/kafka-connect-cassandra/src/test/scala/io/lenses/streamreactor/connect/cassandra/sink/TestCassandraSinkConnector.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2023 Lenses.io Ltd
+ * Copyright 2017-2024 Lenses.io Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-connect-cassandra/src/test/scala/io/lenses/streamreactor/connect/cassandra/sink/Transaction.scala
+++ b/kafka-connect-cassandra/src/test/scala/io/lenses/streamreactor/connect/cassandra/sink/Transaction.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2023 Lenses.io Ltd
+ * Copyright 2017-2024 Lenses.io Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-connect-cassandra/src/test/scala/io/lenses/streamreactor/connect/cassandra/source/TestCassandraSourceTaskTokenCql.scala
+++ b/kafka-connect-cassandra/src/test/scala/io/lenses/streamreactor/connect/cassandra/source/TestCassandraSourceTaskTokenCql.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2023 Lenses.io Ltd
+ * Copyright 2017-2024 Lenses.io Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-connect-cassandra/src/test/scala/io/lenses/streamreactor/connect/cassandra/source/TestCassandraTypeConverter.scala
+++ b/kafka-connect-cassandra/src/test/scala/io/lenses/streamreactor/connect/cassandra/source/TestCassandraTypeConverter.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2023 Lenses.io Ltd
+ * Copyright 2017-2024 Lenses.io Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-connect-cassandra/src/test/scala/io/lenses/streamreactor/connect/cassandra/source/TestCqlGenerator.scala
+++ b/kafka-connect-cassandra/src/test/scala/io/lenses/streamreactor/connect/cassandra/source/TestCqlGenerator.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2023 Lenses.io Ltd
+ * Copyright 2017-2024 Lenses.io Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-connect-cassandra/src/test/scala/io/lenses/streamreactor/connect/cassandra/utils/CassandraUtilsTest.scala
+++ b/kafka-connect-cassandra/src/test/scala/io/lenses/streamreactor/connect/cassandra/utils/CassandraUtilsTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2023 Lenses.io Ltd
+ * Copyright 2017-2024 Lenses.io Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-connect-cassandra/src/test/scala/io/lenses/streamreactor/connect/cassandra/utils/KeyUtilsTest.scala
+++ b/kafka-connect-cassandra/src/test/scala/io/lenses/streamreactor/connect/cassandra/utils/KeyUtilsTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2023 Lenses.io Ltd
+ * Copyright 2017-2024 Lenses.io Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-connect-cassandra/src/test/scala/io/lenses/streamreactor/connect/cassandra/utils/TestUtils.scala
+++ b/kafka-connect-cassandra/src/test/scala/io/lenses/streamreactor/connect/cassandra/utils/TestUtils.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2023 Lenses.io Ltd
+ * Copyright 2017-2024 Lenses.io Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-connect-common/src/test/scala/io/lenses/connect/sql/GeneratorTest.scala
+++ b/kafka-connect-common/src/test/scala/io/lenses/connect/sql/GeneratorTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2023 Lenses.io Ltd
+ * Copyright 2017-2024 Lenses.io Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-connect-common/src/test/scala/io/lenses/connect/sql/Person.scala
+++ b/kafka-connect-common/src/test/scala/io/lenses/connect/sql/Person.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2023 Lenses.io Ltd
+ * Copyright 2017-2024 Lenses.io Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-connect-common/src/test/scala/io/lenses/connect/sql/Pizza.scala
+++ b/kafka-connect-common/src/test/scala/io/lenses/connect/sql/Pizza.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2023 Lenses.io Ltd
+ * Copyright 2017-2024 Lenses.io Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-connect-common/src/test/scala/io/lenses/connect/sql/StructSqlTest.scala
+++ b/kafka-connect-common/src/test/scala/io/lenses/connect/sql/StructSqlTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2023 Lenses.io Ltd
+ * Copyright 2017-2024 Lenses.io Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-connect-common/src/test/scala/io/lenses/connect/sql/StructSqlWithRetainStructureTest.scala
+++ b/kafka-connect-common/src/test/scala/io/lenses/connect/sql/StructSqlWithRetainStructureTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2023 Lenses.io Ltd
+ * Copyright 2017-2024 Lenses.io Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-connect-common/src/test/scala/io/lenses/connect/sql/TransformTests.scala
+++ b/kafka-connect-common/src/test/scala/io/lenses/connect/sql/TransformTests.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2023 Lenses.io Ltd
+ * Copyright 2017-2024 Lenses.io Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-connect-common/src/test/scala/io/lenses/connect/sql/TransformationTests.scala
+++ b/kafka-connect-common/src/test/scala/io/lenses/connect/sql/TransformationTests.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2023 Lenses.io Ltd
+ * Copyright 2017-2024 Lenses.io Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-connect-common/src/test/scala/io/lenses/json/sql/JsonSqlTest.scala
+++ b/kafka-connect-common/src/test/scala/io/lenses/json/sql/JsonSqlTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2023 Lenses.io Ltd
+ * Copyright 2017-2024 Lenses.io Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-connect-common/src/test/scala/io/lenses/json/sql/JsonSqlWithRetainStructureTest.scala
+++ b/kafka-connect-common/src/test/scala/io/lenses/json/sql/JsonSqlWithRetainStructureTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2023 Lenses.io Ltd
+ * Copyright 2017-2024 Lenses.io Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-connect-common/src/test/scala/io/lenses/json/sql/Person.scala
+++ b/kafka-connect-common/src/test/scala/io/lenses/json/sql/Person.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2023 Lenses.io Ltd
+ * Copyright 2017-2024 Lenses.io Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-connect-common/src/test/scala/io/lenses/json/sql/Pizza.scala
+++ b/kafka-connect-common/src/test/scala/io/lenses/json/sql/Pizza.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2023 Lenses.io Ltd
+ * Copyright 2017-2024 Lenses.io Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-connect-common/src/test/scala/io/lenses/streamreactor/common/TestUtilsBase.scala
+++ b/kafka-connect-common/src/test/scala/io/lenses/streamreactor/common/TestUtilsBase.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2023 Lenses.io Ltd
+ * Copyright 2017-2024 Lenses.io Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-connect-common/src/test/scala/io/lenses/streamreactor/common/concurrent/FutureAwaitWithFailFastFnTest.scala
+++ b/kafka-connect-common/src/test/scala/io/lenses/streamreactor/common/concurrent/FutureAwaitWithFailFastFnTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2023 Lenses.io Ltd
+ * Copyright 2017-2024 Lenses.io Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-connect-common/src/test/scala/io/lenses/streamreactor/common/config/KcqlSettingsTest.scala
+++ b/kafka-connect-common/src/test/scala/io/lenses/streamreactor/common/config/KcqlSettingsTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2023 Lenses.io Ltd
+ * Copyright 2017-2024 Lenses.io Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-connect-common/src/test/scala/io/lenses/streamreactor/common/config/TestHelpers.scala
+++ b/kafka-connect-common/src/test/scala/io/lenses/streamreactor/common/config/TestHelpers.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2023 Lenses.io Ltd
+ * Copyright 2017-2024 Lenses.io Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-connect-common/src/test/scala/io/lenses/streamreactor/common/config/TestSSLConfigContext.scala
+++ b/kafka-connect-common/src/test/scala/io/lenses/streamreactor/common/config/TestSSLConfigContext.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2023 Lenses.io Ltd
+ * Copyright 2017-2024 Lenses.io Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-connect-common/src/test/scala/io/lenses/streamreactor/common/converters/sink/AvroConverterTest.scala
+++ b/kafka-connect-common/src/test/scala/io/lenses/streamreactor/common/converters/sink/AvroConverterTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2023 Lenses.io Ltd
+ * Copyright 2017-2024 Lenses.io Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-connect-common/src/test/scala/io/lenses/streamreactor/common/converters/sink/BytesConverterTest.scala
+++ b/kafka-connect-common/src/test/scala/io/lenses/streamreactor/common/converters/sink/BytesConverterTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2023 Lenses.io Ltd
+ * Copyright 2017-2024 Lenses.io Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-connect-common/src/test/scala/io/lenses/streamreactor/common/errors/TestErrorHandlerNoop.scala
+++ b/kafka-connect-common/src/test/scala/io/lenses/streamreactor/common/errors/TestErrorHandlerNoop.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2023 Lenses.io Ltd
+ * Copyright 2017-2024 Lenses.io Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-connect-common/src/test/scala/io/lenses/streamreactor/common/errors/TestErrorHandlerRetry.scala
+++ b/kafka-connect-common/src/test/scala/io/lenses/streamreactor/common/errors/TestErrorHandlerRetry.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2023 Lenses.io Ltd
+ * Copyright 2017-2024 Lenses.io Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-connect-common/src/test/scala/io/lenses/streamreactor/common/errors/TestErrorHandlerThrow.scala
+++ b/kafka-connect-common/src/test/scala/io/lenses/streamreactor/common/errors/TestErrorHandlerThrow.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2023 Lenses.io Ltd
+ * Copyright 2017-2024 Lenses.io Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-connect-common/src/test/scala/io/lenses/streamreactor/common/offsets/TestOffsetHandler.scala
+++ b/kafka-connect-common/src/test/scala/io/lenses/streamreactor/common/offsets/TestOffsetHandler.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2023 Lenses.io Ltd
+ * Copyright 2017-2024 Lenses.io Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-connect-common/src/test/scala/io/lenses/streamreactor/common/schemas/TestConverterUtil.scala
+++ b/kafka-connect-common/src/test/scala/io/lenses/streamreactor/common/schemas/TestConverterUtil.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2023 Lenses.io Ltd
+ * Copyright 2017-2024 Lenses.io Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-connect-common/src/test/scala/io/lenses/streamreactor/common/serialization/AvroSerializerTest.scala
+++ b/kafka-connect-common/src/test/scala/io/lenses/streamreactor/common/serialization/AvroSerializerTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2023 Lenses.io Ltd
+ * Copyright 2017-2024 Lenses.io Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-connect-common/src/test/scala/io/lenses/streamreactor/common/sink/StringGenericRowKeyBuilderTest.scala
+++ b/kafka-connect-common/src/test/scala/io/lenses/streamreactor/common/sink/StringGenericRowKeyBuilderTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2023 Lenses.io Ltd
+ * Copyright 2017-2024 Lenses.io Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-connect-common/src/test/scala/io/lenses/streamreactor/common/sink/StringSinkRecordKeyBuilderTest.scala
+++ b/kafka-connect-common/src/test/scala/io/lenses/streamreactor/common/sink/StringSinkRecordKeyBuilderTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2023 Lenses.io Ltd
+ * Copyright 2017-2024 Lenses.io Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-connect-common/src/test/scala/io/lenses/streamreactor/common/sink/StringStructFieldsStringKeyBuilderTest.scala
+++ b/kafka-connect-common/src/test/scala/io/lenses/streamreactor/common/sink/StringStructFieldsStringKeyBuilderTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2023 Lenses.io Ltd
+ * Copyright 2017-2024 Lenses.io Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-connect-common/src/test/scala/io/lenses/streamreactor/connect/config/kcqlprops/KcqlPropertiesTest.scala
+++ b/kafka-connect-common/src/test/scala/io/lenses/streamreactor/connect/config/kcqlprops/KcqlPropertiesTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2023 Lenses.io Ltd
+ * Copyright 2017-2024 Lenses.io Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-connect-common/src/test/scala/io/lenses/streamreactor/connect/converters/source/AvroConverterTest.scala
+++ b/kafka-connect-common/src/test/scala/io/lenses/streamreactor/connect/converters/source/AvroConverterTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2023 Lenses.io Ltd
+ * Copyright 2017-2024 Lenses.io Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-connect-common/src/test/scala/io/lenses/streamreactor/connect/converters/source/BytesConverterTest.scala
+++ b/kafka-connect-common/src/test/scala/io/lenses/streamreactor/connect/converters/source/BytesConverterTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2023 Lenses.io Ltd
+ * Copyright 2017-2024 Lenses.io Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-connect-common/src/test/scala/io/lenses/streamreactor/connect/converters/source/JacksonJson.scala
+++ b/kafka-connect-common/src/test/scala/io/lenses/streamreactor/connect/converters/source/JacksonJson.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2023 Lenses.io Ltd
+ * Copyright 2017-2024 Lenses.io Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-connect-common/src/test/scala/io/lenses/streamreactor/connect/converters/source/JsonConverterWithSchemaEvolutionTest.scala
+++ b/kafka-connect-common/src/test/scala/io/lenses/streamreactor/connect/converters/source/JsonConverterWithSchemaEvolutionTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2023 Lenses.io Ltd
+ * Copyright 2017-2024 Lenses.io Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-connect-common/src/test/scala/io/lenses/streamreactor/connect/converters/source/JsonPassThroughConverterTest.scala
+++ b/kafka-connect-common/src/test/scala/io/lenses/streamreactor/connect/converters/source/JsonPassThroughConverterTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2023 Lenses.io Ltd
+ * Copyright 2017-2024 Lenses.io Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-connect-common/src/test/scala/io/lenses/streamreactor/connect/converters/source/JsonSimpleConverterTest.scala
+++ b/kafka-connect-common/src/test/scala/io/lenses/streamreactor/connect/converters/source/JsonSimpleConverterTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2023 Lenses.io Ltd
+ * Copyright 2017-2024 Lenses.io Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-connect-common/src/test/scala/io/lenses/streamreactor/connect/io/text/LineStartLineEndReaderTest.scala
+++ b/kafka-connect-common/src/test/scala/io/lenses/streamreactor/connect/io/text/LineStartLineEndReaderTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2023 Lenses.io Ltd
+ * Copyright 2017-2024 Lenses.io Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-connect-common/src/test/scala/io/lenses/streamreactor/connect/io/text/OptionIteratorAdaptorTest.scala
+++ b/kafka-connect-common/src/test/scala/io/lenses/streamreactor/connect/io/text/OptionIteratorAdaptorTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2023 Lenses.io Ltd
+ * Copyright 2017-2024 Lenses.io Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-connect-common/src/test/scala/io/lenses/streamreactor/connect/io/text/PrefixSuffixReaderTest.scala
+++ b/kafka-connect-common/src/test/scala/io/lenses/streamreactor/connect/io/text/PrefixSuffixReaderTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2023 Lenses.io Ltd
+ * Copyright 2017-2024 Lenses.io Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-connect-common/src/test/scala/io/lenses/streamreactor/connect/io/text/RegexMatchLineReaderTest.scala
+++ b/kafka-connect-common/src/test/scala/io/lenses/streamreactor/connect/io/text/RegexMatchLineReaderTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2023 Lenses.io Ltd
+ * Copyright 2017-2024 Lenses.io Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-connect-common/src/test/scala/io/lenses/streamreactor/connect/io/text/SequenceBasedLineReaderTest.scala
+++ b/kafka-connect-common/src/test/scala/io/lenses/streamreactor/connect/io/text/SequenceBasedLineReaderTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2023 Lenses.io Ltd
+ * Copyright 2017-2024 Lenses.io Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-connect-common/src/test/scala/io/lenses/streamreactor/connect/io/text/TextUtilsTest.scala
+++ b/kafka-connect-common/src/test/scala/io/lenses/streamreactor/connect/io/text/TextUtilsTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2023 Lenses.io Ltd
+ * Copyright 2017-2024 Lenses.io Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-connect-common/src/test/scala/io/lenses/streamreactor/connect/json/SimpleJsonConverterTest.scala
+++ b/kafka-connect-common/src/test/scala/io/lenses/streamreactor/connect/json/SimpleJsonConverterTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2023 Lenses.io Ltd
+ * Copyright 2017-2024 Lenses.io Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-connect-elastic6/src/main/scala/io/lenses/streamreactor/connect/elastic6/ElasticJsonWriter.scala
+++ b/kafka-connect-elastic6/src/main/scala/io/lenses/streamreactor/connect/elastic6/ElasticJsonWriter.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2023 Lenses.io Ltd
+ * Copyright 2017-2024 Lenses.io Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-connect-elastic6/src/main/scala/io/lenses/streamreactor/connect/elastic6/ElasticSinkConnector.scala
+++ b/kafka-connect-elastic6/src/main/scala/io/lenses/streamreactor/connect/elastic6/ElasticSinkConnector.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2023 Lenses.io Ltd
+ * Copyright 2017-2024 Lenses.io Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-connect-elastic6/src/main/scala/io/lenses/streamreactor/connect/elastic6/ElasticSinkTask.scala
+++ b/kafka-connect-elastic6/src/main/scala/io/lenses/streamreactor/connect/elastic6/ElasticSinkTask.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2023 Lenses.io Ltd
+ * Copyright 2017-2024 Lenses.io Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-connect-elastic6/src/main/scala/io/lenses/streamreactor/connect/elastic6/ElasticWriter.scala
+++ b/kafka-connect-elastic6/src/main/scala/io/lenses/streamreactor/connect/elastic6/ElasticWriter.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2023 Lenses.io Ltd
+ * Copyright 2017-2024 Lenses.io Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-connect-elastic6/src/main/scala/io/lenses/streamreactor/connect/elastic6/KElasticClient.scala
+++ b/kafka-connect-elastic6/src/main/scala/io/lenses/streamreactor/connect/elastic6/KElasticClient.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2023 Lenses.io Ltd
+ * Copyright 2017-2024 Lenses.io Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-connect-elastic6/src/main/scala/io/lenses/streamreactor/connect/elastic6/PrimaryKeyExtractor.scala
+++ b/kafka-connect-elastic6/src/main/scala/io/lenses/streamreactor/connect/elastic6/PrimaryKeyExtractor.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2023 Lenses.io Ltd
+ * Copyright 2017-2024 Lenses.io Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-connect-elastic6/src/main/scala/io/lenses/streamreactor/connect/elastic6/Transform.scala
+++ b/kafka-connect-elastic6/src/main/scala/io/lenses/streamreactor/connect/elastic6/Transform.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2023 Lenses.io Ltd
+ * Copyright 2017-2024 Lenses.io Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-connect-elastic6/src/main/scala/io/lenses/streamreactor/connect/elastic6/TransformAndExtractPK.scala
+++ b/kafka-connect-elastic6/src/main/scala/io/lenses/streamreactor/connect/elastic6/TransformAndExtractPK.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2023 Lenses.io Ltd
+ * Copyright 2017-2024 Lenses.io Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-connect-elastic6/src/main/scala/io/lenses/streamreactor/connect/elastic6/config/ElasticConfig.scala
+++ b/kafka-connect-elastic6/src/main/scala/io/lenses/streamreactor/connect/elastic6/config/ElasticConfig.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2023 Lenses.io Ltd
+ * Copyright 2017-2024 Lenses.io Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-connect-elastic6/src/main/scala/io/lenses/streamreactor/connect/elastic6/config/ElasticConfigConstants.scala
+++ b/kafka-connect-elastic6/src/main/scala/io/lenses/streamreactor/connect/elastic6/config/ElasticConfigConstants.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2023 Lenses.io Ltd
+ * Copyright 2017-2024 Lenses.io Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-connect-elastic6/src/main/scala/io/lenses/streamreactor/connect/elastic6/config/ElasticSettings.scala
+++ b/kafka-connect-elastic6/src/main/scala/io/lenses/streamreactor/connect/elastic6/config/ElasticSettings.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2023 Lenses.io Ltd
+ * Copyright 2017-2024 Lenses.io Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-connect-elastic6/src/main/scala/io/lenses/streamreactor/connect/elastic6/indexname/CreateIndex.scala
+++ b/kafka-connect-elastic6/src/main/scala/io/lenses/streamreactor/connect/elastic6/indexname/CreateIndex.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2023 Lenses.io Ltd
+ * Copyright 2017-2024 Lenses.io Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-connect-elastic6/src/main/scala/io/lenses/streamreactor/connect/elastic6/indexname/CustomIndexName.scala
+++ b/kafka-connect-elastic6/src/main/scala/io/lenses/streamreactor/connect/elastic6/indexname/CustomIndexName.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2023 Lenses.io Ltd
+ * Copyright 2017-2024 Lenses.io Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-connect-elastic6/src/main/scala/io/lenses/streamreactor/connect/elastic6/indexname/IndexNameFragment.scala
+++ b/kafka-connect-elastic6/src/main/scala/io/lenses/streamreactor/connect/elastic6/indexname/IndexNameFragment.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2023 Lenses.io Ltd
+ * Copyright 2017-2024 Lenses.io Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-connect-elastic6/src/main/scala/io/lenses/streamreactor/connect/elastic6/indexname/package.scala
+++ b/kafka-connect-elastic6/src/main/scala/io/lenses/streamreactor/connect/elastic6/indexname/package.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2023 Lenses.io Ltd
+ * Copyright 2017-2024 Lenses.io Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-connect-elastic6/src/test/scala/io/lenses/streamreactor/connect/elastic6/CreateIndexTest.scala
+++ b/kafka-connect-elastic6/src/test/scala/io/lenses/streamreactor/connect/elastic6/CreateIndexTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2023 Lenses.io Ltd
+ * Copyright 2017-2024 Lenses.io Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-connect-elastic6/src/test/scala/io/lenses/streamreactor/connect/elastic6/ElasticConfigTest.scala
+++ b/kafka-connect-elastic6/src/test/scala/io/lenses/streamreactor/connect/elastic6/ElasticConfigTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2023 Lenses.io Ltd
+ * Copyright 2017-2024 Lenses.io Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-connect-elastic6/src/test/scala/io/lenses/streamreactor/connect/elastic6/ElasticSinkConnectorTest.scala
+++ b/kafka-connect-elastic6/src/test/scala/io/lenses/streamreactor/connect/elastic6/ElasticSinkConnectorTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2023 Lenses.io Ltd
+ * Copyright 2017-2024 Lenses.io Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-connect-elastic6/src/test/scala/io/lenses/streamreactor/connect/elastic6/ElasticSinkTaskTest.scala
+++ b/kafka-connect-elastic6/src/test/scala/io/lenses/streamreactor/connect/elastic6/ElasticSinkTaskTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2023 Lenses.io Ltd
+ * Copyright 2017-2024 Lenses.io Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-connect-elastic6/src/test/scala/io/lenses/streamreactor/connect/elastic6/ElasticWriterCredentialsTest.scala
+++ b/kafka-connect-elastic6/src/test/scala/io/lenses/streamreactor/connect/elastic6/ElasticWriterCredentialsTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2023 Lenses.io Ltd
+ * Copyright 2017-2024 Lenses.io Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-connect-elastic6/src/test/scala/io/lenses/streamreactor/connect/elastic6/TestBase.scala
+++ b/kafka-connect-elastic6/src/test/scala/io/lenses/streamreactor/connect/elastic6/TestBase.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2023 Lenses.io Ltd
+ * Copyright 2017-2024 Lenses.io Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-connect-elastic6/src/test/scala/io/lenses/streamreactor/connect/elastic6/indexname/ClockFixture.scala
+++ b/kafka-connect-elastic6/src/test/scala/io/lenses/streamreactor/connect/elastic6/indexname/ClockFixture.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2023 Lenses.io Ltd
+ * Copyright 2017-2024 Lenses.io Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-connect-elastic6/src/test/scala/io/lenses/streamreactor/connect/elastic6/indexname/CustomIndexNameTest.scala
+++ b/kafka-connect-elastic6/src/test/scala/io/lenses/streamreactor/connect/elastic6/indexname/CustomIndexNameTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2023 Lenses.io Ltd
+ * Copyright 2017-2024 Lenses.io Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-connect-elastic6/src/test/scala/io/lenses/streamreactor/connect/elastic6/indexname/IndexNameFragmentTest.scala
+++ b/kafka-connect-elastic6/src/test/scala/io/lenses/streamreactor/connect/elastic6/indexname/IndexNameFragmentTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2023 Lenses.io Ltd
+ * Copyright 2017-2024 Lenses.io Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-connect-elastic7/src/main/scala/io/lenses/streamreactor/connect/elastic7/ElasticJsonWriter.scala
+++ b/kafka-connect-elastic7/src/main/scala/io/lenses/streamreactor/connect/elastic7/ElasticJsonWriter.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2023 Lenses.io Ltd
+ * Copyright 2017-2024 Lenses.io Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-connect-elastic7/src/main/scala/io/lenses/streamreactor/connect/elastic7/ElasticSinkConnector.scala
+++ b/kafka-connect-elastic7/src/main/scala/io/lenses/streamreactor/connect/elastic7/ElasticSinkConnector.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2023 Lenses.io Ltd
+ * Copyright 2017-2024 Lenses.io Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-connect-elastic7/src/main/scala/io/lenses/streamreactor/connect/elastic7/ElasticSinkTask.scala
+++ b/kafka-connect-elastic7/src/main/scala/io/lenses/streamreactor/connect/elastic7/ElasticSinkTask.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2023 Lenses.io Ltd
+ * Copyright 2017-2024 Lenses.io Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-connect-elastic7/src/main/scala/io/lenses/streamreactor/connect/elastic7/ElasticWriter.scala
+++ b/kafka-connect-elastic7/src/main/scala/io/lenses/streamreactor/connect/elastic7/ElasticWriter.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2023 Lenses.io Ltd
+ * Copyright 2017-2024 Lenses.io Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-connect-elastic7/src/main/scala/io/lenses/streamreactor/connect/elastic7/KElasticClient.scala
+++ b/kafka-connect-elastic7/src/main/scala/io/lenses/streamreactor/connect/elastic7/KElasticClient.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2023 Lenses.io Ltd
+ * Copyright 2017-2024 Lenses.io Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-connect-elastic7/src/main/scala/io/lenses/streamreactor/connect/elastic7/PrimaryKeyExtractor.scala
+++ b/kafka-connect-elastic7/src/main/scala/io/lenses/streamreactor/connect/elastic7/PrimaryKeyExtractor.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2023 Lenses.io Ltd
+ * Copyright 2017-2024 Lenses.io Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-connect-elastic7/src/main/scala/io/lenses/streamreactor/connect/elastic7/Transform.scala
+++ b/kafka-connect-elastic7/src/main/scala/io/lenses/streamreactor/connect/elastic7/Transform.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2023 Lenses.io Ltd
+ * Copyright 2017-2024 Lenses.io Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-connect-elastic7/src/main/scala/io/lenses/streamreactor/connect/elastic7/TransformAndExtractPK.scala
+++ b/kafka-connect-elastic7/src/main/scala/io/lenses/streamreactor/connect/elastic7/TransformAndExtractPK.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2023 Lenses.io Ltd
+ * Copyright 2017-2024 Lenses.io Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-connect-elastic7/src/main/scala/io/lenses/streamreactor/connect/elastic7/config/ElasticConfig.scala
+++ b/kafka-connect-elastic7/src/main/scala/io/lenses/streamreactor/connect/elastic7/config/ElasticConfig.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2023 Lenses.io Ltd
+ * Copyright 2017-2024 Lenses.io Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-connect-elastic7/src/main/scala/io/lenses/streamreactor/connect/elastic7/config/ElasticConfigConstants.scala
+++ b/kafka-connect-elastic7/src/main/scala/io/lenses/streamreactor/connect/elastic7/config/ElasticConfigConstants.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2023 Lenses.io Ltd
+ * Copyright 2017-2024 Lenses.io Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-connect-elastic7/src/main/scala/io/lenses/streamreactor/connect/elastic7/config/ElasticSettings.scala
+++ b/kafka-connect-elastic7/src/main/scala/io/lenses/streamreactor/connect/elastic7/config/ElasticSettings.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2023 Lenses.io Ltd
+ * Copyright 2017-2024 Lenses.io Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-connect-elastic7/src/main/scala/io/lenses/streamreactor/connect/elastic7/indexname/CreateIndex.scala
+++ b/kafka-connect-elastic7/src/main/scala/io/lenses/streamreactor/connect/elastic7/indexname/CreateIndex.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2023 Lenses.io Ltd
+ * Copyright 2017-2024 Lenses.io Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-connect-elastic7/src/main/scala/io/lenses/streamreactor/connect/elastic7/indexname/CustomIndexName.scala
+++ b/kafka-connect-elastic7/src/main/scala/io/lenses/streamreactor/connect/elastic7/indexname/CustomIndexName.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2023 Lenses.io Ltd
+ * Copyright 2017-2024 Lenses.io Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-connect-elastic7/src/main/scala/io/lenses/streamreactor/connect/elastic7/indexname/IndexNameFragment.scala
+++ b/kafka-connect-elastic7/src/main/scala/io/lenses/streamreactor/connect/elastic7/indexname/IndexNameFragment.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2023 Lenses.io Ltd
+ * Copyright 2017-2024 Lenses.io Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-connect-elastic7/src/main/scala/io/lenses/streamreactor/connect/elastic7/indexname/package.scala
+++ b/kafka-connect-elastic7/src/main/scala/io/lenses/streamreactor/connect/elastic7/indexname/package.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2023 Lenses.io Ltd
+ * Copyright 2017-2024 Lenses.io Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-connect-elastic7/src/test/scala/io/lenses/streamreactor/connect/elastic7/CreateIndexTest.scala
+++ b/kafka-connect-elastic7/src/test/scala/io/lenses/streamreactor/connect/elastic7/CreateIndexTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2023 Lenses.io Ltd
+ * Copyright 2017-2024 Lenses.io Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-connect-elastic7/src/test/scala/io/lenses/streamreactor/connect/elastic7/ElasticConfigTest.scala
+++ b/kafka-connect-elastic7/src/test/scala/io/lenses/streamreactor/connect/elastic7/ElasticConfigTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2023 Lenses.io Ltd
+ * Copyright 2017-2024 Lenses.io Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-connect-elastic7/src/test/scala/io/lenses/streamreactor/connect/elastic7/ElasticSinkConnectorTest.scala
+++ b/kafka-connect-elastic7/src/test/scala/io/lenses/streamreactor/connect/elastic7/ElasticSinkConnectorTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2023 Lenses.io Ltd
+ * Copyright 2017-2024 Lenses.io Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-connect-elastic7/src/test/scala/io/lenses/streamreactor/connect/elastic7/ElasticSinkTaskTest.scala
+++ b/kafka-connect-elastic7/src/test/scala/io/lenses/streamreactor/connect/elastic7/ElasticSinkTaskTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2023 Lenses.io Ltd
+ * Copyright 2017-2024 Lenses.io Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-connect-elastic7/src/test/scala/io/lenses/streamreactor/connect/elastic7/ElasticWriterCredentialsTest.scala
+++ b/kafka-connect-elastic7/src/test/scala/io/lenses/streamreactor/connect/elastic7/ElasticWriterCredentialsTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2023 Lenses.io Ltd
+ * Copyright 2017-2024 Lenses.io Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-connect-elastic7/src/test/scala/io/lenses/streamreactor/connect/elastic7/TestBase.scala
+++ b/kafka-connect-elastic7/src/test/scala/io/lenses/streamreactor/connect/elastic7/TestBase.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2023 Lenses.io Ltd
+ * Copyright 2017-2024 Lenses.io Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-connect-elastic7/src/test/scala/io/lenses/streamreactor/connect/elastic7/indexname/ClockFixture.scala
+++ b/kafka-connect-elastic7/src/test/scala/io/lenses/streamreactor/connect/elastic7/indexname/ClockFixture.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2023 Lenses.io Ltd
+ * Copyright 2017-2024 Lenses.io Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-connect-elastic7/src/test/scala/io/lenses/streamreactor/connect/elastic7/indexname/CustomIndexNameTest.scala
+++ b/kafka-connect-elastic7/src/test/scala/io/lenses/streamreactor/connect/elastic7/indexname/CustomIndexNameTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2023 Lenses.io Ltd
+ * Copyright 2017-2024 Lenses.io Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-connect-elastic7/src/test/scala/io/lenses/streamreactor/connect/elastic7/indexname/IndexNameFragmentTest.scala
+++ b/kafka-connect-elastic7/src/test/scala/io/lenses/streamreactor/connect/elastic7/indexname/IndexNameFragmentTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2023 Lenses.io Ltd
+ * Copyright 2017-2024 Lenses.io Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-connect-ftp/src/main/scala/io/lenses/streamreactor/connect/ftp/source/ConnectFileMetaDataStore.scala
+++ b/kafka-connect-ftp/src/main/scala/io/lenses/streamreactor/connect/ftp/source/ConnectFileMetaDataStore.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2023 Lenses.io Ltd
+ * Copyright 2017-2024 Lenses.io Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-connect-ftp/src/main/scala/io/lenses/streamreactor/connect/ftp/source/ExponentialBackOff.scala
+++ b/kafka-connect-ftp/src/main/scala/io/lenses/streamreactor/connect/ftp/source/ExponentialBackOff.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2023 Lenses.io Ltd
+ * Copyright 2017-2024 Lenses.io Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-connect-ftp/src/main/scala/io/lenses/streamreactor/connect/ftp/source/FileConverter.scala
+++ b/kafka-connect-ftp/src/main/scala/io/lenses/streamreactor/connect/ftp/source/FileConverter.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2023 Lenses.io Ltd
+ * Copyright 2017-2024 Lenses.io Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-connect-ftp/src/main/scala/io/lenses/streamreactor/connect/ftp/source/FileMetaData.scala
+++ b/kafka-connect-ftp/src/main/scala/io/lenses/streamreactor/connect/ftp/source/FileMetaData.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2023 Lenses.io Ltd
+ * Copyright 2017-2024 Lenses.io Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-connect-ftp/src/main/scala/io/lenses/streamreactor/connect/ftp/source/FtpFileLister.scala
+++ b/kafka-connect-ftp/src/main/scala/io/lenses/streamreactor/connect/ftp/source/FtpFileLister.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2023 Lenses.io Ltd
+ * Copyright 2017-2024 Lenses.io Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-connect-ftp/src/main/scala/io/lenses/streamreactor/connect/ftp/source/FtpMonitor.scala
+++ b/kafka-connect-ftp/src/main/scala/io/lenses/streamreactor/connect/ftp/source/FtpMonitor.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2023 Lenses.io Ltd
+ * Copyright 2017-2024 Lenses.io Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-connect-ftp/src/main/scala/io/lenses/streamreactor/connect/ftp/source/FtpSourceConfig.scala
+++ b/kafka-connect-ftp/src/main/scala/io/lenses/streamreactor/connect/ftp/source/FtpSourceConfig.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2023 Lenses.io Ltd
+ * Copyright 2017-2024 Lenses.io Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-connect-ftp/src/main/scala/io/lenses/streamreactor/connect/ftp/source/FtpSourceConnector.scala
+++ b/kafka-connect-ftp/src/main/scala/io/lenses/streamreactor/connect/ftp/source/FtpSourceConnector.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2023 Lenses.io Ltd
+ * Copyright 2017-2024 Lenses.io Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-connect-ftp/src/main/scala/io/lenses/streamreactor/connect/ftp/source/FtpSourceTask.scala
+++ b/kafka-connect-ftp/src/main/scala/io/lenses/streamreactor/connect/ftp/source/FtpSourceTask.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2023 Lenses.io Ltd
+ * Copyright 2017-2024 Lenses.io Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-connect-ftp/src/main/scala/io/lenses/streamreactor/connect/ftp/source/MaxLinesFileConverter.scala
+++ b/kafka-connect-ftp/src/main/scala/io/lenses/streamreactor/connect/ftp/source/MaxLinesFileConverter.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2023 Lenses.io Ltd
+ * Copyright 2017-2024 Lenses.io Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-connect-ftp/src/main/scala/io/lenses/streamreactor/connect/ftp/source/NopSourceRecordConverter.scala
+++ b/kafka-connect-ftp/src/main/scala/io/lenses/streamreactor/connect/ftp/source/NopSourceRecordConverter.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2023 Lenses.io Ltd
+ * Copyright 2017-2024 Lenses.io Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-connect-ftp/src/main/scala/io/lenses/streamreactor/connect/ftp/source/OpTimer.scala
+++ b/kafka-connect-ftp/src/main/scala/io/lenses/streamreactor/connect/ftp/source/OpTimer.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2023 Lenses.io Ltd
+ * Copyright 2017-2024 Lenses.io Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-connect-ftp/src/main/scala/io/lenses/streamreactor/connect/ftp/source/SFTPClient.scala
+++ b/kafka-connect-ftp/src/main/scala/io/lenses/streamreactor/connect/ftp/source/SFTPClient.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2023 Lenses.io Ltd
+ * Copyright 2017-2024 Lenses.io Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-connect-ftp/src/main/scala/io/lenses/streamreactor/connect/ftp/source/SimpleFileConverter.scala
+++ b/kafka-connect-ftp/src/main/scala/io/lenses/streamreactor/connect/ftp/source/SimpleFileConverter.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2023 Lenses.io Ltd
+ * Copyright 2017-2024 Lenses.io Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-connect-ftp/src/main/scala/io/lenses/streamreactor/connect/ftp/source/SourceRecordConverter.scala
+++ b/kafka-connect-ftp/src/main/scala/io/lenses/streamreactor/connect/ftp/source/SourceRecordConverter.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2023 Lenses.io Ltd
+ * Copyright 2017-2024 Lenses.io Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-connect-ftp/src/main/scala/io/lenses/streamreactor/connect/ftp/source/SourceRecordProducers.scala
+++ b/kafka-connect-ftp/src/main/scala/io/lenses/streamreactor/connect/ftp/source/SourceRecordProducers.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2023 Lenses.io Ltd
+ * Copyright 2017-2024 Lenses.io Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-connect-ftp/src/test/scala/io/lenses/streamreactor/connect/ftp/source/FtpFileListerTest.scala
+++ b/kafka-connect-ftp/src/test/scala/io/lenses/streamreactor/connect/ftp/source/FtpFileListerTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2023 Lenses.io Ltd
+ * Copyright 2017-2024 Lenses.io Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-connect-ftp/src/test/scala/io/lenses/streamreactor/connect/ftp/source/RegExTest.scala
+++ b/kafka-connect-ftp/src/test/scala/io/lenses/streamreactor/connect/ftp/source/RegExTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2023 Lenses.io Ltd
+ * Copyright 2017-2024 Lenses.io Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-connect-influxdb/src/main/scala/io/lenses/streamreactor/connect/influx/InfluxSinkConnector.scala
+++ b/kafka-connect-influxdb/src/main/scala/io/lenses/streamreactor/connect/influx/InfluxSinkConnector.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2023 Lenses.io Ltd
+ * Copyright 2017-2024 Lenses.io Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-connect-influxdb/src/main/scala/io/lenses/streamreactor/connect/influx/InfluxSinkTask.scala
+++ b/kafka-connect-influxdb/src/main/scala/io/lenses/streamreactor/connect/influx/InfluxSinkTask.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2023 Lenses.io Ltd
+ * Copyright 2017-2024 Lenses.io Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-connect-influxdb/src/main/scala/io/lenses/streamreactor/connect/influx/NanoClock.scala
+++ b/kafka-connect-influxdb/src/main/scala/io/lenses/streamreactor/connect/influx/NanoClock.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2023 Lenses.io Ltd
+ * Copyright 2017-2024 Lenses.io Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-connect-influxdb/src/main/scala/io/lenses/streamreactor/connect/influx/ValidateStringParameterFn.scala
+++ b/kafka-connect-influxdb/src/main/scala/io/lenses/streamreactor/connect/influx/ValidateStringParameterFn.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2023 Lenses.io Ltd
+ * Copyright 2017-2024 Lenses.io Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-connect-influxdb/src/main/scala/io/lenses/streamreactor/connect/influx/config/InfluxConfig.scala
+++ b/kafka-connect-influxdb/src/main/scala/io/lenses/streamreactor/connect/influx/config/InfluxConfig.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2023 Lenses.io Ltd
+ * Copyright 2017-2024 Lenses.io Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-connect-influxdb/src/main/scala/io/lenses/streamreactor/connect/influx/config/InfluxConfigConstants.scala
+++ b/kafka-connect-influxdb/src/main/scala/io/lenses/streamreactor/connect/influx/config/InfluxConfigConstants.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2023 Lenses.io Ltd
+ * Copyright 2017-2024 Lenses.io Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-connect-influxdb/src/main/scala/io/lenses/streamreactor/connect/influx/config/InfluxSettings.scala
+++ b/kafka-connect-influxdb/src/main/scala/io/lenses/streamreactor/connect/influx/config/InfluxSettings.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2023 Lenses.io Ltd
+ * Copyright 2017-2024 Lenses.io Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-connect-influxdb/src/main/scala/io/lenses/streamreactor/connect/influx/converters/InfluxPoint.scala
+++ b/kafka-connect-influxdb/src/main/scala/io/lenses/streamreactor/connect/influx/converters/InfluxPoint.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2023 Lenses.io Ltd
+ * Copyright 2017-2024 Lenses.io Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-connect-influxdb/src/main/scala/io/lenses/streamreactor/connect/influx/converters/SinkRecordParser.scala
+++ b/kafka-connect-influxdb/src/main/scala/io/lenses/streamreactor/connect/influx/converters/SinkRecordParser.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2023 Lenses.io Ltd
+ * Copyright 2017-2024 Lenses.io Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-connect-influxdb/src/main/scala/io/lenses/streamreactor/connect/influx/helpers/Util.scala
+++ b/kafka-connect-influxdb/src/main/scala/io/lenses/streamreactor/connect/influx/helpers/Util.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2023 Lenses.io Ltd
+ * Copyright 2017-2024 Lenses.io Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-connect-influxdb/src/main/scala/io/lenses/streamreactor/connect/influx/writers/InfluxBatchPointsBuilder.scala
+++ b/kafka-connect-influxdb/src/main/scala/io/lenses/streamreactor/connect/influx/writers/InfluxBatchPointsBuilder.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2023 Lenses.io Ltd
+ * Copyright 2017-2024 Lenses.io Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-connect-influxdb/src/main/scala/io/lenses/streamreactor/connect/influx/writers/InfluxDbWriter.scala
+++ b/kafka-connect-influxdb/src/main/scala/io/lenses/streamreactor/connect/influx/writers/InfluxDbWriter.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2023 Lenses.io Ltd
+ * Copyright 2017-2024 Lenses.io Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-connect-influxdb/src/main/scala/io/lenses/streamreactor/connect/influx/writers/ValuesExtractor.scala
+++ b/kafka-connect-influxdb/src/main/scala/io/lenses/streamreactor/connect/influx/writers/ValuesExtractor.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2023 Lenses.io Ltd
+ * Copyright 2017-2024 Lenses.io Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-connect-influxdb/src/main/scala/io/lenses/streamreactor/connect/influx/writers/WriterFactoryFn.scala
+++ b/kafka-connect-influxdb/src/main/scala/io/lenses/streamreactor/connect/influx/writers/WriterFactoryFn.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2023 Lenses.io Ltd
+ * Copyright 2017-2024 Lenses.io Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-connect-influxdb/src/test/scala/io/lenses/streamreactor/connect/influx/InfluxBatchPointsBuilderTest.scala
+++ b/kafka-connect-influxdb/src/test/scala/io/lenses/streamreactor/connect/influx/InfluxBatchPointsBuilderTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2023 Lenses.io Ltd
+ * Copyright 2017-2024 Lenses.io Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-connect-influxdb/src/test/scala/io/lenses/streamreactor/connect/influx/ValuesExtractorJsonTest.scala
+++ b/kafka-connect-influxdb/src/test/scala/io/lenses/streamreactor/connect/influx/ValuesExtractorJsonTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2023 Lenses.io Ltd
+ * Copyright 2017-2024 Lenses.io Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-connect-influxdb/src/test/scala/io/lenses/streamreactor/connect/influx/ValuesExtractorMapTest.scala
+++ b/kafka-connect-influxdb/src/test/scala/io/lenses/streamreactor/connect/influx/ValuesExtractorMapTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2023 Lenses.io Ltd
+ * Copyright 2017-2024 Lenses.io Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-connect-influxdb/src/test/scala/io/lenses/streamreactor/connect/influx/ValuesExtractorStructTest.scala
+++ b/kafka-connect-influxdb/src/test/scala/io/lenses/streamreactor/connect/influx/ValuesExtractorStructTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2023 Lenses.io Ltd
+ * Copyright 2017-2024 Lenses.io Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-connect-influxdb/src/test/scala/io/lenses/streamreactor/connect/influx/config/InfluxSettingsTest.scala
+++ b/kafka-connect-influxdb/src/test/scala/io/lenses/streamreactor/connect/influx/config/InfluxSettingsTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2023 Lenses.io Ltd
+ * Copyright 2017-2024 Lenses.io Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-connect-influxdb/src/test/scala/io/lenses/streamreactor/connect/influx/data/Foo.scala
+++ b/kafka-connect-influxdb/src/test/scala/io/lenses/streamreactor/connect/influx/data/Foo.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2023 Lenses.io Ltd
+ * Copyright 2017-2024 Lenses.io Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-connect-jms/src/main/scala/io/lenses/streamreactor/common/converters/ByteArrayConverter.scala
+++ b/kafka-connect-jms/src/main/scala/io/lenses/streamreactor/common/converters/ByteArrayConverter.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2023 Lenses.io Ltd
+ * Copyright 2017-2024 Lenses.io Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-connect-jms/src/main/scala/io/lenses/streamreactor/connect/jms/JMSSessionProvider.scala
+++ b/kafka-connect-jms/src/main/scala/io/lenses/streamreactor/connect/jms/JMSSessionProvider.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2023 Lenses.io Ltd
+ * Copyright 2017-2024 Lenses.io Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-connect-jms/src/main/scala/io/lenses/streamreactor/connect/jms/config/ConverterConfigWrapper.scala
+++ b/kafka-connect-jms/src/main/scala/io/lenses/streamreactor/connect/jms/config/ConverterConfigWrapper.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2023 Lenses.io Ltd
+ * Copyright 2017-2024 Lenses.io Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-connect-jms/src/main/scala/io/lenses/streamreactor/connect/jms/config/ConverterConfigurator.scala
+++ b/kafka-connect-jms/src/main/scala/io/lenses/streamreactor/connect/jms/config/ConverterConfigurator.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2023 Lenses.io Ltd
+ * Copyright 2017-2024 Lenses.io Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-connect-jms/src/main/scala/io/lenses/streamreactor/connect/jms/config/DestinationType.scala
+++ b/kafka-connect-jms/src/main/scala/io/lenses/streamreactor/connect/jms/config/DestinationType.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2023 Lenses.io Ltd
+ * Copyright 2017-2024 Lenses.io Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-connect-jms/src/main/scala/io/lenses/streamreactor/connect/jms/config/JMSConfig.scala
+++ b/kafka-connect-jms/src/main/scala/io/lenses/streamreactor/connect/jms/config/JMSConfig.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2023 Lenses.io Ltd
+ * Copyright 2017-2024 Lenses.io Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-connect-jms/src/main/scala/io/lenses/streamreactor/connect/jms/config/JMSConfigConstants.scala
+++ b/kafka-connect-jms/src/main/scala/io/lenses/streamreactor/connect/jms/config/JMSConfigConstants.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2023 Lenses.io Ltd
+ * Copyright 2017-2024 Lenses.io Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-connect-jms/src/main/scala/io/lenses/streamreactor/connect/jms/config/JMSSettings.scala
+++ b/kafka-connect-jms/src/main/scala/io/lenses/streamreactor/connect/jms/config/JMSSettings.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2023 Lenses.io Ltd
+ * Copyright 2017-2024 Lenses.io Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-connect-jms/src/main/scala/io/lenses/streamreactor/connect/jms/config/StorageOptions.scala
+++ b/kafka-connect-jms/src/main/scala/io/lenses/streamreactor/connect/jms/config/StorageOptions.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2023 Lenses.io Ltd
+ * Copyright 2017-2024 Lenses.io Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-connect-jms/src/main/scala/io/lenses/streamreactor/connect/jms/converters/ConverterClassLoader.scala
+++ b/kafka-connect-jms/src/main/scala/io/lenses/streamreactor/connect/jms/converters/ConverterClassLoader.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2023 Lenses.io Ltd
+ * Copyright 2017-2024 Lenses.io Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-connect-jms/src/main/scala/io/lenses/streamreactor/connect/jms/converters/ConverterLoaders.scala
+++ b/kafka-connect-jms/src/main/scala/io/lenses/streamreactor/connect/jms/converters/ConverterLoaders.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2023 Lenses.io Ltd
+ * Copyright 2017-2024 Lenses.io Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-connect-jms/src/main/scala/io/lenses/streamreactor/connect/jms/converters/JMSMessageConverter.scala
+++ b/kafka-connect-jms/src/main/scala/io/lenses/streamreactor/connect/jms/converters/JMSMessageConverter.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2023 Lenses.io Ltd
+ * Copyright 2017-2024 Lenses.io Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-connect-jms/src/main/scala/io/lenses/streamreactor/connect/jms/sink/JMSSinkConnector.scala
+++ b/kafka-connect-jms/src/main/scala/io/lenses/streamreactor/connect/jms/sink/JMSSinkConnector.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2023 Lenses.io Ltd
+ * Copyright 2017-2024 Lenses.io Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-connect-jms/src/main/scala/io/lenses/streamreactor/connect/jms/sink/JMSSinkTask.scala
+++ b/kafka-connect-jms/src/main/scala/io/lenses/streamreactor/connect/jms/sink/JMSSinkTask.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2023 Lenses.io Ltd
+ * Copyright 2017-2024 Lenses.io Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-connect-jms/src/main/scala/io/lenses/streamreactor/connect/jms/sink/converters/AvroMessageConverter.scala
+++ b/kafka-connect-jms/src/main/scala/io/lenses/streamreactor/connect/jms/sink/converters/AvroMessageConverter.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2023 Lenses.io Ltd
+ * Copyright 2017-2024 Lenses.io Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-connect-jms/src/main/scala/io/lenses/streamreactor/connect/jms/sink/converters/ByteMessageConverter.scala
+++ b/kafka-connect-jms/src/main/scala/io/lenses/streamreactor/connect/jms/sink/converters/ByteMessageConverter.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2023 Lenses.io Ltd
+ * Copyright 2017-2024 Lenses.io Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-connect-jms/src/main/scala/io/lenses/streamreactor/connect/jms/sink/converters/JMSHeadersConverterWrapper.scala
+++ b/kafka-connect-jms/src/main/scala/io/lenses/streamreactor/connect/jms/sink/converters/JMSHeadersConverterWrapper.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2023 Lenses.io Ltd
+ * Copyright 2017-2024 Lenses.io Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-connect-jms/src/main/scala/io/lenses/streamreactor/connect/jms/sink/converters/JMSMessageConverterFn.scala
+++ b/kafka-connect-jms/src/main/scala/io/lenses/streamreactor/connect/jms/sink/converters/JMSMessageConverterFn.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2023 Lenses.io Ltd
+ * Copyright 2017-2024 Lenses.io Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-connect-jms/src/main/scala/io/lenses/streamreactor/connect/jms/sink/converters/JMSSinkMessageConverter.scala
+++ b/kafka-connect-jms/src/main/scala/io/lenses/streamreactor/connect/jms/sink/converters/JMSSinkMessageConverter.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2023 Lenses.io Ltd
+ * Copyright 2017-2024 Lenses.io Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-connect-jms/src/main/scala/io/lenses/streamreactor/connect/jms/sink/converters/JsonMessageConverter.scala
+++ b/kafka-connect-jms/src/main/scala/io/lenses/streamreactor/connect/jms/sink/converters/JsonMessageConverter.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2023 Lenses.io Ltd
+ * Copyright 2017-2024 Lenses.io Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-connect-jms/src/main/scala/io/lenses/streamreactor/connect/jms/sink/converters/MapMessageConverter.scala
+++ b/kafka-connect-jms/src/main/scala/io/lenses/streamreactor/connect/jms/sink/converters/MapMessageConverter.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2023 Lenses.io Ltd
+ * Copyright 2017-2024 Lenses.io Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-connect-jms/src/main/scala/io/lenses/streamreactor/connect/jms/sink/converters/ObjectMessageConverter.scala
+++ b/kafka-connect-jms/src/main/scala/io/lenses/streamreactor/connect/jms/sink/converters/ObjectMessageConverter.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2023 Lenses.io Ltd
+ * Copyright 2017-2024 Lenses.io Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-connect-jms/src/main/scala/io/lenses/streamreactor/connect/jms/sink/converters/ProtoConverter.scala
+++ b/kafka-connect-jms/src/main/scala/io/lenses/streamreactor/connect/jms/sink/converters/ProtoConverter.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2023 Lenses.io Ltd
+ * Copyright 2017-2024 Lenses.io Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-connect-jms/src/main/scala/io/lenses/streamreactor/connect/jms/sink/converters/ProtoDynamicConverter.scala
+++ b/kafka-connect-jms/src/main/scala/io/lenses/streamreactor/connect/jms/sink/converters/ProtoDynamicConverter.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2023 Lenses.io Ltd
+ * Copyright 2017-2024 Lenses.io Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-connect-jms/src/main/scala/io/lenses/streamreactor/connect/jms/sink/converters/ProtoMessageConverter.scala
+++ b/kafka-connect-jms/src/main/scala/io/lenses/streamreactor/connect/jms/sink/converters/ProtoMessageConverter.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2023 Lenses.io Ltd
+ * Copyright 2017-2024 Lenses.io Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-connect-jms/src/main/scala/io/lenses/streamreactor/connect/jms/sink/converters/ProtoStoredAsConverter.scala
+++ b/kafka-connect-jms/src/main/scala/io/lenses/streamreactor/connect/jms/sink/converters/ProtoStoredAsConverter.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2023 Lenses.io Ltd
+ * Copyright 2017-2024 Lenses.io Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-connect-jms/src/main/scala/io/lenses/streamreactor/connect/jms/sink/converters/TextMessageConverter.scala
+++ b/kafka-connect-jms/src/main/scala/io/lenses/streamreactor/connect/jms/sink/converters/TextMessageConverter.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2023 Lenses.io Ltd
+ * Copyright 2017-2024 Lenses.io Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-connect-jms/src/main/scala/io/lenses/streamreactor/connect/jms/sink/writers/JMSWriter.scala
+++ b/kafka-connect-jms/src/main/scala/io/lenses/streamreactor/connect/jms/sink/writers/JMSWriter.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2023 Lenses.io Ltd
+ * Copyright 2017-2024 Lenses.io Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-connect-jms/src/main/scala/io/lenses/streamreactor/connect/jms/source/JMSSourceConnector.scala
+++ b/kafka-connect-jms/src/main/scala/io/lenses/streamreactor/connect/jms/source/JMSSourceConnector.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2023 Lenses.io Ltd
+ * Copyright 2017-2024 Lenses.io Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-connect-jms/src/main/scala/io/lenses/streamreactor/connect/jms/source/JMSSourceTask.scala
+++ b/kafka-connect-jms/src/main/scala/io/lenses/streamreactor/connect/jms/source/JMSSourceTask.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2023 Lenses.io Ltd
+ * Copyright 2017-2024 Lenses.io Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-connect-jms/src/main/scala/io/lenses/streamreactor/connect/jms/source/converters/CommonJMSMessageConverter.scala
+++ b/kafka-connect-jms/src/main/scala/io/lenses/streamreactor/connect/jms/source/converters/CommonJMSMessageConverter.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2023 Lenses.io Ltd
+ * Copyright 2017-2024 Lenses.io Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-connect-jms/src/main/scala/io/lenses/streamreactor/connect/jms/source/converters/JMSSourceMessageConverter.scala
+++ b/kafka-connect-jms/src/main/scala/io/lenses/streamreactor/connect/jms/source/converters/JMSSourceMessageConverter.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2023 Lenses.io Ltd
+ * Copyright 2017-2024 Lenses.io Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-connect-jms/src/main/scala/io/lenses/streamreactor/connect/jms/source/converters/JMSStructMessageConverter.scala
+++ b/kafka-connect-jms/src/main/scala/io/lenses/streamreactor/connect/jms/source/converters/JMSStructMessageConverter.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2023 Lenses.io Ltd
+ * Copyright 2017-2024 Lenses.io Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-connect-jms/src/main/scala/io/lenses/streamreactor/connect/jms/source/domain/JMSStructMessage.scala
+++ b/kafka-connect-jms/src/main/scala/io/lenses/streamreactor/connect/jms/source/domain/JMSStructMessage.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2023 Lenses.io Ltd
+ * Copyright 2017-2024 Lenses.io Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-connect-jms/src/main/scala/io/lenses/streamreactor/connect/jms/source/readers/JMSReader.scala
+++ b/kafka-connect-jms/src/main/scala/io/lenses/streamreactor/connect/jms/source/readers/JMSReader.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2023 Lenses.io Ltd
+ * Copyright 2017-2024 Lenses.io Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-connect-jms/src/test/scala/io/lenses/streamreactor/connect/jms/TestBase.scala
+++ b/kafka-connect-jms/src/test/scala/io/lenses/streamreactor/connect/jms/TestBase.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2023 Lenses.io Ltd
+ * Copyright 2017-2024 Lenses.io Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-connect-jms/src/test/scala/io/lenses/streamreactor/connect/jms/config/ConverterConfigWrapperTest.scala
+++ b/kafka-connect-jms/src/test/scala/io/lenses/streamreactor/connect/jms/config/ConverterConfigWrapperTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2023 Lenses.io Ltd
+ * Copyright 2017-2024 Lenses.io Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-connect-jms/src/test/scala/io/lenses/streamreactor/connect/jms/config/JMSSettingsTest.scala
+++ b/kafka-connect-jms/src/test/scala/io/lenses/streamreactor/connect/jms/config/JMSSettingsTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2023 Lenses.io Ltd
+ * Copyright 2017-2024 Lenses.io Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-connect-jms/src/test/scala/io/lenses/streamreactor/connect/jms/sink/JMSSinkConnectorTest.scala
+++ b/kafka-connect-jms/src/test/scala/io/lenses/streamreactor/connect/jms/sink/JMSSinkConnectorTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2023 Lenses.io Ltd
+ * Copyright 2017-2024 Lenses.io Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-connect-jms/src/test/scala/io/lenses/streamreactor/connect/jms/sink/converters/ProtoDynamicConverterTest.scala
+++ b/kafka-connect-jms/src/test/scala/io/lenses/streamreactor/connect/jms/sink/converters/ProtoDynamicConverterTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2023 Lenses.io Ltd
+ * Copyright 2017-2024 Lenses.io Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-connect-jms/src/test/scala/io/lenses/streamreactor/connect/jms/sink/converters/ProtoStoredAsConverterTest.scala
+++ b/kafka-connect-jms/src/test/scala/io/lenses/streamreactor/connect/jms/sink/converters/ProtoStoredAsConverterTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2023 Lenses.io Ltd
+ * Copyright 2017-2024 Lenses.io Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-connect-jms/src/test/scala/io/lenses/streamreactor/connect/jms/source/JMSSourceConnectorTest.scala
+++ b/kafka-connect-jms/src/test/scala/io/lenses/streamreactor/connect/jms/source/JMSSourceConnectorTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2023 Lenses.io Ltd
+ * Copyright 2017-2024 Lenses.io Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-connect-mongodb/src/main/scala/io/lenses/streamreactor/connect/mongodb/config/MongoConfig.scala
+++ b/kafka-connect-mongodb/src/main/scala/io/lenses/streamreactor/connect/mongodb/config/MongoConfig.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2023 Lenses.io Ltd
+ * Copyright 2017-2024 Lenses.io Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-connect-mongodb/src/main/scala/io/lenses/streamreactor/connect/mongodb/config/MongoConfigConstants.scala
+++ b/kafka-connect-mongodb/src/main/scala/io/lenses/streamreactor/connect/mongodb/config/MongoConfigConstants.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2023 Lenses.io Ltd
+ * Copyright 2017-2024 Lenses.io Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-connect-mongodb/src/main/scala/io/lenses/streamreactor/connect/mongodb/config/MongoSettings.scala
+++ b/kafka-connect-mongodb/src/main/scala/io/lenses/streamreactor/connect/mongodb/config/MongoSettings.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2023 Lenses.io Ltd
+ * Copyright 2017-2024 Lenses.io Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-connect-mongodb/src/main/scala/io/lenses/streamreactor/connect/mongodb/converters/SinkRecordConverter.scala
+++ b/kafka-connect-mongodb/src/main/scala/io/lenses/streamreactor/connect/mongodb/converters/SinkRecordConverter.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2023 Lenses.io Ltd
+ * Copyright 2017-2024 Lenses.io Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-connect-mongodb/src/main/scala/io/lenses/streamreactor/connect/mongodb/sink/ConverterUtilProxy.scala
+++ b/kafka-connect-mongodb/src/main/scala/io/lenses/streamreactor/connect/mongodb/sink/ConverterUtilProxy.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2023 Lenses.io Ltd
+ * Copyright 2017-2024 Lenses.io Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-connect-mongodb/src/main/scala/io/lenses/streamreactor/connect/mongodb/sink/KeysExtractor.scala
+++ b/kafka-connect-mongodb/src/main/scala/io/lenses/streamreactor/connect/mongodb/sink/KeysExtractor.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2023 Lenses.io Ltd
+ * Copyright 2017-2024 Lenses.io Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-connect-mongodb/src/main/scala/io/lenses/streamreactor/connect/mongodb/sink/MongoSinkConnector.scala
+++ b/kafka-connect-mongodb/src/main/scala/io/lenses/streamreactor/connect/mongodb/sink/MongoSinkConnector.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2023 Lenses.io Ltd
+ * Copyright 2017-2024 Lenses.io Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-connect-mongodb/src/main/scala/io/lenses/streamreactor/connect/mongodb/sink/MongoSinkTask.scala
+++ b/kafka-connect-mongodb/src/main/scala/io/lenses/streamreactor/connect/mongodb/sink/MongoSinkTask.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2023 Lenses.io Ltd
+ * Copyright 2017-2024 Lenses.io Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-connect-mongodb/src/main/scala/io/lenses/streamreactor/connect/mongodb/sink/MongoWriter.scala
+++ b/kafka-connect-mongodb/src/main/scala/io/lenses/streamreactor/connect/mongodb/sink/MongoWriter.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2023 Lenses.io Ltd
+ * Copyright 2017-2024 Lenses.io Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-connect-mongodb/src/main/scala/io/lenses/streamreactor/connect/mongodb/sink/SinkRecordToDocument.scala
+++ b/kafka-connect-mongodb/src/main/scala/io/lenses/streamreactor/connect/mongodb/sink/SinkRecordToDocument.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2023 Lenses.io Ltd
+ * Copyright 2017-2024 Lenses.io Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-connect-mongodb/src/test/scala/io/lenses/streamreactor/connect/mongodb/SinkRecordToDocumentTest.scala
+++ b/kafka-connect-mongodb/src/test/scala/io/lenses/streamreactor/connect/mongodb/SinkRecordToDocumentTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2023 Lenses.io Ltd
+ * Copyright 2017-2024 Lenses.io Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-connect-mongodb/src/test/scala/io/lenses/streamreactor/connect/mongodb/config/MongoSettingsTest.scala
+++ b/kafka-connect-mongodb/src/test/scala/io/lenses/streamreactor/connect/mongodb/config/MongoSettingsTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2023 Lenses.io Ltd
+ * Copyright 2017-2024 Lenses.io Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-connect-mongodb/src/test/scala/io/lenses/streamreactor/connect/mongodb/converters/SinkRecordConverterTest.scala
+++ b/kafka-connect-mongodb/src/test/scala/io/lenses/streamreactor/connect/mongodb/converters/SinkRecordConverterTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2023 Lenses.io Ltd
+ * Copyright 2017-2024 Lenses.io Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-connect-mongodb/src/test/scala/io/lenses/streamreactor/connect/mongodb/sink/KeysExtractorTest.scala
+++ b/kafka-connect-mongodb/src/test/scala/io/lenses/streamreactor/connect/mongodb/sink/KeysExtractorTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2023 Lenses.io Ltd
+ * Copyright 2017-2024 Lenses.io Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-connect-mongodb/src/test/scala/io/lenses/streamreactor/connect/mongodb/sink/MongoSinkConnectorTest.scala
+++ b/kafka-connect-mongodb/src/test/scala/io/lenses/streamreactor/connect/mongodb/sink/MongoSinkConnectorTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2023 Lenses.io Ltd
+ * Copyright 2017-2024 Lenses.io Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-connect-mqtt/src/main/scala/io/lenses/streamreactor/connect/mqtt/config/MqttConfig.scala
+++ b/kafka-connect-mqtt/src/main/scala/io/lenses/streamreactor/connect/mqtt/config/MqttConfig.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2023 Lenses.io Ltd
+ * Copyright 2017-2024 Lenses.io Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-connect-mqtt/src/main/scala/io/lenses/streamreactor/connect/mqtt/config/MqttConfigConstants.scala
+++ b/kafka-connect-mqtt/src/main/scala/io/lenses/streamreactor/connect/mqtt/config/MqttConfigConstants.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2023 Lenses.io Ltd
+ * Copyright 2017-2024 Lenses.io Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-connect-mqtt/src/main/scala/io/lenses/streamreactor/connect/mqtt/config/MqttSinkSettings.scala
+++ b/kafka-connect-mqtt/src/main/scala/io/lenses/streamreactor/connect/mqtt/config/MqttSinkSettings.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2023 Lenses.io Ltd
+ * Copyright 2017-2024 Lenses.io Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-connect-mqtt/src/main/scala/io/lenses/streamreactor/connect/mqtt/config/MqttSourceSettings.scala
+++ b/kafka-connect-mqtt/src/main/scala/io/lenses/streamreactor/connect/mqtt/config/MqttSourceSettings.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2023 Lenses.io Ltd
+ * Copyright 2017-2024 Lenses.io Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-connect-mqtt/src/main/scala/io/lenses/streamreactor/connect/mqtt/connection/MqttClientConnectionFn.scala
+++ b/kafka-connect-mqtt/src/main/scala/io/lenses/streamreactor/connect/mqtt/connection/MqttClientConnectionFn.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2023 Lenses.io Ltd
+ * Copyright 2017-2024 Lenses.io Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-connect-mqtt/src/main/scala/io/lenses/streamreactor/connect/mqtt/sink/MqttSinkConnector.scala
+++ b/kafka-connect-mqtt/src/main/scala/io/lenses/streamreactor/connect/mqtt/sink/MqttSinkConnector.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2023 Lenses.io Ltd
+ * Copyright 2017-2024 Lenses.io Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-connect-mqtt/src/main/scala/io/lenses/streamreactor/connect/mqtt/sink/MqttSinkTask.scala
+++ b/kafka-connect-mqtt/src/main/scala/io/lenses/streamreactor/connect/mqtt/sink/MqttSinkTask.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2023 Lenses.io Ltd
+ * Copyright 2017-2024 Lenses.io Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-connect-mqtt/src/main/scala/io/lenses/streamreactor/connect/mqtt/sink/MqttWriter.scala
+++ b/kafka-connect-mqtt/src/main/scala/io/lenses/streamreactor/connect/mqtt/sink/MqttWriter.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2023 Lenses.io Ltd
+ * Copyright 2017-2024 Lenses.io Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-connect-mqtt/src/main/scala/io/lenses/streamreactor/connect/mqtt/source/MqttManager.scala
+++ b/kafka-connect-mqtt/src/main/scala/io/lenses/streamreactor/connect/mqtt/source/MqttManager.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2023 Lenses.io Ltd
+ * Copyright 2017-2024 Lenses.io Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-connect-mqtt/src/main/scala/io/lenses/streamreactor/connect/mqtt/source/MqttSSLSocketFactory.scala
+++ b/kafka-connect-mqtt/src/main/scala/io/lenses/streamreactor/connect/mqtt/source/MqttSSLSocketFactory.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2023 Lenses.io Ltd
+ * Copyright 2017-2024 Lenses.io Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-connect-mqtt/src/main/scala/io/lenses/streamreactor/connect/mqtt/source/MqttSourceConnector.scala
+++ b/kafka-connect-mqtt/src/main/scala/io/lenses/streamreactor/connect/mqtt/source/MqttSourceConnector.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2023 Lenses.io Ltd
+ * Copyright 2017-2024 Lenses.io Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-connect-mqtt/src/main/scala/io/lenses/streamreactor/connect/mqtt/source/MqttSourceTask.scala
+++ b/kafka-connect-mqtt/src/main/scala/io/lenses/streamreactor/connect/mqtt/source/MqttSourceTask.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2023 Lenses.io Ltd
+ * Copyright 2017-2024 Lenses.io Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-connect-mqtt/src/test/scala/io/lenses/streamreactor/connect/mqtt/Stype.scala
+++ b/kafka-connect-mqtt/src/test/scala/io/lenses/streamreactor/connect/mqtt/Stype.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2023 Lenses.io Ltd
+ * Copyright 2017-2024 Lenses.io Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-connect-mqtt/src/test/scala/io/lenses/streamreactor/connect/mqtt/config/MqttSourceSettingsTest.scala
+++ b/kafka-connect-mqtt/src/test/scala/io/lenses/streamreactor/connect/mqtt/config/MqttSourceSettingsTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2023 Lenses.io Ltd
+ * Copyright 2017-2024 Lenses.io Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-connect-mqtt/src/test/scala/io/lenses/streamreactor/connect/mqtt/sink/MqttSinkConnectorTest.scala
+++ b/kafka-connect-mqtt/src/test/scala/io/lenses/streamreactor/connect/mqtt/sink/MqttSinkConnectorTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2023 Lenses.io Ltd
+ * Copyright 2017-2024 Lenses.io Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-connect-mqtt/src/test/scala/io/lenses/streamreactor/connect/mqtt/source/MqttSourceConnectorTest.scala
+++ b/kafka-connect-mqtt/src/test/scala/io/lenses/streamreactor/connect/mqtt/source/MqttSourceConnectorTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2023 Lenses.io Ltd
+ * Copyright 2017-2024 Lenses.io Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-connect-query-language/src/main/java/io/lenses/kcql/Bucketing.java
+++ b/kafka-connect-query-language/src/main/java/io/lenses/kcql/Bucketing.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2023 Lenses.io Ltd
+ * Copyright 2017-2024 Lenses.io Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-connect-query-language/src/main/java/io/lenses/kcql/CompressionType.java
+++ b/kafka-connect-query-language/src/main/java/io/lenses/kcql/CompressionType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2023 Lenses.io Ltd
+ * Copyright 2017-2024 Lenses.io Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-connect-query-language/src/main/java/io/lenses/kcql/EnumsHelper.java
+++ b/kafka-connect-query-language/src/main/java/io/lenses/kcql/EnumsHelper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2023 Lenses.io Ltd
+ * Copyright 2017-2024 Lenses.io Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-connect-query-language/src/main/java/io/lenses/kcql/Field.java
+++ b/kafka-connect-query-language/src/main/java/io/lenses/kcql/Field.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2023 Lenses.io Ltd
+ * Copyright 2017-2024 Lenses.io Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-connect-query-language/src/main/java/io/lenses/kcql/FieldType.java
+++ b/kafka-connect-query-language/src/main/java/io/lenses/kcql/FieldType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2023 Lenses.io Ltd
+ * Copyright 2017-2024 Lenses.io Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-connect-query-language/src/main/java/io/lenses/kcql/FormatType.java
+++ b/kafka-connect-query-language/src/main/java/io/lenses/kcql/FormatType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2023 Lenses.io Ltd
+ * Copyright 2017-2024 Lenses.io Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-connect-query-language/src/main/java/io/lenses/kcql/Kcql.java
+++ b/kafka-connect-query-language/src/main/java/io/lenses/kcql/Kcql.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2023 Lenses.io Ltd
+ * Copyright 2017-2024 Lenses.io Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-connect-query-language/src/main/java/io/lenses/kcql/KcqlException.java
+++ b/kafka-connect-query-language/src/main/java/io/lenses/kcql/KcqlException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2023 Lenses.io Ltd
+ * Copyright 2017-2024 Lenses.io Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-connect-query-language/src/main/java/io/lenses/kcql/PartitionOffset.java
+++ b/kafka-connect-query-language/src/main/java/io/lenses/kcql/PartitionOffset.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2023 Lenses.io Ltd
+ * Copyright 2017-2024 Lenses.io Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-connect-query-language/src/main/java/io/lenses/kcql/PartitioningStrategy.java
+++ b/kafka-connect-query-language/src/main/java/io/lenses/kcql/PartitioningStrategy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2023 Lenses.io Ltd
+ * Copyright 2017-2024 Lenses.io Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-connect-query-language/src/main/java/io/lenses/kcql/SchemaEvolution.java
+++ b/kafka-connect-query-language/src/main/java/io/lenses/kcql/SchemaEvolution.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2023 Lenses.io Ltd
+ * Copyright 2017-2024 Lenses.io Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-connect-query-language/src/main/java/io/lenses/kcql/Tag.java
+++ b/kafka-connect-query-language/src/main/java/io/lenses/kcql/Tag.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2023 Lenses.io Ltd
+ * Copyright 2017-2024 Lenses.io Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-connect-query-language/src/main/java/io/lenses/kcql/WriteModeEnum.java
+++ b/kafka-connect-query-language/src/main/java/io/lenses/kcql/WriteModeEnum.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2023 Lenses.io Ltd
+ * Copyright 2017-2024 Lenses.io Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-connect-query-language/src/test/java/io/lenses/kcql/KcqlNestedFieldTest.scala
+++ b/kafka-connect-query-language/src/test/java/io/lenses/kcql/KcqlNestedFieldTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2023 Lenses.io Ltd
+ * Copyright 2017-2024 Lenses.io Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-connect-query-language/src/test/java/io/lenses/kcql/KcqlPropertiesTest.scala
+++ b/kafka-connect-query-language/src/test/java/io/lenses/kcql/KcqlPropertiesTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2023 Lenses.io Ltd
+ * Copyright 2017-2024 Lenses.io Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-connect-query-language/src/test/java/io/lenses/kcql/KcqlSelectOnlyTest.scala
+++ b/kafka-connect-query-language/src/test/java/io/lenses/kcql/KcqlSelectOnlyTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2023 Lenses.io Ltd
+ * Copyright 2017-2024 Lenses.io Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-connect-query-language/src/test/java/io/lenses/kcql/KcqlTest.scala
+++ b/kafka-connect-query-language/src/test/java/io/lenses/kcql/KcqlTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2023 Lenses.io Ltd
+ * Copyright 2017-2024 Lenses.io Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-connect-redis/src/main/scala/io/lenses/streamreactor/connect/redis/sink/JedisClientBuilder.scala
+++ b/kafka-connect-redis/src/main/scala/io/lenses/streamreactor/connect/redis/sink/JedisClientBuilder.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2023 Lenses.io Ltd
+ * Copyright 2017-2024 Lenses.io Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-connect-redis/src/main/scala/io/lenses/streamreactor/connect/redis/sink/RedisSinkConnector.scala
+++ b/kafka-connect-redis/src/main/scala/io/lenses/streamreactor/connect/redis/sink/RedisSinkConnector.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2023 Lenses.io Ltd
+ * Copyright 2017-2024 Lenses.io Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-connect-redis/src/main/scala/io/lenses/streamreactor/connect/redis/sink/RedisSinkTask.scala
+++ b/kafka-connect-redis/src/main/scala/io/lenses/streamreactor/connect/redis/sink/RedisSinkTask.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2023 Lenses.io Ltd
+ * Copyright 2017-2024 Lenses.io Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-connect-redis/src/main/scala/io/lenses/streamreactor/connect/redis/sink/config/RedisConfig.scala
+++ b/kafka-connect-redis/src/main/scala/io/lenses/streamreactor/connect/redis/sink/config/RedisConfig.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2023 Lenses.io Ltd
+ * Copyright 2017-2024 Lenses.io Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-connect-redis/src/main/scala/io/lenses/streamreactor/connect/redis/sink/config/RedisConfigConstants.scala
+++ b/kafka-connect-redis/src/main/scala/io/lenses/streamreactor/connect/redis/sink/config/RedisConfigConstants.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2023 Lenses.io Ltd
+ * Copyright 2017-2024 Lenses.io Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-connect-redis/src/main/scala/io/lenses/streamreactor/connect/redis/sink/config/RedisSinkSettings.scala
+++ b/kafka-connect-redis/src/main/scala/io/lenses/streamreactor/connect/redis/sink/config/RedisSinkSettings.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2023 Lenses.io Ltd
+ * Copyright 2017-2024 Lenses.io Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-connect-redis/src/main/scala/io/lenses/streamreactor/connect/redis/sink/writer/GeoAddSupport.scala
+++ b/kafka-connect-redis/src/main/scala/io/lenses/streamreactor/connect/redis/sink/writer/GeoAddSupport.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2023 Lenses.io Ltd
+ * Copyright 2017-2024 Lenses.io Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-connect-redis/src/main/scala/io/lenses/streamreactor/connect/redis/sink/writer/PubSubSupport.scala
+++ b/kafka-connect-redis/src/main/scala/io/lenses/streamreactor/connect/redis/sink/writer/PubSubSupport.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2023 Lenses.io Ltd
+ * Copyright 2017-2024 Lenses.io Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-connect-redis/src/main/scala/io/lenses/streamreactor/connect/redis/sink/writer/RedisCache.scala
+++ b/kafka-connect-redis/src/main/scala/io/lenses/streamreactor/connect/redis/sink/writer/RedisCache.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2023 Lenses.io Ltd
+ * Copyright 2017-2024 Lenses.io Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-connect-redis/src/main/scala/io/lenses/streamreactor/connect/redis/sink/writer/RedisGeoAdd.scala
+++ b/kafka-connect-redis/src/main/scala/io/lenses/streamreactor/connect/redis/sink/writer/RedisGeoAdd.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2023 Lenses.io Ltd
+ * Copyright 2017-2024 Lenses.io Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-connect-redis/src/main/scala/io/lenses/streamreactor/connect/redis/sink/writer/RedisInsertSortedSet.scala
+++ b/kafka-connect-redis/src/main/scala/io/lenses/streamreactor/connect/redis/sink/writer/RedisInsertSortedSet.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2023 Lenses.io Ltd
+ * Copyright 2017-2024 Lenses.io Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-connect-redis/src/main/scala/io/lenses/streamreactor/connect/redis/sink/writer/RedisMultipleSortedSets.scala
+++ b/kafka-connect-redis/src/main/scala/io/lenses/streamreactor/connect/redis/sink/writer/RedisMultipleSortedSets.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2023 Lenses.io Ltd
+ * Copyright 2017-2024 Lenses.io Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-connect-redis/src/main/scala/io/lenses/streamreactor/connect/redis/sink/writer/RedisPubSub.scala
+++ b/kafka-connect-redis/src/main/scala/io/lenses/streamreactor/connect/redis/sink/writer/RedisPubSub.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2023 Lenses.io Ltd
+ * Copyright 2017-2024 Lenses.io Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-connect-redis/src/main/scala/io/lenses/streamreactor/connect/redis/sink/writer/RedisStreams.scala
+++ b/kafka-connect-redis/src/main/scala/io/lenses/streamreactor/connect/redis/sink/writer/RedisStreams.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2023 Lenses.io Ltd
+ * Copyright 2017-2024 Lenses.io Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-connect-redis/src/main/scala/io/lenses/streamreactor/connect/redis/sink/writer/RedisWriter.scala
+++ b/kafka-connect-redis/src/main/scala/io/lenses/streamreactor/connect/redis/sink/writer/RedisWriter.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2023 Lenses.io Ltd
+ * Copyright 2017-2024 Lenses.io Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-connect-redis/src/main/scala/io/lenses/streamreactor/connect/redis/sink/writer/SortedSetSupport.scala
+++ b/kafka-connect-redis/src/main/scala/io/lenses/streamreactor/connect/redis/sink/writer/SortedSetSupport.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2023 Lenses.io Ltd
+ * Copyright 2017-2024 Lenses.io Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-connect-redis/src/test/scala/io/lenses/streamreactor/connect/redis/sink/RedisSinkTaskTest.scala
+++ b/kafka-connect-redis/src/test/scala/io/lenses/streamreactor/connect/redis/sink/RedisSinkTaskTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2023 Lenses.io Ltd
+ * Copyright 2017-2024 Lenses.io Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-connect-redis/src/test/scala/io/lenses/streamreactor/connect/redis/sink/config/ConfigGeoAddTest.scala
+++ b/kafka-connect-redis/src/test/scala/io/lenses/streamreactor/connect/redis/sink/config/ConfigGeoAddTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2023 Lenses.io Ltd
+ * Copyright 2017-2024 Lenses.io Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-connect-redis/src/test/scala/io/lenses/streamreactor/connect/redis/sink/config/ConfigInsertSortedSetTest.scala
+++ b/kafka-connect-redis/src/test/scala/io/lenses/streamreactor/connect/redis/sink/config/ConfigInsertSortedSetTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2023 Lenses.io Ltd
+ * Copyright 2017-2024 Lenses.io Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-connect-redis/src/test/scala/io/lenses/streamreactor/connect/redis/sink/config/ConfigMultipleSortedSetsTest.scala
+++ b/kafka-connect-redis/src/test/scala/io/lenses/streamreactor/connect/redis/sink/config/ConfigMultipleSortedSetsTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2023 Lenses.io Ltd
+ * Copyright 2017-2024 Lenses.io Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-connect-redis/src/test/scala/io/lenses/streamreactor/connect/redis/sink/config/RedisConfigTest.scala
+++ b/kafka-connect-redis/src/test/scala/io/lenses/streamreactor/connect/redis/sink/config/RedisConfigTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2023 Lenses.io Ltd
+ * Copyright 2017-2024 Lenses.io Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-connect-redis/src/test/scala/io/lenses/streamreactor/connect/redis/sink/config/RedisSinkSettingsTest.scala
+++ b/kafka-connect-redis/src/test/scala/io/lenses/streamreactor/connect/redis/sink/config/RedisSinkSettingsTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2023 Lenses.io Ltd
+ * Copyright 2017-2024 Lenses.io Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-connect-redis/src/test/scala/io/lenses/streamreactor/connect/redis/sink/support/RedisMockSupport.scala
+++ b/kafka-connect-redis/src/test/scala/io/lenses/streamreactor/connect/redis/sink/support/RedisMockSupport.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2023 Lenses.io Ltd
+ * Copyright 2017-2024 Lenses.io Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-connect-redis/src/test/scala/io/lenses/streamreactor/connect/redis/sink/writer/RedisStreamTest.scala
+++ b/kafka-connect-redis/src/test/scala/io/lenses/streamreactor/connect/redis/sink/writer/RedisStreamTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2023 Lenses.io Ltd
+ * Copyright 2017-2024 Lenses.io Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -38,7 +38,6 @@ object Dependencies {
     "typesafe" at "https://repo.typesafe.com/typesafe/releases/",
     "cloudera" at "https://repository.cloudera.com/artifactory/cloudera-repos/",
     "jitpack" at "https://jitpack.io",
-    "twitter" at "https://maven.twttr.com/",
   )
 
   object Versions {
@@ -95,7 +94,6 @@ object Dependencies {
 
     val xzVersion  = "1.9"
     val lz4Version = "1.8.0"
-    val lzoVersion = "0.4.19"
 
     val californiumVersion  = "3.5.0"
     val bouncyCastleVersion = "1.70"
@@ -363,7 +361,6 @@ object Dependencies {
 
   lazy val xz  = "org.tukaani"               % "xz"         % xzVersion
   lazy val lz4 = "org.lz4"                   % "lz4-java"   % lz4Version
-  lazy val lzo = "com.hadoop.gplcompression" % "hadoop-lzo" % lzoVersion
 
   def hiveExcludes(moduleID: ModuleID): ModuleID =
     moduleID
@@ -469,7 +466,7 @@ trait Dependencies {
     stsSdk,
   )
 
-  val compressionCodecDeps: Seq[ModuleID] = Seq(xz, lzo, lz4)
+  val compressionCodecDeps: Seq[ModuleID] = Seq(xz, lz4)
 
   val kafkaConnectAzureDatalakeDeps: Seq[ModuleID] = Seq(
     azureDataLakeSdk,

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -359,8 +359,8 @@ object Dependencies {
   lazy val jedis = "redis.clients"        % "jedis" % jedisVersion
   lazy val gson  = "com.google.code.gson" % "gson"  % gsonVersion
 
-  lazy val xz  = "org.tukaani"               % "xz"         % xzVersion
-  lazy val lz4 = "org.lz4"                   % "lz4-java"   % lz4Version
+  lazy val xz  = "org.tukaani" % "xz"       % xzVersion
+  lazy val lz4 = "org.lz4"     % "lz4-java" % lz4Version
 
   def hiveExcludes(moduleID: ModuleID): ModuleID =
     moduleID


### PR DESCRIPTION
Remove lzo test case as it is reliant on twitter's infrastructure, which is unreliable.