### PR TITLE
Add GZIP support for JSON in S3 sink connector

### DIFF
--- a/kafka-connect-aws-s3/src/main/scala/io/lenses/streamreactor/connect/aws/s3/sink/config/S3SinkConfigDefBuilder.scala
+++ b/kafka-connect-aws-s3/src/main/scala/io/lenses/streamreactor/connect/aws/s3/sink/config/S3SinkConfigDefBuilder.scala
@@ -18,7 +18,6 @@ package io.lenses.streamreactor.connect.aws.s3.sink.config
 import io.lenses.streamreactor.common.config.base.traits._
 import io.lenses.streamreactor.connect.aws.s3.config.DeleteModeSettings
 import io.lenses.streamreactor.connect.aws.s3.config.S3ConfigSettings
-import io.lenses.streamreactor.connect.cloud.common.config.CompressionCodecSettings
 import io.lenses.streamreactor.connect.cloud.common.sink.config.CloudSinkConfigDefBuilder
 
 import java.util
@@ -31,7 +30,6 @@ case class S3SinkConfigDefBuilder(props: util.Map[String, String])
     with NumberRetriesSettings
     with UserSettings
     with ConnectionSettings
-    with CompressionCodecSettings
     with DeleteModeSettings {
 
   def getParsedValues: Map[String, _] = values().asScala.toMap

--- a/kafka-connect-azure-datalake/src/main/scala/io/lenses/streamreactor/connect/datalake/sink/config/DatalakeSinkConfigDefBuilder.scala
+++ b/kafka-connect-azure-datalake/src/main/scala/io/lenses/streamreactor/connect/datalake/sink/config/DatalakeSinkConfigDefBuilder.scala
@@ -16,7 +16,6 @@
 package io.lenses.streamreactor.connect.datalake.sink.config
 
 import io.lenses.streamreactor.common.config.base.traits._
-import io.lenses.streamreactor.connect.cloud.common.config.CompressionCodecSettings
 import io.lenses.streamreactor.connect.cloud.common.sink.config.CloudSinkConfigDefBuilder
 import io.lenses.streamreactor.connect.datalake.config.AuthModeSettings
 import io.lenses.streamreactor.connect.datalake.config.AzureConfigSettings
@@ -31,7 +30,6 @@ case class DatalakeSinkConfigDefBuilder(props: util.Map[String, String])
     with NumberRetriesSettings
     with UserSettings
     with ConnectionSettings
-    with CompressionCodecSettings
     with AuthModeSettings {
 
   def getParsedValues: Map[String, _] = values().asScala.toMap

--- a/kafka-connect-cloud-common/src/main/scala/io/lenses/streamreactor/connect/cloud/common/config/CompressionCodecSettings.scala
+++ b/kafka-connect-cloud-common/src/main/scala/io/lenses/streamreactor/connect/cloud/common/config/CompressionCodecSettings.scala
@@ -25,7 +25,7 @@ trait CompressionCodecConfigKeys extends WithConnectorPrefix {
 
   def COMPRESSION_CODEC = s"$connectorPrefix.compression.codec"
 
-  val COMPRESSION_CODEC_DOC = "Compression codec to use for Avro or Parquet."
+  val COMPRESSION_CODEC_DOC = "Compression codec to use for Avro, Parquet or JSON."
   val COMPRESSION_CODEC_DEFAULT: String = UNCOMPRESSED.entryName
 
   def COMPRESSION_LEVEL = s"$connectorPrefix.compression.level"
@@ -41,9 +41,25 @@ trait CompressionCodecSettings extends BaseSettings with CompressionCodecConfigK
       CompressionCodecName.withNameInsensitiveOption(getString(COMPRESSION_CODEC)).getOrElse(
         CompressionCodecName.UNCOMPRESSED,
       )
-    val level    = getInt(COMPRESSION_LEVEL)
-    val levelOpt = Option.when(level != -1)(level.toInt)
 
-    CompressionCodec(codec, levelOpt)
+    val level     = getInt(COMPRESSION_LEVEL)
+    val levelOpt  = Option.when(level != -1)(level.toInt)
+    val extension = getCompressedFileExtension(codec)
+
+    CompressionCodec(codec, levelOpt, extension)
   }
+
+  private def getCompressedFileExtension(codec: CompressionCodecName): Option[String] =
+    codec match {
+      case CompressionCodecName.UNCOMPRESSED => None
+      case CompressionCodecName.SNAPPY       => Some("sz")
+      case CompressionCodecName.GZIP         => Some("gz")
+      case CompressionCodecName.LZO          => Some("lzo")
+      case CompressionCodecName.BROTLI       => Some("br")
+      case CompressionCodecName.LZ4          => Some("lz4")
+      case CompressionCodecName.BZIP2        => Some("bz2")
+      case CompressionCodecName.ZSTD         => Some("zst")
+      case CompressionCodecName.DEFLATE      => Some("gz")
+      case CompressionCodecName.XZ           => Some("xz")
+    }
 }

--- a/kafka-connect-cloud-common/src/main/scala/io/lenses/streamreactor/connect/cloud/common/config/CompressionCodecSettings.scala
+++ b/kafka-connect-cloud-common/src/main/scala/io/lenses/streamreactor/connect/cloud/common/config/CompressionCodecSettings.scala
@@ -42,24 +42,9 @@ trait CompressionCodecSettings extends BaseSettings with CompressionCodecConfigK
         CompressionCodecName.UNCOMPRESSED,
       )
 
