### PR TITLE
Byte Array Support

### DIFF
--- a/kafka-connect-aws-s3/src/it/scala/io/lenses/streamreactor/connect/aws/s3/source/S3SourceAvroWithValueAsArrayEnvelopeTest.scala
+++ b/kafka-connect-aws-s3/src/it/scala/io/lenses/streamreactor/connect/aws/s3/source/S3SourceAvroWithValueAsArrayEnvelopeTest.scala
@@ -1,0 +1,153 @@
+package io.lenses.streamreactor.connect.aws.s3.source
+
+import cats.implicits.catsSyntaxEitherId
+import io.lenses.streamreactor.connect.aws.s3.source.config.SourcePartitionSearcherSettingsKeys
+import io.lenses.streamreactor.connect.aws.s3.storage.AwsS3StorageInterface
+import io.lenses.streamreactor.connect.aws.s3.utils.S3ProxyContainerTest
+import io.lenses.streamreactor.connect.cloud.common.model.UploadableFile
+import org.apache.avro.SchemaBuilder
+import org.apache.avro.file.CodecFactory
+import org.apache.avro.file.DataFileWriter
+import org.apache.avro.generic.GenericDatumWriter
+import org.apache.kafka.connect.data.Schema
+import org.apache.kafka.connect.source.SourceRecord
+import org.scalatest.EitherValues
+import org.scalatest.concurrent.Eventually.eventually
+import org.scalatest.flatspec.AnyFlatSpecLike
+import org.scalatest.matchers.should.Matchers
+
+import java.nio.ByteBuffer
+import java.time.Instant
+import scala.jdk.CollectionConverters.IterableHasAsScala
+import scala.jdk.CollectionConverters.ListHasAsScala
+import scala.jdk.CollectionConverters.MapHasAsJava
+import scala.jdk.CollectionConverters.MapHasAsScala
+
+class S3SourceAvroWithValueAsArrayEnvelopeTest
+    extends S3ProxyContainerTest
+    with AnyFlatSpecLike
+    with Matchers
+    with EitherValues
+    with SourcePartitionSearcherSettingsKeys {
+
+  def DefaultProps: Map[String, String] = defaultProps + (
+    SOURCE_PARTITION_SEARCH_INTERVAL_MILLIS -> "1000",
+  )
+
+  val MyPrefix  = "backups"
+  val TopicName = "myTopic"
+
+  // An array of bytes schema
+  private val ArraySchema = SchemaBuilder.builder().bytesType()
+
+  private val MetadataSchema = SchemaBuilder.record("metadata").fields()
+    .optionalLong("timestamp")
+    .requiredString("topic")
+    .requiredInt("partition")
+    .requiredLong("offset")
+    .endRecord()
+
+  private val HeadersSchema = SchemaBuilder.record("headers").fields()
+    .requiredString("header1")
+    .requiredLong("header2")
+    .endRecord()
+
+  private val EnvelopeSchema = SchemaBuilder.record("envelope").fields()
+    .name("key").`type`(ArraySchema).noDefault()
+    .name("value").`type`(ArraySchema).noDefault()
+    .name("headers").`type`(HeadersSchema).noDefault()
+    .name("metadata").`type`(MetadataSchema).noDefault()
+    .endRecord()
+
+  override def cleanUp(): Unit = ()
+
+  override def setUpTestData(storageInterface: AwsS3StorageInterface): Either[Throwable, Unit] = {
+
+    val envelope = new org.apache.avro.generic.GenericData.Record(EnvelopeSchema)
+    val key      = ByteBuffer.wrap(Array[Byte](1, 2, 3, 4, 5, 6, 7, 8, 9))
+    envelope.put("key", key)
+    val value = ByteBuffer.wrap(Array[Byte](1, 2, 3, 4, 5, 6, 7, 8, 9))
+    envelope.put("value", value)
+
+    val headers = new org.apache.avro.generic.GenericData.Record(HeadersSchema)
+    headers.put("header1", "value1")
+    headers.put("header2", 123456789L)
+    envelope.put("headers", headers)
+
+    val metadata = new org.apache.avro.generic.GenericData.Record(MetadataSchema)
+    metadata.put("timestamp", 1234567890L)
+    metadata.put("topic", TopicName)
+    metadata.put("partition", 3)
+    metadata.put("offset", 0L)
+    envelope.put("metadata", metadata)
+
+    val file = new java.io.File("00001.avro")
+    try {
+      val outputStream = new java.io.BufferedOutputStream(new java.io.FileOutputStream(file))
+      val writer: GenericDatumWriter[Any] = new GenericDatumWriter[Any](EnvelopeSchema)
+      val fileWriter: DataFileWriter[Any] =
+        new DataFileWriter[Any](writer).setCodec(CodecFactory.snappyCodec()).create(EnvelopeSchema, outputStream)
+
+      fileWriter.append(envelope)
+      fileWriter.flush()
+      fileWriter.close()
+
+      storageInterface.uploadFile(UploadableFile(file), BucketName, s"$MyPrefix/avro/0")
+      ().asRight
+    } finally {
+      file.delete()
+      ()
+    }
+
+  }
+
+  "task" should "extract from avro files containing the envelope" in {
+
+    val task = new S3SourceTask()
+
+    val props = (defaultProps ++ Map(
+      "connect.s3.kcql"                            -> s"insert into $TopicName select * from $BucketName:$MyPrefix/avro STOREAS `AVRO` LIMIT 1000 PROPERTIES ('store.envelope'=true)",
+      "connect.s3.partition.search.recurse.levels" -> "0",
+      "connect.partition.search.continuous"        -> "false",
+    )).asJava
+
+    task.start(props)
+
+    var sourceRecords: Seq[SourceRecord] = List.empty
+    try {
+      eventually {
+
+        do {
+          sourceRecords = sourceRecords ++ task.poll().asScala
+        } while (sourceRecords.size != 1)
+        task.poll() should be(empty)
+
+      }
+    } finally {
+      task.stop()
+    }
+
+    //assert the record matches the envelope
+    val sourceRecord = sourceRecords.head
+    sourceRecord.keySchema().`type`() should be(Schema.Type.BYTES)
+    sourceRecord.key().asInstanceOf[Array[Byte]] should be(Array[Byte](1, 2, 3, 4, 5, 6, 7, 8, 9))
+
+    sourceRecord.valueSchema().`type`() should be(Schema.Type.BYTES)
+    val value: Array[Byte] = sourceRecord.value().asInstanceOf[Array[Byte]]
+    value should be(Array[Byte](1, 2, 3, 4, 5, 6, 7, 8, 9))
+
+    sourceRecord.headers().asScala.map(h => h.key() -> h.value()).toMap should be(Map("header1" -> "value1",
+                                                                                      "header2" -> 123456789L,
+    ))
+
+    sourceRecord.sourcePartition().asScala shouldBe Map("container" -> BucketName, "prefix" -> s"$MyPrefix/avro/")
+    val sourceOffsetMap = sourceRecord.sourceOffset().asScala
+    sourceOffsetMap("path") shouldBe s"$MyPrefix/avro/0"
+    sourceOffsetMap("line") shouldBe "0"
+    sourceOffsetMap("ts").toString.toLong < Instant.now().toEpochMilli shouldBe true
+
+    sourceRecord.topic() shouldBe TopicName
+    sourceRecord.kafkaPartition() shouldBe 3
+    sourceRecord.timestamp() shouldBe 1234567890L
+  }
+}

--- a/kafka-connect-aws-s3/src/it/scala/io/lenses/streamreactor/connect/aws/s3/source/S3SourceAvroWithValueAsOptionalArrayEnvelopeTest.scala
+++ b/kafka-connect-aws-s3/src/it/scala/io/lenses/streamreactor/connect/aws/s3/source/S3SourceAvroWithValueAsOptionalArrayEnvelopeTest.scala
@@ -5,6 +5,7 @@ import io.lenses.streamreactor.connect.aws.s3.source.config.SourcePartitionSearc
 import io.lenses.streamreactor.connect.aws.s3.storage.AwsS3StorageInterface
 import io.lenses.streamreactor.connect.aws.s3.utils.S3ProxyContainerTest
 import io.lenses.streamreactor.connect.cloud.common.model.UploadableFile
+import org.apache.avro
 import org.apache.avro.SchemaBuilder
 import org.apache.avro.file.CodecFactory
 import org.apache.avro.file.DataFileWriter
@@ -16,14 +17,13 @@ import org.scalatest.concurrent.Eventually.eventually
 import org.scalatest.flatspec.AnyFlatSpecLike
 import org.scalatest.matchers.should.Matchers
 
-import java.nio.ByteBuffer
 import java.time.Instant
 import scala.jdk.CollectionConverters.IterableHasAsScala
 import scala.jdk.CollectionConverters.ListHasAsScala
 import scala.jdk.CollectionConverters.MapHasAsJava
 import scala.jdk.CollectionConverters.MapHasAsScala
 