-    val level     = getInt(COMPRESSION_LEVEL)
-    val levelOpt  = Option.when(level != -1)(level.toInt)
-    val extension = getCompressedFileExtension(codec)
+    val level    = getInt(COMPRESSION_LEVEL)
+    val levelOpt = Option.when(level != -1)(level.toInt)
 
-    CompressionCodec(codec, levelOpt, extension)
+    CompressionCodec(codec, levelOpt, CompressionCodecName.toFileExtension(codec))
   }
-
-  private def getCompressedFileExtension(codec: CompressionCodecName): Option[String] =
-    codec match {
-      case CompressionCodecName.UNCOMPRESSED => None
-      case CompressionCodecName.SNAPPY       => Some("sz")
-      case CompressionCodecName.GZIP         => Some("gz")
-      case CompressionCodecName.LZO          => Some("lzo")
-      case CompressionCodecName.BROTLI       => Some("br")
-      case CompressionCodecName.LZ4          => Some("lz4")
-      case CompressionCodecName.BZIP2        => Some("bz2")
-      case CompressionCodecName.ZSTD         => Some("zst")
-      case CompressionCodecName.DEFLATE      => Some("gz")
-      case CompressionCodecName.XZ           => Some("xz")
-    }
 }

--- a/kafka-connect-cloud-common/src/main/scala/io/lenses/streamreactor/connect/cloud/common/config/FormatSelection.scala
+++ b/kafka-connect-cloud-common/src/main/scala/io/lenses/streamreactor/connect/cloud/common/config/FormatSelection.scala
@@ -111,6 +111,11 @@ case object FormatSelection {
 }
 
 case object JsonFormatSelection extends FormatSelection {
+  override def availableCompressionCodecs: Map[CompressionCodecName, Boolean] = Map(
+    UNCOMPRESSED -> true,
+    GZIP         -> true, // Only applies to sink currently.
+  )
+
   override def toStreamReader(
     input: ReaderBuilderContext,
   ): CloudStreamReader = {

--- a/kafka-connect-cloud-common/src/main/scala/io/lenses/streamreactor/connect/cloud/common/formats/writer/AvroFormatWriter.scala
+++ b/kafka-connect-cloud-common/src/main/scala/io/lenses/streamreactor/connect/cloud/common/formats/writer/AvroFormatWriter.scala
@@ -41,12 +41,12 @@ class AvroFormatWriter(outputStream: CloudOutputStream)(implicit compressionCode
 
   private val avroCompressionCodec: CodecFactory = {
     compressionCodec match {
-      case CompressionCodec(UNCOMPRESSED, _)      => CodecFactory.nullCodec()
-      case CompressionCodec(SNAPPY, _)            => CodecFactory.snappyCodec()
-      case CompressionCodec(BZIP2, _)             => CodecFactory.bzip2Codec()
-      case CompressionCodec(ZSTD, Some(level))    => CodecFactory.zstandardCodec(level)
-      case CompressionCodec(DEFLATE, Some(level)) => CodecFactory.deflateCodec(level)
-      case CompressionCodec(XZ, Some(level))      => CodecFactory.xzCodec(level)
+      case CompressionCodec(UNCOMPRESSED, _, _)      => CodecFactory.nullCodec()
+      case CompressionCodec(SNAPPY, _, _)            => CodecFactory.snappyCodec()
+      case CompressionCodec(BZIP2, _, _)             => CodecFactory.bzip2Codec()
+      case CompressionCodec(ZSTD, Some(level), _)    => CodecFactory.zstandardCodec(level)
+      case CompressionCodec(DEFLATE, Some(level), _) => CodecFactory.deflateCodec(level)
+      case CompressionCodec(XZ, Some(level), _)      => CodecFactory.xzCodec(level)
       case _ =>
         throw new IllegalArgumentException("No or invalid compressionCodec specified - does codec require a level?")
     }

--- a/kafka-connect-cloud-common/src/main/scala/io/lenses/streamreactor/connect/cloud/common/formats/writer/JsonFormatWriter.scala
+++ b/kafka-connect-cloud-common/src/main/scala/io/lenses/streamreactor/connect/cloud/common/formats/writer/JsonFormatWriter.scala
@@ -64,6 +64,7 @@ class JsonFormatWriter(outputStream: CloudOutputStream)(implicit compressionCode
         }
 
         compressedOutputStream.write(dataBytes)
+        compressedOutputStream.write(LineSeparatorBytes)
         compressedOutputStream.flush()
       } else {
         outputStream.write(dataBytes)

--- a/kafka-connect-cloud-common/src/main/scala/io/lenses/streamreactor/connect/cloud/common/model/CompressionCodecName.scala
+++ b/kafka-connect-cloud-common/src/main/scala/io/lenses/streamreactor/connect/cloud/common/model/CompressionCodecName.scala
@@ -20,9 +20,13 @@ import enumeratum.Enum
 import enumeratum.EnumEntry
 
 sealed trait CompressionCodecName extends EnumEntry {
-  def withLevel(level: Int): CompressionCodec = CompressionCodec(this, level.some)
+  def withLevel(level: Int): CompressionCodec =
+    CompressionCodec(this, level.some, CompressionCodecName.toFileExtension(this))
 
-  def toCodec(): CompressionCodec = CompressionCodec(this)
+  def toCodec(): CompressionCodec = CompressionCodec(
+    compressionCodec = this,
+    extension        = CompressionCodecName.toFileExtension(this),
+  )
 }
 
 object CompressionCodecName extends Enum[CompressionCodecName] {
@@ -39,6 +43,19 @@ object CompressionCodecName extends Enum[CompressionCodecName] {
   case object XZ           extends CompressionCodecName
 
   override def values: IndexedSeq[CompressionCodecName] = findValues
+
+  def toFileExtension(codecName: CompressionCodecName): Option[String] = codecName match {
+    case CompressionCodecName.UNCOMPRESSED => None
+    case CompressionCodecName.SNAPPY       => Some("sz")
+    case CompressionCodecName.GZIP         => Some("gz")
+    case CompressionCodecName.LZO          => Some("lzo")
+    case CompressionCodecName.BROTLI       => Some("br")
+    case CompressionCodecName.LZ4          => Some("lz4")
+    case CompressionCodecName.BZIP2        => Some("bz2")
+    case CompressionCodecName.ZSTD         => Some("zst")
+    case CompressionCodecName.DEFLATE      => Some("gz")
+    case CompressionCodecName.XZ           => Some("xz")
+  }
 }
 
 /**

--- a/kafka-connect-cloud-common/src/main/scala/io/lenses/streamreactor/connect/cloud/common/model/CompressionCodecName.scala
+++ b/kafka-connect-cloud-common/src/main/scala/io/lenses/streamreactor/connect/cloud/common/model/CompressionCodecName.scala
@@ -41,4 +41,13 @@ object CompressionCodecName extends Enum[CompressionCodecName] {
   override def values: IndexedSeq[CompressionCodecName] = findValues
 }
 
-case class CompressionCodec(compressionCodec: CompressionCodecName, level: Option[Int] = Option.empty)
+/**
+  * @param extension
+  *   Some format selections have compression built-in, such as Avro and Parquet.
+  *   Text formats like CSV and JSON do not, and require an update to the file extension when compressed.
+  */
+case class CompressionCodec(
+  compressionCodec: CompressionCodecName,
+  level:            Option[Int]    = Option.empty,
+  extension:        Option[String] = None,
+)

--- a/kafka-connect-cloud-common/src/main/scala/io/lenses/streamreactor/connect/cloud/common/sink/config/CloudSinkBucketOptions.scala
+++ b/kafka-connect-cloud-common/src/main/scala/io/lenses/streamreactor/connect/cloud/common/sink/config/CloudSinkBucketOptions.scala
@@ -48,7 +48,7 @@ object CloudSinkBucketOptions extends LazyLogging {
     config.getKCQL.map { kcql: Kcql =>
       for {
         formatSelection   <- FormatSelection.fromKcql(kcql, SinkPropsSchema.schema)
-        fileExtension      = extractFileExtension(config, formatSelection)
+        fileExtension      = extractFileExtension(config.getCompressionCodec(), formatSelection)
         sinkProps          = CloudSinkProps.fromKcql(kcql)
         partitionSelection = PartitionSelection(kcql, sinkProps)
         paddingService    <- PaddingService.fromConfig(config, sinkProps)
@@ -110,12 +110,12 @@ object CloudSinkBucketOptions extends LazyLogging {
         new IllegalArgumentException(s"Envelope is not supported for format ${format.extension.toUpperCase()}.").asLeft
     }
 
-  private def extractFileExtension(config: CloudSinkConfigDefBuilder, formatSelection: FormatSelection): String = {
+  private def extractFileExtension(compressionCodec: CompressionCodec, formatSelection: FormatSelection): String = {
     // Avro or Parquet do not change filenames when compressed; guards for JSON only.
     if (formatSelection != JsonFormatSelection)
       return formatSelection.extension
 
-    config.getCompressionCodec().extension.getOrElse(formatSelection.extension)
+    compressionCodec.extension.getOrElse(formatSelection.extension)
   }
 }
 

--- a/kafka-connect-cloud-common/src/main/scala/io/lenses/streamreactor/connect/cloud/common/sink/config/CloudSinkBucketOptions.scala
+++ b/kafka-connect-cloud-common/src/main/scala/io/lenses/streamreactor/connect/cloud/common/sink/config/CloudSinkBucketOptions.scala
@@ -35,6 +35,7 @@ import io.lenses.streamreactor.connect.cloud.common.sink.naming.CloudKeyNamer
 import io.lenses.streamreactor.connect.cloud.common.sink.naming.KeyNamer
 import io.lenses.streamreactor.connect.cloud.common.sink.naming.OffsetFileNamer
 import io.lenses.streamreactor.connect.cloud.common.sink.naming.TopicPartitionOffsetFileNamer
+import io.lenses.streamreactor.connect.cloud.common.model.CompressionCodec
 
 object CloudSinkBucketOptions extends LazyLogging {
 

--- a/kafka-connect-cloud-common/src/main/scala/io/lenses/streamreactor/connect/cloud/common/sink/config/CloudSinkConfigDefBuilder.scala
+++ b/kafka-connect-cloud-common/src/main/scala/io/lenses/streamreactor/connect/cloud/common/sink/config/CloudSinkConfigDefBuilder.scala
@@ -17,9 +17,11 @@ package io.lenses.streamreactor.connect.cloud.common.sink.config
 
 import io.lenses.streamreactor.common.config.base.traits.KcqlSettings
 import io.lenses.streamreactor.connect.cloud.common.sink.config.padding.PaddingStrategySettings
+import io.lenses.streamreactor.connect.cloud.common.config.CompressionCodecSettings
 
 trait CloudSinkConfigDefBuilder
     extends KcqlSettings
     with FlushSettings
     with LocalStagingAreaSettings
-    with PaddingStrategySettings {}
+    with PaddingStrategySettings
+    with CompressionCodecSettings {}

--- a/kafka-connect-cloud-common/src/main/scala/io/lenses/streamreactor/connect/cloud/common/sink/conversion/ToJsonDataConverter.scala
+++ b/kafka-connect-cloud-common/src/main/scala/io/lenses/streamreactor/connect/cloud/common/sink/conversion/ToJsonDataConverter.scala
@@ -15,13 +15,31 @@
  */
 package io.lenses.streamreactor.connect.cloud.common.sink.conversion
 
+import io.lenses.streamreactor.connect.cloud.common.formats.writer.ArraySinkData
 import io.lenses.streamreactor.connect.cloud.common.formats.writer.ByteArraySinkData
+import io.lenses.streamreactor.connect.cloud.common.formats.writer.MapSinkData
+import io.lenses.streamreactor.connect.cloud.common.formats.writer.NullSinkData
 import io.lenses.streamreactor.connect.cloud.common.formats.writer.PrimitiveSinkData
 import io.lenses.streamreactor.connect.cloud.common.formats.writer.SinkData
+import io.lenses.streamreactor.connect.cloud.common.formats.writer.StructSinkData
+import io.lenses.streamreactor.connect.cloud.common.model.Topic
+import org.apache.kafka.connect.json.JsonConverter
 
 import java.nio.ByteBuffer
 
 object ToJsonDataConverter {
+
+  def convertMessageValueToByteArray(converter: JsonConverter, topic: Topic, data: SinkData): Array[Byte] =
+    data match {
+      case data: PrimitiveSinkData => converter.fromConnectData(topic.value, data.schema().orNull, data.safeValue)
+      case StructSinkData(structVal)    => converter.fromConnectData(topic.value, data.schema().orNull, structVal)
+      case MapSinkData(map, schema)     => converter.fromConnectData(topic.value, schema.orNull, map)
+      case ArraySinkData(array, schema) => converter.fromConnectData(topic.value, schema.orNull, array)
+      case ByteArraySinkData(_, _)      => throw new IllegalStateException("Cannot currently write byte array as json")
+      case NullSinkData(schema)         => converter.fromConnectData(topic.value, schema.orNull, null)
+      case other                        => throw new IllegalStateException(s"Unknown SinkData type, ${other.getClass.getSimpleName}")
+    }
+
   def convert(data: SinkData): Any = data match {
     case data: PrimitiveSinkData => data.safeValue
     case ByteArraySinkData(bArray, _) => ByteBuffer.wrap(bArray)

--- a/kafka-connect-cloud-common/src/main/scala/io/lenses/streamreactor/connect/cloud/common/sink/naming/FileExtensionNamer.scala
+++ b/kafka-connect-cloud-common/src/main/scala/io/lenses/streamreactor/connect/cloud/common/sink/naming/FileExtensionNamer.scala
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2017-2024 Lenses.io Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.lenses.streamreactor.connect.cloud.common.sink.naming
+
+import io.lenses.streamreactor.connect.cloud.common.model.CompressionCodec
+import io.lenses.streamreactor.connect.cloud.common.config.FormatSelection
+import io.lenses.streamreactor.connect.cloud.common.config.JsonFormatSelection
+
+object FileExtensionNamer {
+
+  /**
+    * Reconciles the file extensions set in the given format & codec.
+    *
+    * @note Avro or Parquet do not change filenames when compressed; guards for JSON only.
+    */
+  def fileExtension(codec: CompressionCodec, formatSelection: FormatSelection): String = {
+    if (formatSelection != JsonFormatSelection)
+      return formatSelection.extension
+
+    codec.extension.getOrElse(formatSelection.extension)
+  }
+}

--- a/kafka-connect-cloud-common/src/test/scala/io/lenses/streamreactor/connect/cloud/common/formats/JsonFormatWriterTest.scala
+++ b/kafka-connect-cloud-common/src/test/scala/io/lenses/streamreactor/connect/cloud/common/formats/JsonFormatWriterTest.scala
@@ -28,6 +28,11 @@ import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 import io.lenses.streamreactor.connect.cloud.common.model.CompressionCodec
 import io.lenses.streamreactor.connect.cloud.common.model.CompressionCodecName.UNCOMPRESSED
+import io.lenses.streamreactor.connect.cloud.common.model.CompressionCodecName.GZIP
+
+import org.apache.commons.compress.compressors.gzip.GzipCompressorInputStream
+import java.io.ByteArrayInputStream
+import io.lenses.streamreactor.connect.cloud.common.formats.reader.TextStreamReader
 
 import java.time.Instant
 import scala.jdk.CollectionConverters.MapHasAsJava
@@ -35,6 +40,67 @@ import scala.jdk.CollectionConverters.SeqHasAsJava
 
 class JsonFormatWriterTest extends AnyFlatSpec with Matchers {
   private implicit val compressionCodec: CompressionCodec = UNCOMPRESSED.toCodec()
+
+  "convert" should "write compressed byte output stream with json for a single record" in {
+    implicit val compressionCodec = GZIP.toCodec()
+
+    val outputStream     = new CloudByteArrayOutputStream()
+    val jsonFormatWriter = new JsonFormatWriter(outputStream)
+
+    jsonFormatWriter.write(
+      MessageDetail(
+        NullSinkData(None),
+        StructSinkData(SampleData.Users.head),
+        Map.empty,
+        Some(Instant.now()),
+        topic,
+        0,
+        Offset(0),
+      ),
+    )
+    jsonFormatWriter.complete()
+
+    val byteArrayInputStream       = new ByteArrayInputStream(outputStream.toByteArray)
+    val compressedStream           = new GzipCompressorInputStream(byteArrayInputStream)
+    val jsonTextFormatStreamReader = new TextStreamReader(compressedStream)
+
+    jsonTextFormatStreamReader.hasNext should be(true)
+    jsonTextFormatStreamReader.next() should be(SampleData.recordsAsJson(0))
+  }
+
+  "convert" should "write compressed byte output stream with json for multiple records" in {
+    implicit val compressionCodec = GZIP.toCodec()
+
+    val outputStream     = new CloudByteArrayOutputStream()
+    val jsonFormatWriter = new JsonFormatWriter(outputStream)
+
+    SampleData.Users.take(3).foreach(sampleUser =>
+      jsonFormatWriter.write(
+        MessageDetail(
+          NullSinkData(None),
+          StructSinkData(sampleUser),
+          Map.empty,
+          Some(Instant.now()),
+          topic,
+          0,
+          Offset(0),
+        ),
+      ),
+    )
+    jsonFormatWriter.complete()
+
+    val byteArrayInputStream       = new ByteArrayInputStream(outputStream.toByteArray)
+    val compressedStream           = new GzipCompressorInputStream(byteArrayInputStream)
+    val jsonTextFormatStreamReader = new TextStreamReader(compressedStream)
+
+    jsonTextFormatStreamReader.hasNext should be(true)
+    jsonTextFormatStreamReader.next() should be(SampleData.recordsAsJson(0))
+    jsonTextFormatStreamReader.hasNext should be(true)
+    jsonTextFormatStreamReader.next() should be(SampleData.recordsAsJson(1))
+    jsonTextFormatStreamReader.hasNext should be(true)
+    jsonTextFormatStreamReader.next() should be(SampleData.recordsAsJson(2))
+    jsonTextFormatStreamReader.hasNext should be(false)
+  }
 
   "convert" should "write byte output stream with json for a single record" in {
 

--- a/kafka-connect-cloud-common/src/test/scala/io/lenses/streamreactor/connect/cloud/common/formats/JsonFormatWriterTest.scala
+++ b/kafka-connect-cloud-common/src/test/scala/io/lenses/streamreactor/connect/cloud/common/formats/JsonFormatWriterTest.scala
@@ -26,12 +26,15 @@ import io.lenses.streamreactor.connect.cloud.common.utils.SampleData.topic
 import org.apache.kafka.connect.data.SchemaBuilder
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
+import io.lenses.streamreactor.connect.cloud.common.model.CompressionCodec
+import io.lenses.streamreactor.connect.cloud.common.model.CompressionCodecName.UNCOMPRESSED
 
 import java.time.Instant
 import scala.jdk.CollectionConverters.MapHasAsJava
 import scala.jdk.CollectionConverters.SeqHasAsJava
 
 class JsonFormatWriterTest extends AnyFlatSpec with Matchers {
+  private implicit val compressionCodec: CompressionCodec = UNCOMPRESSED.toCodec()
 
   "convert" should "write byte output stream with json for a single record" in {
 

--- a/kafka-connect-cloud-common/src/test/scala/io/lenses/streamreactor/connect/cloud/common/formats/TextFormatStreamReaderTest.scala
+++ b/kafka-connect-cloud-common/src/test/scala/io/lenses/streamreactor/connect/cloud/common/formats/TextFormatStreamReaderTest.scala
@@ -38,18 +38,15 @@ class TextFormatStreamReaderTest extends AnyFlatSpec with Matchers {
   "read" should "take read through all records" in {
 
     val byteArrayInputStream: ByteArrayInputStream = writeRecordsToOutputStream
-    val avroFormatStreamReader =
-      new TextStreamReader(
-        byteArrayInputStream,
-      )
+    val jsonTextFormatStreamReader = new TextStreamReader(byteArrayInputStream)
 
-    avroFormatStreamReader.hasNext should be(true)
-    avroFormatStreamReader.next() should be(SampleData.recordsAsJson(0))
-    avroFormatStreamReader.hasNext should be(true)
-    avroFormatStreamReader.next() should be(SampleData.recordsAsJson(1))
-    avroFormatStreamReader.hasNext should be(true)
-    avroFormatStreamReader.next() should be(SampleData.recordsAsJson(2))
-    avroFormatStreamReader.hasNext should be(false)
+    jsonTextFormatStreamReader.hasNext should be(true)
+    jsonTextFormatStreamReader.next() should be(SampleData.recordsAsJson(0))
+    jsonTextFormatStreamReader.hasNext should be(true)
+    jsonTextFormatStreamReader.next() should be(SampleData.recordsAsJson(1))
+    jsonTextFormatStreamReader.hasNext should be(true)
+    jsonTextFormatStreamReader.next() should be(SampleData.recordsAsJson(2))
+    jsonTextFormatStreamReader.hasNext should be(false)
 
   }
 

--- a/kafka-connect-cloud-common/src/test/scala/io/lenses/streamreactor/connect/cloud/common/formats/TextFormatStreamReaderTest.scala
+++ b/kafka-connect-cloud-common/src/test/scala/io/lenses/streamreactor/connect/cloud/common/formats/TextFormatStreamReaderTest.scala
@@ -26,11 +26,14 @@ import io.lenses.streamreactor.connect.cloud.common.utils.SampleData
 import io.lenses.streamreactor.connect.cloud.common.utils.SampleData.topic
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
+import io.lenses.streamreactor.connect.cloud.common.model.CompressionCodec
+import io.lenses.streamreactor.connect.cloud.common.model.CompressionCodecName.UNCOMPRESSED
 
 import java.io.ByteArrayInputStream
 import java.time.Instant
 
 class TextFormatStreamReaderTest extends AnyFlatSpec with Matchers {
+  private implicit val compressionCodec: CompressionCodec = UNCOMPRESSED.toCodec()
 
   "read" should "take read through all records" in {
 

--- a/kafka-connect-cloud-common/src/test/scala/io/lenses/streamreactor/connect/cloud/common/sink/naming/FileExtensionNamerTest.scala
+++ b/kafka-connect-cloud-common/src/test/scala/io/lenses/streamreactor/connect/cloud/common/sink/naming/FileExtensionNamerTest.scala
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2017-2024 Lenses.io Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.lenses.streamreactor.connect.cloud.common.sink.naming
+
+import io.lenses.streamreactor.connect.cloud.common.sink.naming.FileExtensionNamer
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.should.Matchers
+
+import io.lenses.streamreactor.connect.cloud.common.model.CompressionCodecName
+import io.lenses.streamreactor.connect.cloud.common.config.JsonFormatSelection
+import io.lenses.streamreactor.connect.cloud.common.config.AvroFormatSelection
+
+class FileExtensionNamerTest extends AnyFunSuite with Matchers {
+
+  test("FileExtensionNamer.fileExtension maintains the original file extension for uncompressed JSON") {
+    val extension = FileExtensionNamer.fileExtension(CompressionCodecName.UNCOMPRESSED.toCodec(), JsonFormatSelection)
+    extension shouldEqual "json"
+  }
+
+  test("FileExtensionNamer.fileExtension updates the file extension for compressed JSON") {
+    val gzipExtension = FileExtensionNamer.fileExtension(CompressionCodecName.GZIP.toCodec(), JsonFormatSelection)
+    gzipExtension shouldEqual "gz"
+
+    val brotliExtension = FileExtensionNamer.fileExtension(CompressionCodecName.BROTLI.toCodec(), JsonFormatSelection)
+    brotliExtension shouldEqual "br"
+  }
+
+  test("FileExtensionNamer.fileExtension maintains the original file extension for uncompressed Avro") {
+    val extension = FileExtensionNamer.fileExtension(CompressionCodecName.UNCOMPRESSED.toCodec(), AvroFormatSelection)
+    extension shouldEqual "avro"
+  }
+
+  test("FileExtensionNamer.fileExtension maintains the original file extension for compressed Avro") {
+    val extension = FileExtensionNamer.fileExtension(CompressionCodecName.SNAPPY.toCodec(), AvroFormatSelection)
+    extension shouldEqual "avro"
+  }
+}

--- a/kafka-connect-gcp-storage/src/main/scala/io/lenses/streamreactor/connect/gcp/storage/sink/config/GCPStorageSinkConfigDefBuilder.scala
+++ b/kafka-connect-gcp-storage/src/main/scala/io/lenses/streamreactor/connect/gcp/storage/sink/config/GCPStorageSinkConfigDefBuilder.scala
@@ -16,7 +16,6 @@
 package io.lenses.streamreactor.connect.gcp.storage.sink.config
 
 import io.lenses.streamreactor.common.config.base.traits._
-import io.lenses.streamreactor.connect.cloud.common.config.CompressionCodecSettings
 import io.lenses.streamreactor.connect.cloud.common.sink.config.CloudSinkConfigDefBuilder
 import io.lenses.streamreactor.connect.gcp.storage.config.AuthModeSettings
 import io.lenses.streamreactor.connect.gcp.storage.config.GCPConfigSettings
@@ -32,7 +31,6 @@ case class GCPStorageSinkConfigDefBuilder(props: util.Map[String, String])
     with NumberRetriesSettings
     with UserSettings
     with ConnectionSettings
-    with CompressionCodecSettings
     with AuthModeSettings
     with UploadSettings {
 

--- a/test-common/src/main/scala/io/lenses/streamreactor/connect/model/Order.scala
+++ b/test-common/src/main/scala/io/lenses/streamreactor/connect/model/Order.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2023 Lenses.io Ltd
+ * Copyright 2017-2024 Lenses.io Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test-common/src/main/scala/io/lenses/streamreactor/connect/mongodb/Input.scala
+++ b/test-common/src/main/scala/io/lenses/streamreactor/connect/mongodb/Input.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2023 Lenses.io Ltd
+ * Copyright 2017-2024 Lenses.io Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test-common/src/main/scala/io/lenses/streamreactor/connect/mongodb/JacksonJson.scala
+++ b/test-common/src/main/scala/io/lenses/streamreactor/connect/mongodb/JacksonJson.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2023 Lenses.io Ltd
+ * Copyright 2017-2024 Lenses.io Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test-common/src/main/scala/io/lenses/streamreactor/connect/mongodb/Output.scala
+++ b/test-common/src/main/scala/io/lenses/streamreactor/connect/mongodb/Output.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2023 Lenses.io Ltd
+ * Copyright 2017-2024 Lenses.io Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test-common/src/main/scala/io/lenses/streamreactor/connect/mongodb/Transaction.scala
+++ b/test-common/src/main/scala/io/lenses/streamreactor/connect/mongodb/Transaction.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2023 Lenses.io Ltd
+ * Copyright 2017-2024 Lenses.io Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test-common/src/main/scala/io/lenses/streamreactor/connect/testcontainers/CassandraContainer.scala
+++ b/test-common/src/main/scala/io/lenses/streamreactor/connect/testcontainers/CassandraContainer.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2023 Lenses.io Ltd
+ * Copyright 2017-2024 Lenses.io Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test-common/src/main/scala/io/lenses/streamreactor/connect/testcontainers/ElasticsearchContainer.scala
+++ b/test-common/src/main/scala/io/lenses/streamreactor/connect/testcontainers/ElasticsearchContainer.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2023 Lenses.io Ltd
+ * Copyright 2017-2024 Lenses.io Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test-common/src/main/scala/io/lenses/streamreactor/connect/testcontainers/GCPStorageContainer.scala
+++ b/test-common/src/main/scala/io/lenses/streamreactor/connect/testcontainers/GCPStorageContainer.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2023 Lenses.io Ltd
+ * Copyright 2017-2024 Lenses.io Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test-common/src/main/scala/io/lenses/streamreactor/connect/testcontainers/KafkaConnectContainer.scala
+++ b/test-common/src/main/scala/io/lenses/streamreactor/connect/testcontainers/KafkaConnectContainer.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2023 Lenses.io Ltd
+ * Copyright 2017-2024 Lenses.io Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test-common/src/main/scala/io/lenses/streamreactor/connect/testcontainers/KafkaVersions.scala
+++ b/test-common/src/main/scala/io/lenses/streamreactor/connect/testcontainers/KafkaVersions.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2023 Lenses.io Ltd
+ * Copyright 2017-2024 Lenses.io Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test-common/src/main/scala/io/lenses/streamreactor/connect/testcontainers/MongoDBContainer.scala
+++ b/test-common/src/main/scala/io/lenses/streamreactor/connect/testcontainers/MongoDBContainer.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2023 Lenses.io Ltd
+ * Copyright 2017-2024 Lenses.io Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test-common/src/main/scala/io/lenses/streamreactor/connect/testcontainers/PausableContainer.scala
+++ b/test-common/src/main/scala/io/lenses/streamreactor/connect/testcontainers/PausableContainer.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2023 Lenses.io Ltd
+ * Copyright 2017-2024 Lenses.io Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test-common/src/main/scala/io/lenses/streamreactor/connect/testcontainers/RedisContainer.scala
+++ b/test-common/src/main/scala/io/lenses/streamreactor/connect/testcontainers/RedisContainer.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2023 Lenses.io Ltd
+ * Copyright 2017-2024 Lenses.io Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test-common/src/main/scala/io/lenses/streamreactor/connect/testcontainers/RootContainerExec.scala
+++ b/test-common/src/main/scala/io/lenses/streamreactor/connect/testcontainers/RootContainerExec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2023 Lenses.io Ltd
+ * Copyright 2017-2024 Lenses.io Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test-common/src/main/scala/io/lenses/streamreactor/connect/testcontainers/S3Container.scala
+++ b/test-common/src/main/scala/io/lenses/streamreactor/connect/testcontainers/S3Container.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2023 Lenses.io Ltd
+ * Copyright 2017-2024 Lenses.io Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test-common/src/main/scala/io/lenses/streamreactor/connect/testcontainers/SchemaRegistryContainer.scala
+++ b/test-common/src/main/scala/io/lenses/streamreactor/connect/testcontainers/SchemaRegistryContainer.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2023 Lenses.io Ltd
+ * Copyright 2017-2024 Lenses.io Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test-common/src/main/scala/io/lenses/streamreactor/connect/testcontainers/SingleContainer.scala
+++ b/test-common/src/main/scala/io/lenses/streamreactor/connect/testcontainers/SingleContainer.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2023 Lenses.io Ltd
+ * Copyright 2017-2024 Lenses.io Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test-common/src/main/scala/io/lenses/streamreactor/connect/testcontainers/connect/ConfigValue.scala
+++ b/test-common/src/main/scala/io/lenses/streamreactor/connect/testcontainers/connect/ConfigValue.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2023 Lenses.io Ltd
+ * Copyright 2017-2024 Lenses.io Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test-common/src/main/scala/io/lenses/streamreactor/connect/testcontainers/connect/ConnectorConfiguration.scala
+++ b/test-common/src/main/scala/io/lenses/streamreactor/connect/testcontainers/connect/ConnectorConfiguration.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2023 Lenses.io Ltd
+ * Copyright 2017-2024 Lenses.io Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test-common/src/main/scala/io/lenses/streamreactor/connect/testcontainers/connect/KafkaConnectClient.scala
+++ b/test-common/src/main/scala/io/lenses/streamreactor/connect/testcontainers/connect/KafkaConnectClient.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2023 Lenses.io Ltd
+ * Copyright 2017-2024 Lenses.io Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test-common/src/main/scala/io/lenses/streamreactor/connect/testcontainers/package.scala
+++ b/test-common/src/main/scala/io/lenses/streamreactor/connect/testcontainers/package.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2023 Lenses.io Ltd
+ * Copyright 2017-2024 Lenses.io Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test-common/src/main/scala/io/lenses/streamreactor/connect/testcontainers/scalatest/StreamReactorContainerPerSuite.scala
+++ b/test-common/src/main/scala/io/lenses/streamreactor/connect/testcontainers/scalatest/StreamReactorContainerPerSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2023 Lenses.io Ltd
+ * Copyright 2017-2024 Lenses.io Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
Solves https://github.com/lensesio/stream-reactor/issues/875 for the AWS S3 sink connector; planning on adding support for the source connector in a follow-up PR.

This PR makes the following changes:
- Move `CompressionCodecSettings` from `S3SinkConfigDefBuilder` to `CloudSinkConfigDefBuilder` so that it can be used in `CloudSinkBucketOptions` to update the file extension in the `FileNamer` if the specified format and compression configuration require it (e.g. JSON and GZIP). 
  - Update the Azure and GCP packages as well, because they already inherit from the cloud builder.
- Extract message value conversion function from `JsonFormatWriter` to `ToJsonDataConverter`.
- Update `CompressionCodec` class with `extension` field for format + compression combinations that require a file extension change. Propogated the changes.
- Add GZIP compression via `GzipCompressorOutputStream` class in `JsonFormatWriter`; enable configurable compression level & remain consistent with existing connector configuration fields. 
- Test JSON format writer can write compressed output stream of single record or multiple records; add uncompressed implicit codec to existing tests to fix format writer signature change; update `TextFormatStreamReaderTest` naming.

**Note:** theoretically, this should also add support for GZIP/JSON compression in GCP + Azure, though I've only tested it with S3.

Modules affected:
1. `kafka-connect-cloud-common`
2. `kafka-connect-aws-s3`
3. `kafka-connect-azure-datalake`
4. `kafka-connect-gcp-storage`