-class S3SourceAvroWithValueAsArrayEnvelopeTest
+class S3SourceAvroWithValueAsOptionalArrayEnvelopeTest
     extends S3ProxyContainerTest
     with AnyFlatSpecLike
     with Matchers
@@ -37,7 +37,8 @@ class S3SourceAvroWithValueAsArrayEnvelopeTest
   val MyPrefix  = "backups"
   val TopicName = "myTopic"
 
-  private val ArraySchema = SchemaBuilder.builder().bytesType()
+  //optional bytes avro
+  private val OptionalArraySchema: avro.Schema = SchemaBuilder.nullable().bytesType()
 
   private val MetadataSchema = SchemaBuilder.record("metadata").fields()
     .optionalLong("timestamp")
@@ -52,8 +53,8 @@ class S3SourceAvroWithValueAsArrayEnvelopeTest
     .endRecord()
 
   private val EnvelopeSchema = SchemaBuilder.record("envelope").fields()
-    .name("key").`type`(ArraySchema).noDefault()
-    .name("value").`type`(ArraySchema).noDefault()
+    .name("key").`type`(OptionalArraySchema).noDefault()
+    .name("value").`type`(OptionalArraySchema).noDefault()
     .name("headers").`type`(HeadersSchema).noDefault()
     .name("metadata").`type`(MetadataSchema).noDefault()
     .endRecord()
@@ -63,10 +64,8 @@ class S3SourceAvroWithValueAsArrayEnvelopeTest
   override def setUpTestData(storageInterface: AwsS3StorageInterface): Either[Throwable, Unit] = {
 
     val envelope = new org.apache.avro.generic.GenericData.Record(EnvelopeSchema)
-    val key      = ByteBuffer.wrap(Array[Byte](1, 2, 3, 4, 5, 6, 7, 8, 9))
-    envelope.put("key", key)
-    val value = ByteBuffer.wrap(Array[Byte](1, 2, 3, 4, 5, 6, 7, 8, 9))
-    envelope.put("value", value)
+    envelope.put("key", null)
+    envelope.put("value", null)
 
     val headers = new org.apache.avro.generic.GenericData.Record(HeadersSchema)
     headers.put("header1", "value1")
@@ -129,11 +128,137 @@ class S3SourceAvroWithValueAsArrayEnvelopeTest
     //assert the record matches the envelope
     val sourceRecord = sourceRecords.head
     sourceRecord.keySchema().`type`() should be(Schema.Type.BYTES)
-    sourceRecord.key().asInstanceOf[Array[Byte]] should be(Array[Byte](1, 2, 3, 4, 5, 6, 7, 8, 9))
+    sourceRecord.key() shouldBe null
 
     sourceRecord.valueSchema().`type`() should be(Schema.Type.BYTES)
     val value: Array[Byte] = sourceRecord.value().asInstanceOf[Array[Byte]]
-    value should be(Array[Byte](1, 2, 3, 4, 5, 6, 7, 8, 9))
+    value shouldBe null
+
+    sourceRecord.headers().asScala.map(h => h.key() -> h.value()).toMap should be(Map("header1" -> "value1",
+                                                                                      "header2" -> 123456789L,
+    ))
+
+    sourceRecord.sourcePartition().asScala shouldBe Map("container" -> BucketName, "prefix" -> s"$MyPrefix/avro/")
+    val sourceOffsetMap = sourceRecord.sourceOffset().asScala
+    sourceOffsetMap("path") shouldBe s"$MyPrefix/avro/0"
+    sourceOffsetMap("line") shouldBe "0"
+    sourceOffsetMap("ts").toString.toLong < Instant.now().toEpochMilli shouldBe true
+
+    sourceRecord.topic() shouldBe TopicName
+    sourceRecord.kafkaPartition() shouldBe 3
+    sourceRecord.timestamp() shouldBe 1234567890L
+  }
+}
+
+class S3SourceAvroWithValueAsOptionalArrayMixValuesEnvelopeTest
+    extends S3ProxyContainerTest
+    with AnyFlatSpecLike
+    with Matchers
+    with EitherValues
+    with SourcePartitionSearcherSettingsKeys {
+
+  def DefaultProps: Map[String, String] = defaultProps + (
+    SOURCE_PARTITION_SEARCH_INTERVAL_MILLIS -> "1000",
+  )
+
+  val MyPrefix  = "backups"
+  val TopicName = "myTopic"
+
+  //optional bytes avro
+  private val OptionalArraySchema: avro.Schema = SchemaBuilder.nullable().bytesType()
+
+  private val MetadataSchema = SchemaBuilder.record("metadata").fields()
+    .optionalLong("timestamp")
+    .requiredString("topic")
+    .requiredInt("partition")
+    .requiredLong("offset")
+    .endRecord()
+
+  private val HeadersSchema = SchemaBuilder.record("headers").fields()
+    .requiredString("header1")
+    .requiredLong("header2")
+    .endRecord()
+
+  private val EnvelopeSchema = SchemaBuilder.record("envelope").fields()
+    .name("key").`type`(OptionalArraySchema).noDefault()
+    .name("value").`type`(OptionalArraySchema).noDefault()
+    .name("headers").`type`(HeadersSchema).noDefault()
+    .name("metadata").`type`(MetadataSchema).noDefault()
+    .endRecord()
+
+  override def cleanUp(): Unit = ()
+
+  override def setUpTestData(storageInterface: AwsS3StorageInterface): Either[Throwable, Unit] = {
+
+    val envelope = new org.apache.avro.generic.GenericData.Record(EnvelopeSchema)
+    envelope.put("key", null)
+    val buffer = java.nio.ByteBuffer.wrap("value".getBytes())
+    envelope.put("value", buffer)
+
+    val headers = new org.apache.avro.generic.GenericData.Record(HeadersSchema)
+    headers.put("header1", "value1")
+    headers.put("header2", 123456789L)
+    envelope.put("headers", headers)
+
+    val metadata = new org.apache.avro.generic.GenericData.Record(MetadataSchema)
+    metadata.put("timestamp", 1234567890L)
+    metadata.put("topic", TopicName)
+    metadata.put("partition", 3)
+    metadata.put("offset", 0L)
+    envelope.put("metadata", metadata)
+
+    val file = new java.io.File("00001.avro")
+    try {
+      val outputStream = new java.io.BufferedOutputStream(new java.io.FileOutputStream(file))
+      val writer: GenericDatumWriter[Any] = new GenericDatumWriter[Any](EnvelopeSchema)
+      val fileWriter: DataFileWriter[Any] =
+        new DataFileWriter[Any](writer).setCodec(CodecFactory.snappyCodec()).create(EnvelopeSchema, outputStream)
+
+      fileWriter.append(envelope)
+      fileWriter.flush()
+      fileWriter.close()
+
+      storageInterface.uploadFile(UploadableFile(file), BucketName, s"$MyPrefix/avro/0")
+      ().asRight
+    } finally {
+      file.delete()
+      ()
+    }
+
+  }
+
+  "task" should "extract from avro files containing the envelope" in {
+
+    val task = new S3SourceTask()
+
+    val props = (defaultProps ++ Map(
+      "connect.s3.kcql"                            -> s"insert into $TopicName select * from $BucketName:$MyPrefix/avro STOREAS `AVRO` LIMIT 1000 PROPERTIES ('store.envelope'=true)",
+      "connect.s3.partition.search.recurse.levels" -> "0",
+      "connect.partition.search.continuous"        -> "false",
+    )).asJava
+
+    task.start(props)
+
+    var sourceRecords: Seq[SourceRecord] = List.empty
+    try {
+      eventually {
+        do {
+          sourceRecords = sourceRecords ++ task.poll().asScala
+        } while (sourceRecords.size != 1)
+        task.poll() should be(empty)
+      }
+    } finally {
+      task.stop()
+    }
+
+    //assert the record matches the envelope
+    val sourceRecord = sourceRecords.head
+    sourceRecord.keySchema().`type`() should be(Schema.Type.BYTES)
+    sourceRecord.key() shouldBe null
+
+    sourceRecord.valueSchema().`type`() should be(Schema.Type.BYTES)
+    val value: Array[Byte] = sourceRecord.value().asInstanceOf[Array[Byte]]
+    value shouldBe "value".getBytes()
 
     sourceRecord.headers().asScala.map(h => h.key() -> h.value()).toMap should be(Map("header1" -> "value1",
                                                                                       "header2" -> 123456789L,

--- a/kafka-connect-cloud-common/src/main/scala/io/lenses/streamreactor/connect/cloud/common/formats/reader/converters/SchemaAndValueEnvelopeConverter.scala
+++ b/kafka-connect-cloud-common/src/main/scala/io/lenses/streamreactor/connect/cloud/common/formats/reader/converters/SchemaAndValueEnvelopeConverter.scala
@@ -21,6 +21,7 @@ import io.lenses.streamreactor.connect.cloud.common.model.location.CloudLocation
 import io.lenses.streamreactor.connect.cloud.common.source.SourceWatermark
 import org.apache.kafka.connect.data.Schema
 import org.apache.kafka.connect.data.SchemaAndValue
+import org.apache.kafka.connect.data.Struct
 import org.apache.kafka.connect.header.ConnectHeaders
 import org.apache.kafka.connect.header.Headers
 import org.apache.kafka.connect.source.SourceRecord
@@ -73,24 +74,11 @@ class SchemaAndValueEnvelopeConverter(
         s"Invalid schema type [${schemaAndValue.schema().`type`()}]. Expected [${Schema.Type.STRUCT}]",
       )
     }
-    val struct = schemaAndValue.value().asInstanceOf[org.apache.kafka.connect.data.Struct]
+    val struct: Struct = schemaAndValue.value().asInstanceOf[org.apache.kafka.connect.data.Struct]
     val fields = struct.schema().fields().asScala.map(_.name()).toSet
 
-    var key:       Any    = null
-    var keySchema: Schema = null
-    if (fields.contains("key")) {
-      key       = struct.get("key")
-      keySchema = struct.schema().field("key").schema()
-      key       = byteBufferToArray(keySchema, key)
-    }
-
-    var value:       Any    = null
-    var valueSchema: Schema = null
-    if (fields.contains("value")) {
-      value       = struct.get("value")
-      valueSchema = struct.schema().field("value").schema()
-      value       = byteBufferToArray(valueSchema, value)
-    }
+    val (key, keySchema)     = extractValueAndSchemaFor(struct, fields, "key")
+    val (value, valueSchema) = extractValueAndSchemaFor(struct, fields, "value")
 
     var headers: Headers = null
     if (fields.contains("headers")) {
@@ -116,10 +104,10 @@ class SchemaAndValueEnvelopeConverter(
       SourceWatermark.offset(location, index, lastModified),
       topic.value,
       partition,
-      keySchema,
-      key,
-      valueSchema,
-      value,
+      keySchema.orNull,
+      key.orNull,
+      valueSchema.orNull,
+      value.orNull,
       timestamp,
       headers,
     )
@@ -133,5 +121,19 @@ class SchemaAndValueEnvelopeConverter(
         case _ => value
       }.orNull
       adjusted
+    }
+
+  private def extractValueAndSchemaFor(
+    struct: Struct,
+    fields: Set[String],
+    field:  String,
+  ): (Option[Any], Option[Schema]) =
+    if (fields.contains(field)) {
+      val value          = struct.get(field)
+      val valueSchema    = struct.schema().field(field).schema()
+      val valueConverted = byteBufferToArray(valueSchema, value)
+      (Some(valueConverted), Some(valueSchema))
+    } else {
+      (None, None)
     }
 }


### PR DESCRIPTION
Storing the Key/Value as an array of bytes has an issue since the connector returns java.nio.ByteBuffer but the Connect framework ByteArrayConverter works only with byte[]

This change ensures that if the key/value are a ByteBuffer it converts that to byte[]