### PR TITLE
LC-68 - Avoid passing round java maps

### DIFF
--- a/kafka-connect-aws-s3/src/main/scala/io/lenses/streamreactor/connect/aws/s3/sink/S3ConsumerGroupsSinkTask.scala
+++ b/kafka-connect-aws-s3/src/main/scala/io/lenses/streamreactor/connect/aws/s3/sink/S3ConsumerGroupsSinkTask.scala
@@ -33,7 +33,6 @@ import org.apache.kafka.connect.sink.SinkTask
 
 import java.util
 import scala.jdk.CollectionConverters.CollectionHasAsScala
-import scala.jdk.CollectionConverters.MapHasAsJava
 import scala.jdk.CollectionConverters.MapHasAsScala
 
 /**
@@ -62,9 +61,9 @@ class S3ConsumerGroupsSinkTask extends SinkTask with ErrorHandler {
     logger.debug(s"[{}] S3ConsumerGroupSinkTask.start", fallbackProps.get("name"))
 
     val contextProps = Option(context).flatMap(c => Option(c.configs())).map(_.asScala.toMap).getOrElse(Map.empty)
-    val props        = MapUtils.mergeProps(contextProps, fallbackProps.asScala.toMap).asJava
+    val props        = MapUtils.mergeProps(contextProps, fallbackProps.asScala.toMap)
     (for {
-      taskId   <- new ConnectorTaskIdCreator(CONNECTOR_PREFIX).fromProps(fallbackProps)
+      taskId   <- new ConnectorTaskIdCreator(CONNECTOR_PREFIX).fromProps(fallbackProps.asScala.toMap)
       config   <- S3ConsumerGroupsSinkConfig.fromProps(props)
       s3Client <- AwsS3ClientCreator.make(config.config)
       uploader  = new AwsS3Uploader(s3Client, taskId)

--- a/kafka-connect-aws-s3/src/main/scala/io/lenses/streamreactor/connect/aws/s3/sink/S3SinkTask.scala
+++ b/kafka-connect-aws-s3/src/main/scala/io/lenses/streamreactor/connect/aws/s3/sink/S3SinkTask.scala
@@ -28,7 +28,6 @@ import io.lenses.streamreactor.connect.cloud.common.sink.CloudSinkTask
 import io.lenses.streamreactor.connect.cloud.common.sink.WriterManagerCreator
 import io.lenses.streamreactor.connect.cloud.common.sink.writer.WriterManager
 
-import scala.jdk.CollectionConverters.MapHasAsJava
 import scala.util.Try
 
 object S3SinkTask {}
@@ -46,7 +45,7 @@ class S3SinkTask
 
   def createWriterMan(props: Map[String, String]): Either[Throwable, WriterManager[S3FileMetadata]] =
     for {
-      config          <- S3SinkConfig.fromProps(props.asJava)
+      config          <- S3SinkConfig.fromProps(props)
       s3Client        <- AwsS3ClientCreator.make(config.s3Config)
       storageInterface = new AwsS3StorageInterface(connectorTaskId, s3Client, config.batchDelete)
       _               <- Try(setErrorRetryInterval(config.s3Config)).toEither

--- a/kafka-connect-aws-s3/src/main/scala/io/lenses/streamreactor/connect/aws/s3/sink/config/S3ConsumerGroupsSinkConfig.scala
+++ b/kafka-connect-aws-s3/src/main/scala/io/lenses/streamreactor/connect/aws/s3/sink/config/S3ConsumerGroupsSinkConfig.scala
@@ -20,8 +20,6 @@ import io.lenses.streamreactor.connect.aws.s3.config._
 import io.lenses.streamreactor.connect.cloud.common.config.PropertiesHelper
 import io.lenses.streamreactor.connect.cloud.common.consumers.CloudObjectKey
 
-import java.util
-
 case class S3ConsumerGroupsSinkConfig(
   location: CloudObjectKey,
   config:   S3Config,
@@ -29,7 +27,7 @@ case class S3ConsumerGroupsSinkConfig(
 
 object S3ConsumerGroupsSinkConfig extends PropertiesHelper {
   def fromProps(
-    props: util.Map[String, String],
+    props: Map[String, String],
   ): Either[Throwable, S3ConsumerGroupsSinkConfig] =
     S3ConsumerGroupsSinkConfig(S3ConsumerGroupsSinkConfigDef(props))
 

--- a/kafka-connect-aws-s3/src/main/scala/io/lenses/streamreactor/connect/aws/s3/sink/config/S3ConsumerGroupsSinkConfigDef.scala
+++ b/kafka-connect-aws-s3/src/main/scala/io/lenses/streamreactor/connect/aws/s3/sink/config/S3ConsumerGroupsSinkConfigDef.scala
@@ -22,7 +22,6 @@ import org.apache.kafka.common.config.ConfigDef
 import org.apache.kafka.common.config.ConfigDef.Importance
 import org.apache.kafka.common.config.ConfigDef.Type
 
-import java.util
 import scala.jdk.CollectionConverters._
 
 object S3ConsumerGroupsSinkConfigDef {
@@ -116,7 +115,7 @@ object S3ConsumerGroupsSinkConfigDef {
     )
 }
 
-case class S3ConsumerGroupsSinkConfigDef(props: util.Map[String, String])
+case class S3ConsumerGroupsSinkConfigDef(props: Map[String, String])
     extends BaseConfig(S3ConfigSettings.CONNECTOR_PREFIX, S3ConsumerGroupsSinkConfigDef.config, props) {
   def getParsedValues: Map[String, _] = values().asScala.toMap
 

--- a/kafka-connect-aws-s3/src/main/scala/io/lenses/streamreactor/connect/aws/s3/sink/config/S3SinkConfig.scala
+++ b/kafka-connect-aws-s3/src/main/scala/io/lenses/streamreactor/connect/aws/s3/sink/config/S3SinkConfig.scala
@@ -25,12 +25,10 @@ import io.lenses.streamreactor.connect.cloud.common.sink.config.CloudSinkBucketO
 import io.lenses.streamreactor.connect.cloud.common.sink.config.CloudSinkConfig
 import io.lenses.streamreactor.connect.cloud.common.sink.config.OffsetSeekerOptions
 
-import java.util
-
 object S3SinkConfig {
 
   def fromProps(
-    props: util.Map[String, String],
+    props: Map[String, String],
   )(
     implicit
     connectorTaskId:        ConnectorTaskId,

--- a/kafka-connect-aws-s3/src/main/scala/io/lenses/streamreactor/connect/aws/s3/sink/config/S3SinkConfigDefBuilder.scala
+++ b/kafka-connect-aws-s3/src/main/scala/io/lenses/streamreactor/connect/aws/s3/sink/config/S3SinkConfigDefBuilder.scala
@@ -20,10 +20,9 @@ import io.lenses.streamreactor.connect.aws.s3.config.DeleteModeSettings
 import io.lenses.streamreactor.connect.aws.s3.config.S3ConfigSettings
 import io.lenses.streamreactor.connect.cloud.common.sink.config.CloudSinkConfigDefBuilder
 
-import java.util
 import scala.jdk.CollectionConverters.MapHasAsScala
 
-case class S3SinkConfigDefBuilder(props: util.Map[String, String])
+case class S3SinkConfigDefBuilder(props: Map[String, String])
     extends BaseConfig(S3ConfigSettings.CONNECTOR_PREFIX, S3SinkConfigDef.config, props)
     with CloudSinkConfigDefBuilder
     with ErrorPolicySettings

--- a/kafka-connect-aws-s3/src/main/scala/io/lenses/streamreactor/connect/aws/s3/source/S3SourceTask.scala
+++ b/kafka-connect-aws-s3/src/main/scala/io/lenses/streamreactor/connect/aws/s3/source/S3SourceTask.scala
@@ -63,8 +63,9 @@ class S3SourceTask extends SourceTask with LazyLogging {
 
     logger.debug(s"Received call to S3SourceTask.start with ${props.size()} properties")
 
-    val contextProperties = Option(context).flatMap(c => Option(c.configs()).map(_.asScala.toMap)).getOrElse(Map.empty)
-    val mergedProperties  = MapUtils.mergeProps(contextProperties, props.asScala.toMap).asJava
+    val contextProperties: Map[String, String] =
+      Option(context).flatMap(c => Option(c.configs()).map(_.asScala.toMap)).getOrElse(Map.empty)
+    val mergedProperties: Map[String, String] = MapUtils.mergeProps(contextProperties, props.asScala.toMap)
     (for {
       result <- S3SourceState.make(mergedProperties, contextOffsetFn)
       fiber  <- result.partitionDiscoveryLoop.start

--- a/kafka-connect-aws-s3/src/main/scala/io/lenses/streamreactor/connect/aws/s3/source/config/S3SourceConfig.scala
+++ b/kafka-connect-aws-s3/src/main/scala/io/lenses/streamreactor/connect/aws/s3/source/config/S3SourceConfig.scala
@@ -40,13 +40,12 @@ import io.lenses.streamreactor.connect.cloud.common.storage.ListOfKeysResponse
 import io.lenses.streamreactor.connect.cloud.common.storage.StorageInterface
 import io.lenses.streamreactor.connect.config.kcqlprops.KcqlProperties
 
-import java.util
 import scala.util.Try
 
 object S3SourceConfig {
 
   def fromProps(
-    props: util.Map[String, String],
+    props: Map[String, String],
   ): Either[Throwable, S3SourceConfig] =
     S3SourceConfig(S3SourceConfigDefBuilder(props))
 

--- a/kafka-connect-aws-s3/src/main/scala/io/lenses/streamreactor/connect/aws/s3/source/config/S3SourceConfigDefBuilder.scala
+++ b/kafka-connect-aws-s3/src/main/scala/io/lenses/streamreactor/connect/aws/s3/source/config/S3SourceConfigDefBuilder.scala
@@ -20,10 +20,9 @@ import io.lenses.streamreactor.connect.aws.s3.config.DeleteModeSettings
 import io.lenses.streamreactor.connect.aws.s3.config.S3ConfigSettings
 import io.lenses.streamreactor.connect.cloud.common.config.CompressionCodecSettings
 
-import java.util
 import scala.jdk.CollectionConverters.MapHasAsScala
 
-case class S3SourceConfigDefBuilder(props: util.Map[String, String])
+case class S3SourceConfigDefBuilder(props: Map[String, String])
     extends BaseConfig(S3ConfigSettings.CONNECTOR_PREFIX, S3SourceConfigDef.config, props)
     with KcqlSettings
     with ErrorPolicySettings

--- a/kafka-connect-aws-s3/src/main/scala/io/lenses/streamreactor/connect/aws/s3/source/state/S3SourceBuilder.scala
+++ b/kafka-connect-aws-s3/src/main/scala/io/lenses/streamreactor/connect/aws/s3/source/state/S3SourceBuilder.scala
@@ -31,12 +31,11 @@ import io.lenses.streamreactor.connect.cloud.common.source.reader.ReaderManager
 import io.lenses.streamreactor.connect.cloud.common.source.reader.ReaderManagerState
 import io.lenses.streamreactor.connect.cloud.common.source.state.CloudSourceTaskState
 
-import java.util
 import scala.jdk.CollectionConverters.IteratorHasAsScala
 
 object S3SourceState extends StrictLogging {
   def make(
-    props:           util.Map[String, String],
+    props:           Map[String, String],
     contextOffsetFn: CloudLocation => Option[CloudLocation],
   )(
     implicit

--- a/kafka-connect-aws-s3/src/test/scala/io/lenses/streamreactor/connect/aws/s3/config/S3ConsumerGroupsSinkConfigTest.scala
+++ b/kafka-connect-aws-s3/src/test/scala/io/lenses/streamreactor/connect/aws/s3/config/S3ConsumerGroupsSinkConfigTest.scala
@@ -23,7 +23,6 @@ import io.lenses.streamreactor.connect.cloud.common.consumers.CloudObjectKey
 import org.scalatest.funsuite.AnyFunSuite
 import org.scalatest.matchers.should.Matchers
 
-import scala.jdk.CollectionConverters._
 class S3ConsumerGroupsSinkConfigTest extends AnyFunSuite with Matchers {
   test("creates an instance of S3ConsumerGroupsSinkConfig") {
     S3ConsumerGroupsSinkConfig.fromProps(
@@ -34,7 +33,7 @@ class S3ConsumerGroupsSinkConfigTest extends AnyFunSuite with Matchers {
         AWS_SECRET_KEY   -> "secret",
         AUTH_MODE        -> "credentials",
         CUSTOM_ENDPOINT  -> "endpoint",
-      ).asJava,
+      ),
     ) match {
       case Left(value) => fail("Expecting to build a config but got an error instead.", value)
       case Right(value) =>
@@ -68,7 +67,7 @@ class S3ConsumerGroupsSinkConfigTest extends AnyFunSuite with Matchers {
         AWS_SECRET_KEY   -> "secret",
         AUTH_MODE        -> "credentials",
         CUSTOM_ENDPOINT  -> "endpoint",
-      ).asJava,
+      ),
     ) match {
       case Left(value) => fail("Expecting to build a config but got an error instead.", value)
       case Right(value) =>

--- a/kafka-connect-aws-s3/src/test/scala/io/lenses/streamreactor/connect/aws/s3/sink/config/DeleteModeSettingsTest.scala
+++ b/kafka-connect-aws-s3/src/test/scala/io/lenses/streamreactor/connect/aws/s3/sink/config/DeleteModeSettingsTest.scala
@@ -20,8 +20,6 @@ import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.prop.TableDrivenPropertyChecks._
 
-import scala.jdk.CollectionConverters.MapHasAsJava
-
 class DeleteModeSettingsTest extends AnyFlatSpec with Matchers with LazyLogging {
   private val deleteModeMap = Table[String, String, Boolean](
     ("testName", "value", "expected"),
@@ -36,7 +34,7 @@ class DeleteModeSettingsTest extends AnyFlatSpec with Matchers with LazyLogging 
         S3SinkConfigDefBuilder(Map(
           "connect.s3.kcql"        -> "abc",
           "connect.s3.delete.mode" -> value,
-        ).asJava).batchDelete() should be(expected)
+        )).batchDelete() should be(expected)
     }
   }
 }

--- a/kafka-connect-aws-s3/src/test/scala/io/lenses/streamreactor/connect/aws/s3/sink/config/S3ConsumerGroupsSinkConfigTest.scala
+++ b/kafka-connect-aws-s3/src/test/scala/io/lenses/streamreactor/connect/aws/s3/sink/config/S3ConsumerGroupsSinkConfigTest.scala
@@ -26,7 +26,6 @@ import io.lenses.streamreactor.connect.cloud.common.consumers.CloudObjectKey
 import org.scalatest.funsuite.AnyFunSuite
 import org.scalatest.matchers.should.Matchers
 
-import scala.jdk.CollectionConverters._
 class S3ConsumerGroupsSinkConfigTest extends AnyFunSuite with Matchers {
   test("creates an instance of S3ConsumerGroupsSinkConfig") {
     S3ConsumerGroupsSinkConfig.fromProps(
@@ -37,7 +36,7 @@ class S3ConsumerGroupsSinkConfigTest extends AnyFunSuite with Matchers {
         AWS_SECRET_KEY   -> "secret",
         AUTH_MODE        -> "credentials",
         CUSTOM_ENDPOINT  -> "endpoint",
-      ).asJava,
+      ),
     ) match {
       case Left(value) => fail("Expecting to build a config but got an error instead.", value)
       case Right(value) =>
@@ -71,7 +70,7 @@ class S3ConsumerGroupsSinkConfigTest extends AnyFunSuite with Matchers {
         AWS_SECRET_KEY   -> "secret",
         AUTH_MODE        -> "credentials",
         CUSTOM_ENDPOINT  -> "endpoint",
-      ).asJava,
+      ),
     ) match {
       case Left(value) => fail("Expecting to build a config but got an error instead.", value)
       case Right(value) =>

--- a/kafka-connect-aws-s3/src/test/scala/io/lenses/streamreactor/connect/aws/s3/sink/config/S3S3S3SinkConfigDefBuilderTest.scala
+++ b/kafka-connect-aws-s3/src/test/scala/io/lenses/streamreactor/connect/aws/s3/sink/config/S3S3S3SinkConfigDefBuilderTest.scala
@@ -32,7 +32,6 @@ import org.scalatest.matchers.should.Matchers
 
 import scala.concurrent.duration.DurationInt
 import scala.jdk.CollectionConverters.IteratorHasAsScala
-import scala.jdk.CollectionConverters.MapHasAsJava
 
 class S3S3S3SinkConfigDefBuilderTest extends AnyFlatSpec with MockitoSugar with Matchers with EitherValues {
 
@@ -48,7 +47,7 @@ class S3S3S3SinkConfigDefBuilderTest extends AnyFlatSpec with MockitoSugar with 
       "connect.s3.kcql" -> s"insert into $BucketName:$PrefixName select * from $TopicName PARTITIONBY _key STOREAS `CSV` WITHPARTITIONER=Values WITH_FLUSH_COUNT = 1",
     )
 
-    val kcql = S3SinkConfigDefBuilder(props.asJava).getKCQL
+    val kcql = S3SinkConfigDefBuilder(props).getKCQL
     kcql should have size 1
 
     val element = kcql.head
@@ -65,7 +64,7 @@ class S3S3S3SinkConfigDefBuilderTest extends AnyFlatSpec with MockitoSugar with 
       "connect.s3.kcql" -> s"insert into mybucket:myprefix select * from $TopicName PARTITIONBY _key STOREAS CSV WITHPARTITIONER=Values WITH_FLUSH_COUNT = 1",
     )
 
-    CloudSinkBucketOptions(S3SinkConfigDefBuilder(props.asJava)) match {
+    CloudSinkBucketOptions(S3SinkConfigDefBuilder(props)) match {
       case Left(value)  => fail(value.toString)
       case Right(value) => value.map(_.dataStorage) should be(List(DataStorageSettings.Default))
     }
@@ -76,7 +75,7 @@ class S3S3S3SinkConfigDefBuilderTest extends AnyFlatSpec with MockitoSugar with 
       "connect.s3.kcql" -> s"insert into mybucket:myprefix select * from $TopicName PARTITIONBY _key STOREAS `JSON` WITHPARTITIONER=Values WITH_FLUSH_COUNT = 1 PROPERTIES('${DataStorageSettings.StoreEnvelopeKey}'=true)",
     )
 
-    config.CloudSinkBucketOptions(S3SinkConfigDefBuilder(props.asJava)) match {
+    config.CloudSinkBucketOptions(S3SinkConfigDefBuilder(props)) match {
       case Left(value)  => fail(value.toString)
       case Right(value) => value.map(_.dataStorage) should be(List(DataStorageSettings.enabled))
     }
@@ -87,7 +86,7 @@ class S3S3S3SinkConfigDefBuilderTest extends AnyFlatSpec with MockitoSugar with 
       "connect.s3.kcql" -> s"insert into mybucket:myprefix select * from $TopicName PARTITIONBY _key STOREAS `PARQUET` WITHPARTITIONER=Values WITH_FLUSH_COUNT = 1 PROPERTIES('${DataStorageSettings.StoreEnvelopeKey}'=true, '${DataStorageSettings.StoreKeyKey}'=true, '${DataStorageSettings.StoreValueKey}'=true, '${DataStorageSettings.StoreMetadataKey}'=false, '${DataStorageSettings.StoreHeadersKey}'=false)",
     )
 
-    config.CloudSinkBucketOptions(S3SinkConfigDefBuilder(props.asJava)) match {
+    config.CloudSinkBucketOptions(S3SinkConfigDefBuilder(props)) match {
       case Left(value) => fail(value.toString)
       case Right(value) =>
         value.map(_.dataStorage) should be(List(DataStorageSettings(true, true, true, false, false)))
@@ -116,7 +115,7 @@ class S3S3S3SinkConfigDefBuilderTest extends AnyFlatSpec with MockitoSugar with 
            |""".stripMargin,
     )
 
-    config.CloudSinkBucketOptions(S3SinkConfigDefBuilder(props.asJava)) match {
+    config.CloudSinkBucketOptions(S3SinkConfigDefBuilder(props)) match {
       case Left(value) => fail(value.toString)
       case Right(value) =>
         value.map(_.dataStorage) should be(List(DataStorageSettings(true, true, true, false, false),
@@ -131,7 +130,7 @@ class S3S3S3SinkConfigDefBuilderTest extends AnyFlatSpec with MockitoSugar with 
     )
 
     val commitPolicy =
-      S3SinkConfigDefBuilder(props.asJava).commitPolicy(S3SinkConfigDefBuilder(props.asJava).getKCQL.head)
+      S3SinkConfigDefBuilder(props).commitPolicy(S3SinkConfigDefBuilder(props).getKCQL.head)
 
     commitPolicy.conditions should be(
       Seq(
@@ -149,7 +148,7 @@ class S3S3S3SinkConfigDefBuilderTest extends AnyFlatSpec with MockitoSugar with 
     )
 
     val commitPolicy =
-      S3SinkConfigDefBuilder(props.asJava).commitPolicy(S3SinkConfigDefBuilder(props.asJava).getKCQL.head)
+      S3SinkConfigDefBuilder(props).commitPolicy(S3SinkConfigDefBuilder(props).getKCQL.head)
 
     commitPolicy.conditions should be(
       Seq(
@@ -165,7 +164,7 @@ class S3S3S3SinkConfigDefBuilderTest extends AnyFlatSpec with MockitoSugar with 
     )
 
     val commitPolicy =
-      S3SinkConfigDefBuilder(props.asJava).commitPolicy(S3SinkConfigDefBuilder(props.asJava).getKCQL.head)
+      S3SinkConfigDefBuilder(props).commitPolicy(S3SinkConfigDefBuilder(props).getKCQL.head)
 
     commitPolicy.conditions should be(
       Seq(
@@ -181,7 +180,7 @@ class S3S3S3SinkConfigDefBuilderTest extends AnyFlatSpec with MockitoSugar with 
       "connect.s3.kcql" -> s"insert into $BucketName:$PrefixName select * from $TopicName BATCH = 150 STOREAS `CSV` LIMIT 550",
     )
 
-    val kcql = S3SinkConfigDefBuilder(props.asJava).getKCQL
+    val kcql = S3SinkConfigDefBuilder(props).getKCQL
 
     kcql.head.getBatchSize should be(150)
     kcql.head.getLimit should be(550)
@@ -192,7 +191,7 @@ class S3S3S3SinkConfigDefBuilderTest extends AnyFlatSpec with MockitoSugar with 
       "connect.s3.kcql" -> s"insert into $BucketName:$PrefixName select * from $TopicName STOREAS `JSON` WITH_FLUSH_COUNT = 1 PROPERTIES('${DataStorageSettings.StoreEnvelopeKey}'=true, '${DataStorageSettings.StoreKeyKey}'=true, '${DataStorageSettings.StoreValueKey}'=true, '${DataStorageSettings.StoreMetadataKey}'=false, '${DataStorageSettings.StoreHeadersKey}'=false)",
     )
 
-    config.CloudSinkBucketOptions(S3SinkConfigDefBuilder(props.asJava)) match {
+    config.CloudSinkBucketOptions(S3SinkConfigDefBuilder(props)) match {
       case Left(value) => fail(value.toString)
       case Right(value) =>
         value.map(_.dataStorage) should be(List(DataStorageSettings(envelope = true,
@@ -209,7 +208,7 @@ class S3S3S3SinkConfigDefBuilderTest extends AnyFlatSpec with MockitoSugar with 
       "connect.s3.kcql" -> s"insert into $BucketName:$PrefixName select * from $TopicName STOREAS `JSON` WITH_FLUSH_COUNT = 1 PROPERTIES('${DataStorageSettings.StoreEnvelopeKey}'=true, '${DataStorageSettings.StoreKeyKey}'=true, '${DataStorageSettings.StoreValueKey}'=true, '${DataStorageSettings.StoreMetadataKey}'=false, '${DataStorageSettings.StoreHeadersKey}'=false)",
     )
 
-    config.CloudSinkBucketOptions(S3SinkConfigDefBuilder(props.asJava)) match {
+    config.CloudSinkBucketOptions(S3SinkConfigDefBuilder(props)) match {
       case Left(value) => fail(value.toString)
       case Right(value) =>
         value.map(_.dataStorage) should be(List(DataStorageSettings(envelope = true,
@@ -226,7 +225,7 @@ class S3S3S3SinkConfigDefBuilderTest extends AnyFlatSpec with MockitoSugar with 
       "connect.s3.kcql" -> s"insert into $BucketName:$PrefixName select * from $TopicName STOREAS `BYTES_VALUEONLY` WITH_FLUSH_COUNT = 1",
     )
 
-    config.CloudSinkBucketOptions(S3SinkConfigDefBuilder(props.asJava)).left.value.getMessage should startWith(
+    config.CloudSinkBucketOptions(S3SinkConfigDefBuilder(props)).left.value.getMessage should startWith(
       "Unsupported format - BYTES_VALUEONLY.  Please note",
     )
   }
@@ -236,7 +235,7 @@ class S3S3S3SinkConfigDefBuilderTest extends AnyFlatSpec with MockitoSugar with 
       "connect.s3.kcql" -> s"insert into $BucketName:$PrefixName select * from $TopicName STOREAS `BYTES` WITH_FLUSH_COUNT = 3",
     )
 
-    config.CloudSinkBucketOptions(S3SinkConfigDefBuilder(props.asJava)).left.value.getMessage should startWith(
+    config.CloudSinkBucketOptions(S3SinkConfigDefBuilder(props)).left.value.getMessage should startWith(
       "FLUSH_COUNT > 1 is not allowed for BYTES",
     )
   }

--- a/kafka-connect-aws-s3/src/test/scala/io/lenses/streamreactor/connect/aws/s3/sink/config/S3SinkConfigDefBuilderTest.scala
+++ b/kafka-connect-aws-s3/src/test/scala/io/lenses/streamreactor/connect/aws/s3/sink/config/S3SinkConfigDefBuilderTest.scala
@@ -33,7 +33,7 @@ import org.scalatest.matchers.should.Matchers
 import scala.concurrent.duration.DurationInt
 import scala.jdk.CollectionConverters.IteratorHasAsScala
 
-class S3S3S3SinkConfigDefBuilderTest extends AnyFlatSpec with MockitoSugar with Matchers with EitherValues {
+class S3SinkConfigDefBuilderTest extends AnyFlatSpec with MockitoSugar with Matchers with EitherValues {
 
   val PrefixName = "streamReactorBackups"
   val TopicName  = "myTopic"

--- a/kafka-connect-aws-s3/src/test/scala/io/lenses/streamreactor/connect/aws/s3/sink/config/S3SinkConfigTest.scala
+++ b/kafka-connect-aws-s3/src/test/scala/io/lenses/streamreactor/connect/aws/s3/sink/config/S3SinkConfigTest.scala
@@ -24,8 +24,6 @@ import io.lenses.streamreactor.connect.cloud.common.sink.config.CloudSinkBucketO
 import org.scalatest.funsuite.AnyFunSuite
 import org.scalatest.matchers.should.Matchers
 
-import scala.jdk.CollectionConverters.MapHasAsJava
-
 class S3SinkConfigTest extends AnyFunSuite with Matchers {
   private implicit val connectorTaskId = ConnectorTaskId("connector", 1, 0)
   private implicit val cloudLocationValidator: CloudLocationValidator = S3LocationValidator
@@ -34,7 +32,7 @@ class S3SinkConfigTest extends AnyFunSuite with Matchers {
       "connect.s3.kcql" -> s"insert into mybucket:myprefix select * from TopicName PARTITIONBY _key STOREAS `CSV` WITHPARTITIONER=Values WITH_FLUSH_COUNT = 1 PROPERTIES('${DataStorageSettings.StoreEnvelopeKey}'=true)",
     )
 
-    CloudSinkBucketOptions(S3SinkConfigDefBuilder(props.asJava)) match {
+    CloudSinkBucketOptions(S3SinkConfigDefBuilder(props)) match {
       case Left(value) => value.getMessage shouldBe "Envelope is not supported for format CSV."
       case Right(_)    => fail("Should fail since envelope and CSV storage is not allowed")
     }
@@ -45,7 +43,7 @@ class S3SinkConfigTest extends AnyFunSuite with Matchers {
       "connect.s3.kcql" -> s"insert into mybucket:myprefix select * from TopicName PARTITIONBY _key STOREAS `Parquet` WITHPARTITIONER=Values WITH_FLUSH_COUNT = 1 PROPERTIES('${DataStorageSettings.StoreEnvelopeKey}'=true)",
     )
 
-    config.CloudSinkBucketOptions(S3SinkConfigDefBuilder(props.asJava)) match {
+    config.CloudSinkBucketOptions(S3SinkConfigDefBuilder(props)) match {
       case Left(error) => fail("Should not fail since envelope and Parquet storage is allowed", error)
       case Right(_)    => succeed
     }
@@ -55,7 +53,7 @@ class S3SinkConfigTest extends AnyFunSuite with Matchers {
       "connect.s3.kcql" -> s"insert into mybucket:myprefix select * from TopicName PARTITIONBY _key STOREAS `Avro` WITHPARTITIONER=Values WITH_FLUSH_COUNT = 1 PROPERTIES('${DataStorageSettings.StoreEnvelopeKey}'=true)",
     )
 
-    config.CloudSinkBucketOptions(S3SinkConfigDefBuilder(props.asJava)) match {
+    config.CloudSinkBucketOptions(S3SinkConfigDefBuilder(props)) match {
       case Left(error) => fail("Should not fail since envelope and Avro storage is allowed", error)
       case Right(_)    => succeed
     }
@@ -65,7 +63,7 @@ class S3SinkConfigTest extends AnyFunSuite with Matchers {
       "connect.s3.kcql" -> s"insert into mybucket:myprefix select * from TopicName PARTITIONBY _key STOREAS `Json` WITHPARTITIONER=Values WITH_FLUSH_COUNT = 1 PROPERTIES('${DataStorageSettings.StoreEnvelopeKey}'=true)",
     )
 
-    config.CloudSinkBucketOptions(S3SinkConfigDefBuilder(props.asJava)) match {
+    config.CloudSinkBucketOptions(S3SinkConfigDefBuilder(props)) match {
       case Left(error) => fail("Should not fail since envelope and Json storage is allowed", error)
       case Right(_)    => succeed
     }
@@ -75,7 +73,7 @@ class S3SinkConfigTest extends AnyFunSuite with Matchers {
       "connect.s3.kcql" -> s"insert into mybucket:myprefix select * from TopicName PARTITIONBY _key STOREAS `Text` WITHPARTITIONER=Values WITH_FLUSH_COUNT = 1 PROPERTIES('${DataStorageSettings.StoreEnvelopeKey}'=true)",
     )
 
-    config.CloudSinkBucketOptions(S3SinkConfigDefBuilder(props.asJava)) match {
+    config.CloudSinkBucketOptions(S3SinkConfigDefBuilder(props)) match {
       case Left(value) => value.getMessage shouldBe "Envelope is not supported for format TEXT."
       case Right(_)    => fail("Should fail since text and envelope storage is not allowed")
     }
@@ -85,7 +83,7 @@ class S3SinkConfigTest extends AnyFunSuite with Matchers {
       "connect.s3.kcql" -> s"insert into mybucket:myprefix select * from TopicName PARTITIONBY _key STOREAS `Bytes` WITHPARTITIONER=Values WITH_FLUSH_COUNT = 1 PROPERTIES('${DataStorageSettings.StoreEnvelopeKey}'=true)",
     )
 
-    config.CloudSinkBucketOptions(S3SinkConfigDefBuilder(props.asJava)) match {
+    config.CloudSinkBucketOptions(S3SinkConfigDefBuilder(props)) match {
       case Left(value) => value.getMessage shouldBe "Envelope is not supported for format BYTES."
       case Right(_)    => fail("Should fail since envelope and bytes storage is not allowed")
     }

--- a/kafka-connect-aws-s3/src/test/scala/io/lenses/streamreactor/connect/aws/s3/source/config/DeleteModeSettingsTest.scala
+++ b/kafka-connect-aws-s3/src/test/scala/io/lenses/streamreactor/connect/aws/s3/source/config/DeleteModeSettingsTest.scala
@@ -20,8 +20,6 @@ import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.prop.TableDrivenPropertyChecks._
 
-import scala.jdk.CollectionConverters.MapHasAsJava
-
 class DeleteModeSettingsTest extends AnyFlatSpec with Matchers with LazyLogging {
   private val deleteModeMap = Table[String, String, Boolean](
     ("testName", "value", "expected"),
@@ -36,7 +34,7 @@ class DeleteModeSettingsTest extends AnyFlatSpec with Matchers with LazyLogging 
         S3SourceConfigDefBuilder(Map(
           "connect.s3.kcql"        -> "abc",
           "connect.s3.delete.mode" -> value,
-        ).asJava).batchDelete() should be(expected)
+        )).batchDelete() should be(expected)
     }
   }
 }

--- a/kafka-connect-aws-s3/src/test/scala/io/lenses/streamreactor/connect/aws/s3/source/config/S3SourceConfigTest.scala
+++ b/kafka-connect-aws-s3/src/test/scala/io/lenses/streamreactor/connect/aws/s3/source/config/S3SourceConfigTest.scala
@@ -21,8 +21,6 @@ import io.lenses.streamreactor.connect.cloud.common.config.TaskIndexKey
 import org.scalatest.funsuite.AnyFunSuite
 import org.scalatest.matchers.should.Matchers
 
-import scala.jdk.CollectionConverters.MapHasAsJava
-
 class S3SourceConfigTest extends AnyFunSuite with Matchers with TaskIndexKey with SourcePartitionSearcherSettingsKeys {
   private val Identity:   String = "identity"
   private val Credential: String = "credential"
@@ -55,7 +53,7 @@ class S3SourceConfigTest extends AnyFunSuite with Matchers with TaskIndexKey wit
       "connect.s3.partition.search.recurse.levels" -> "0",
     )
 
-    S3SourceConfig(S3SourceConfigDefBuilder(props.asJava)) match {
+    S3SourceConfig(S3SourceConfigDefBuilder(props)) match {
       case Left(value) => fail(value.toString)
       case Right(config) =>
         config.bucketOptions.size shouldBe 3

--- a/kafka-connect-aws-s3/src/test/scala/io/lenses/streamreactor/connect/aws/s3/source/config/S3SourceConfigTests.scala
+++ b/kafka-connect-aws-s3/src/test/scala/io/lenses/streamreactor/connect/aws/s3/source/config/S3SourceConfigTests.scala
@@ -23,7 +23,6 @@ import org.scalatest.funsuite.AnyFunSuite
 import org.scalatest.matchers.should.Matchers
 
 import scala.concurrent.duration._
-import scala.jdk.CollectionConverters._
 
 class S3SourceConfigTests extends AnyFunSuite with Matchers with TaskIndexKey with SourcePartitionSearcherSettingsKeys {
   test("default recursive levels is 0") {
@@ -33,7 +32,7 @@ class S3SourceConfigTests extends AnyFunSuite with Matchers with TaskIndexKey wi
         SOURCE_PARTITION_SEARCH_INTERVAL_MILLIS -> "1000",
         TASK_INDEX                              -> "1:0",
         KCQL_CONFIG                             -> "INSERT INTO topic SELECT * FROM bucket:/a/b/c",
-      ).asJava,
+      ),
     ) match {
       case Left(value) => fail(value.toString)
       case Right(value) =>
@@ -48,7 +47,7 @@ class S3SourceConfigTests extends AnyFunSuite with Matchers with TaskIndexKey wi
         SOURCE_PARTITION_SEARCH_INTERVAL_MILLIS -> "1000",
         TASK_INDEX                              -> "1:0",
         KCQL_CONFIG                             -> "INSERT INTO topic SELECT * FROM bucket:/a/b/c",
-      ).asJava,
+      ),
     ) match {
       case Left(value) => fail(value.toString)
       case Right(value) =>
@@ -63,7 +62,7 @@ class S3SourceConfigTests extends AnyFunSuite with Matchers with TaskIndexKey wi
         SOURCE_PARTITION_SEARCH_INTERVAL_MILLIS -> "1000",
         TASK_INDEX                              -> "1:0",
         KCQL_CONFIG                             -> "INSERT INTO topic SELECT * FROM bucket:/a/b/c",
-      ).asJava,
+      ),
     ) match {
       case Left(value) => fail(value.toString)
       case Right(value) =>
@@ -77,7 +76,7 @@ class S3SourceConfigTests extends AnyFunSuite with Matchers with TaskIndexKey wi
         SOURCE_PARTITION_SEARCH_INTERVAL_MILLIS -> "1000",
         TASK_INDEX                              -> "1:0",
         KCQL_CONFIG                             -> "INSERT INTO topic SELECT * FROM bucket:/a/b/c",
-      ).asJava,
+      ),
     ) match {
       case Left(value) => fail(value.toString)
       case Right(value) =>

--- a/kafka-connect-azure-datalake/src/main/scala/io/lenses/streamreactor/connect/datalake/sink/DatalakeSinkTask.scala
+++ b/kafka-connect-azure-datalake/src/main/scala/io/lenses/streamreactor/connect/datalake/sink/DatalakeSinkTask.scala
@@ -28,7 +28,6 @@ import io.lenses.streamreactor.connect.datalake.sink.config.DatalakeSinkConfig
 import io.lenses.streamreactor.connect.datalake.storage.DatalakeFileMetadata
 import io.lenses.streamreactor.connect.datalake.storage.DatalakeStorageInterface
 
-import scala.jdk.CollectionConverters.MapHasAsJava
 import scala.util.Try
 object DatalakeSinkTask {}
 class DatalakeSinkTask
@@ -44,7 +43,7 @@ class DatalakeSinkTask
 
   def createWriterMan(props: Map[String, String]): Either[Throwable, WriterManager[DatalakeFileMetadata]] =
     for {
-      config          <- DatalakeSinkConfig.fromProps(props.asJava)
+      config          <- DatalakeSinkConfig.fromProps(props)
       s3Client        <- DatalakeClientCreator.make(config.s3Config)
       storageInterface = new DatalakeStorageInterface(connectorTaskId, s3Client)
       _               <- Try(setErrorRetryInterval(config.s3Config)).toEither

--- a/kafka-connect-azure-datalake/src/main/scala/io/lenses/streamreactor/connect/datalake/sink/config/DatalakeSinkConfig.scala
+++ b/kafka-connect-azure-datalake/src/main/scala/io/lenses/streamreactor/connect/datalake/sink/config/DatalakeSinkConfig.scala
@@ -24,12 +24,10 @@ import io.lenses.streamreactor.connect.cloud.common.sink.config.OffsetSeekerOpti
 import io.lenses.streamreactor.connect.datalake.config.AzureConfig
 import io.lenses.streamreactor.connect.datalake.config.AzureConfigSettings.SEEK_MAX_INDEX_FILES
 
-import java.util
-
 object DatalakeSinkConfig {
 
   def fromProps(
-    props: util.Map[String, String],
+    props: Map[String, String],
   )(
     implicit
     connectorTaskId:        ConnectorTaskId,

--- a/kafka-connect-azure-datalake/src/main/scala/io/lenses/streamreactor/connect/datalake/sink/config/DatalakeSinkConfigDefBuilder.scala
+++ b/kafka-connect-azure-datalake/src/main/scala/io/lenses/streamreactor/connect/datalake/sink/config/DatalakeSinkConfigDefBuilder.scala
@@ -20,10 +20,9 @@ import io.lenses.streamreactor.connect.cloud.common.sink.config.CloudSinkConfigD
 import io.lenses.streamreactor.connect.datalake.config.AuthModeSettings
 import io.lenses.streamreactor.connect.datalake.config.AzureConfigSettings
 
-import java.util
 import scala.jdk.CollectionConverters.MapHasAsScala
 
-case class DatalakeSinkConfigDefBuilder(props: util.Map[String, String])
+case class DatalakeSinkConfigDefBuilder(props: Map[String, String])
     extends BaseConfig(AzureConfigSettings.CONNECTOR_PREFIX, DatalakeSinkConfigDef.config, props)
     with CloudSinkConfigDefBuilder
     with ErrorPolicySettings

--- a/kafka-connect-azure-documentdb/src/main/scala/io/lenses/streamreactor/connect/azure/documentdb/config/DocumentDbConfig.scala
+++ b/kafka-connect-azure-documentdb/src/main/scala/io/lenses/streamreactor/connect/azure/documentdb/config/DocumentDbConfig.scala
@@ -22,7 +22,6 @@ import io.lenses.streamreactor.common.config.base.traits.ErrorPolicySettings
 import io.lenses.streamreactor.common.config.base.traits.KcqlSettings
 import io.lenses.streamreactor.common.config.base.traits.NumberRetriesSettings
 
-import java.util
 import com.microsoft.azure.documentdb.ConsistencyLevel
 import org.apache.kafka.common.config.ConfigDef
 import org.apache.kafka.common.config.ConfigDef.Importance
@@ -149,7 +148,7 @@ object DocumentDbConfig {
     )
 }
 
-case class DocumentDbConfig(props: util.Map[String, String])
+case class DocumentDbConfig(props: Map[String, String])
     extends BaseConfig(DocumentDbConfigConstants.CONNECTOR_PREFIX, DocumentDbConfig.config, props)
     with KcqlSettings
     with DatabaseSettings

--- a/kafka-connect-azure-documentdb/src/main/scala/io/lenses/streamreactor/connect/azure/documentdb/sink/DocumentDbSinkConnector.scala
+++ b/kafka-connect-azure-documentdb/src/main/scala/io/lenses/streamreactor/connect/azure/documentdb/sink/DocumentDbSinkConnector.scala
@@ -90,7 +90,7 @@ class DocumentDbSinkConnector private[sink] (builder: DocumentDbSinkSettings => 
     * @param props A map of properties for the connector and worker
     */
   override def start(props: util.Map[String, String]): Unit = {
-    val config = Try(DocumentDbConfig(props)) match {
+    val config = Try(DocumentDbConfig(props.asScala.toMap)) match {
       case Failure(f) =>
         throw new ConnectException(s"Couldn't start Azure DocumentDb sink due to configuration error: ${f.getMessage}",
                                    f,

--- a/kafka-connect-azure-documentdb/src/main/scala/io/lenses/streamreactor/connect/azure/documentdb/sink/DocumentDbSinkTask.scala
+++ b/kafka-connect-azure-documentdb/src/main/scala/io/lenses/streamreactor/connect/azure/documentdb/sink/DocumentDbSinkTask.scala
@@ -29,6 +29,7 @@ import org.apache.kafka.connect.sink.SinkTask
 
 import java.util
 import scala.jdk.CollectionConverters.CollectionHasAsScala
+import scala.jdk.CollectionConverters.MapHasAsScala
 import scala.util.Failure
 import scala.util.Success
 import scala.util.Try
@@ -52,7 +53,7 @@ class DocumentDbSinkTask extends SinkTask with StrictLogging {
   override def start(props: util.Map[String, String]): Unit = {
     val config = if (context.configs().isEmpty) props else context.configs()
 
-    val taskConfig = Try(DocumentDbConfig(config)) match {
+    val taskConfig = Try(DocumentDbConfig(config.asScala.toMap)) match {
       case Failure(f) =>
         throw new ConnectException("Couldn't start Azure Document DB Sink due to configuration error.", f)
       case Success(s) => s

--- a/kafka-connect-azure-documentdb/src/test/scala/io/lenses/streamreactor/connect/azure/documentdb/config/DocumentDbSinkSettingsTest.scala
+++ b/kafka-connect-azure-documentdb/src/test/scala/io/lenses/streamreactor/connect/azure/documentdb/config/DocumentDbSinkSettingsTest.scala
@@ -20,8 +20,6 @@ import org.apache.kafka.common.config.ConfigException
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 
-import scala.jdk.CollectionConverters.MapHasAsJava
-
 class DocumentDbSinkSettingsTest extends AnyWordSpec with Matchers {
   private val connection = "https://accountName.documents.azure.com:443/"
 
@@ -31,7 +29,7 @@ class DocumentDbSinkSettingsTest extends AnyWordSpec with Matchers {
         DocumentDbConfigConstants.DATABASE_CONFIG   -> "dbs/database1",
         DocumentDbConfigConstants.CONNECTION_CONFIG -> connection,
         DocumentDbConfigConstants.KCQL_CONFIG       -> "INSERT INTO collection1 SELECT * FROM topic1",
-      ).asJava
+      )
 
       intercept[ConfigException] {
         DocumentDbConfig(map)
@@ -43,7 +41,7 @@ class DocumentDbSinkSettingsTest extends AnyWordSpec with Matchers {
         DocumentDbConfigConstants.DATABASE_CONFIG   -> "dbs/database1",
         DocumentDbConfigConstants.MASTER_KEY_CONFIG -> "secret",
         DocumentDbConfigConstants.KCQL_CONFIG       -> "INSERT INTO collection1 SELECT * FROM topic1",
-      ).asJava
+      )
 
       intercept[ConfigException] {
         DocumentDbConfig(map)
@@ -57,7 +55,7 @@ class DocumentDbSinkSettingsTest extends AnyWordSpec with Matchers {
         DocumentDbConfigConstants.CONNECTION_CONFIG -> connection,
         DocumentDbConfigConstants.MASTER_KEY_CONFIG -> "secret",
         DocumentDbConfigConstants.KCQL_CONFIG       -> "INSERT INTO collection1 SELECT * FROM topic1;INSERT INTO coll2 SELECT a as F1, b as F2 FROM topic2",
-      ).asJava
+      )
 
       val config   = DocumentDbConfig(map)
       val settings = DocumentDbSinkSettings(config)
@@ -75,7 +73,7 @@ class DocumentDbSinkSettingsTest extends AnyWordSpec with Matchers {
         DocumentDbConfigConstants.CONNECTION_CONFIG -> connection,
         DocumentDbConfigConstants.MASTER_KEY_CONFIG -> "secret",
         DocumentDbConfigConstants.KCQL_CONFIG       -> "INSERT INTO collection1 SELECT * FROM topic1 IGNORE a,b,c",
-      ).asJava
+      )
 
       val config   = DocumentDbConfig(map)
       val settings = DocumentDbSinkSettings(config)
@@ -94,7 +92,7 @@ class DocumentDbSinkSettingsTest extends AnyWordSpec with Matchers {
         DocumentDbConfigConstants.CONNECTION_CONFIG -> connection,
         DocumentDbConfigConstants.MASTER_KEY_CONFIG -> "secret",
         DocumentDbConfigConstants.KCQL_CONFIG       -> "INSERT INTO collection1 SELECT * FROM topic1 PK a,b",
-      ).asJava
+      )
 
       val config   = DocumentDbConfig(map)
       val settings = DocumentDbSinkSettings(config)
@@ -112,7 +110,7 @@ class DocumentDbSinkSettingsTest extends AnyWordSpec with Matchers {
         DocumentDbConfigConstants.MASTER_KEY_CONFIG  -> "secret",
         DocumentDbConfigConstants.CONSISTENCY_CONFIG -> "invalid",
         DocumentDbConfigConstants.KCQL_CONFIG        -> "INSERT INTO collection1 SELECT * FROM topic1 PK a,b",
-      ).asJava
+      )
 
       val config = DocumentDbConfig(map)
       intercept[ConfigException] {
@@ -126,7 +124,7 @@ class DocumentDbSinkSettingsTest extends AnyWordSpec with Matchers {
         DocumentDbConfigConstants.CONNECTION_CONFIG -> connection,
         DocumentDbConfigConstants.MASTER_KEY_CONFIG -> "secret",
         DocumentDbConfigConstants.KCQL_CONFIG       -> "INSERT INTO  SELECT * FROM topic1",
-      ).asJava
+      )
 
       val config = DocumentDbConfig(map)
       intercept[IllegalArgumentException] {
@@ -140,7 +138,7 @@ class DocumentDbSinkSettingsTest extends AnyWordSpec with Matchers {
         DocumentDbConfigConstants.CONNECTION_CONFIG -> connection,
         DocumentDbConfigConstants.MASTER_KEY_CONFIG -> "secret",
         DocumentDbConfigConstants.KCQL_CONFIG       -> "INSERT INTO collection1 SELECT * FROM topic1",
-      ).asJava
+      )
 
       val config = DocumentDbConfig(map)
       intercept[ConfigException] {

--- a/kafka-connect-azure-documentdb/src/test/scala/io/lenses/streamreactor/connect/azure/documentdb/sink/DocumentDbSinkTaskJsonTest.scala
+++ b/kafka-connect-azure-documentdb/src/test/scala/io/lenses/streamreactor/connect/azure/documentdb/sink/DocumentDbSinkTaskJsonTest.scala
@@ -27,8 +27,6 @@ import org.mockito.MockitoSugar
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 
-import scala.jdk.CollectionConverters.MapHasAsJava
-
 class DocumentDbSinkTaskJsonTest extends AnyWordSpec with Matchers with MockitoSugar with MatchingArgument {
   private val connection = "https://accountName.documents.azure.com:443/"
 
@@ -39,7 +37,7 @@ class DocumentDbSinkTaskJsonTest extends AnyWordSpec with Matchers with MockitoS
         DocumentDbConfigConstants.CONNECTION_CONFIG -> connection,
         DocumentDbConfigConstants.MASTER_KEY_CONFIG -> "secret",
         DocumentDbConfigConstants.KCQL_CONFIG       -> "INSERT INTO coll1 SELECT * FROM topic1;INSERT INTO coll2 SELECT * FROM topic2",
-      ).asJava
+      )
 
       val documentClient = mock[DocumentClient]
       val dbResource: ResourceResponse[Database] = mock[ResourceResponse[Database]]
@@ -142,7 +140,7 @@ class DocumentDbSinkTaskJsonTest extends AnyWordSpec with Matchers with MockitoS
         DocumentDbConfigConstants.MASTER_KEY_CONFIG  -> "secret",
         DocumentDbConfigConstants.CONSISTENCY_CONFIG -> ConsistencyLevel.Eventual.toString,
         DocumentDbConfigConstants.KCQL_CONFIG        -> "INSERT INTO coll1 SELECT * FROM topic1;INSERT INTO coll2 SELECT * FROM topic2",
-      ).asJava
+      )
 
       val documentClient = mock[DocumentClient]
       val dbResource: ResourceResponse[Database] = mock[ResourceResponse[Database]]
@@ -245,7 +243,7 @@ class DocumentDbSinkTaskJsonTest extends AnyWordSpec with Matchers with MockitoS
         DocumentDbConfigConstants.MASTER_KEY_CONFIG  -> "secret",
         DocumentDbConfigConstants.CONSISTENCY_CONFIG -> ConsistencyLevel.Eventual.toString,
         DocumentDbConfigConstants.KCQL_CONFIG        -> "UPSERT INTO coll1 SELECT * FROM topic1 PK time",
-      ).asJava
+      )
 
       val documentClient = mock[DocumentClient]
       val dbResource: ResourceResponse[Database] = mock[ResourceResponse[Database]]

--- a/kafka-connect-azure-documentdb/src/test/scala/io/lenses/streamreactor/connect/azure/documentdb/sink/DocumentDbSinkTaskMapTest.scala
+++ b/kafka-connect-azure-documentdb/src/test/scala/io/lenses/streamreactor/connect/azure/documentdb/sink/DocumentDbSinkTaskMapTest.scala
@@ -27,8 +27,6 @@ import org.mockito.MockitoSugar
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 
-import scala.jdk.CollectionConverters.MapHasAsJava
-
 class DocumentDbSinkTaskMapTest extends AnyWordSpec with Matchers with MockitoSugar with MatchingArgument {
   private val connection = "https://accountName.documents.azure.com:443/"
 
@@ -43,7 +41,7 @@ class DocumentDbSinkTaskMapTest extends AnyWordSpec with Matchers with MockitoSu
         DocumentDbConfigConstants.CONNECTION_CONFIG -> connection,
         DocumentDbConfigConstants.MASTER_KEY_CONFIG -> "secret",
         DocumentDbConfigConstants.KCQL_CONFIG       -> "INSERT INTO coll1 SELECT * FROM topic1;INSERT INTO coll2 SELECT * FROM topic2",
-      ).asJava
+      )
 
       val documentClient = mock[DocumentClient]
       val dbResource: ResourceResponse[Database] = mock[ResourceResponse[Database]]
@@ -153,7 +151,7 @@ class DocumentDbSinkTaskMapTest extends AnyWordSpec with Matchers with MockitoSu
         DocumentDbConfigConstants.MASTER_KEY_CONFIG  -> "secret",
         DocumentDbConfigConstants.CONSISTENCY_CONFIG -> ConsistencyLevel.Eventual.toString,
         DocumentDbConfigConstants.KCQL_CONFIG        -> "INSERT INTO coll1 SELECT * FROM topic1;INSERT INTO coll2 SELECT * FROM topic2",
-      ).asJava
+      )
 
       val documentClient = mock[DocumentClient]
       val dbResource: ResourceResponse[Database] = mock[ResourceResponse[Database]]
@@ -265,7 +263,7 @@ class DocumentDbSinkTaskMapTest extends AnyWordSpec with Matchers with MockitoSu
         DocumentDbConfigConstants.MASTER_KEY_CONFIG  -> "secret",
         DocumentDbConfigConstants.CONSISTENCY_CONFIG -> ConsistencyLevel.Eventual.toString,
         DocumentDbConfigConstants.KCQL_CONFIG        -> "UPSERT INTO coll1 SELECT * FROM topic1 PK time",
-      ).asJava
+      )
 
       val documentClient = mock[DocumentClient]
       val dbResource: ResourceResponse[Database] = mock[ResourceResponse[Database]]

--- a/kafka-connect-azure-documentdb/src/test/scala/io/lenses/streamreactor/connect/azure/documentdb/sink/DocumentDbSinkTaskStructTest.scala
+++ b/kafka-connect-azure-documentdb/src/test/scala/io/lenses/streamreactor/connect/azure/documentdb/sink/DocumentDbSinkTaskStructTest.scala
@@ -27,8 +27,6 @@ import org.mockito.MockitoSugar
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 
-import scala.jdk.CollectionConverters.MapHasAsJava
-
 class DocumentDbSinkTaskStructTest extends AnyWordSpec with Matchers with MockitoSugar with MatchingArgument {
   private val connection = "https://accountName.documents.azure.com:443/"
 
@@ -39,7 +37,7 @@ class DocumentDbSinkTaskStructTest extends AnyWordSpec with Matchers with Mockit
         DocumentDbConfigConstants.CONNECTION_CONFIG -> connection,
         DocumentDbConfigConstants.MASTER_KEY_CONFIG -> "secret",
         DocumentDbConfigConstants.KCQL_CONFIG       -> "INSERT INTO coll1 SELECT * FROM topic1;INSERT INTO coll2 SELECT * FROM topic2",
-      ).asJava
+      )
 
       val documentClient = mock[DocumentClient]
       val dbResource: ResourceResponse[Database] = mock[ResourceResponse[Database]]
@@ -143,7 +141,7 @@ class DocumentDbSinkTaskStructTest extends AnyWordSpec with Matchers with Mockit
         DocumentDbConfigConstants.MASTER_KEY_CONFIG  -> "secret",
         DocumentDbConfigConstants.CONSISTENCY_CONFIG -> ConsistencyLevel.Eventual.toString,
         DocumentDbConfigConstants.KCQL_CONFIG        -> "INSERT INTO coll1 SELECT * FROM topic1;INSERT INTO coll2 SELECT * FROM topic2",
-      ).asJava
+      )
 
       val documentClient = mock[DocumentClient]
       val dbResource: ResourceResponse[Database] = mock[ResourceResponse[Database]]
@@ -253,7 +251,7 @@ class DocumentDbSinkTaskStructTest extends AnyWordSpec with Matchers with Mockit
         DocumentDbConfigConstants.MASTER_KEY_CONFIG  -> "secret",
         DocumentDbConfigConstants.CONSISTENCY_CONFIG -> ConsistencyLevel.Eventual.toString,
         DocumentDbConfigConstants.KCQL_CONFIG        -> "UPSERT INTO coll1 SELECT * FROM topic1 PK time",
-      ).asJava
+      )
 
       val documentClient = mock[DocumentClient]
       val dbResource: ResourceResponse[Database] = mock[ResourceResponse[Database]]

--- a/kafka-connect-cassandra/src/it/scala/io/lenses/streamreactor/connect/cassandra/TestCassandraConnectionSecure.scala
+++ b/kafka-connect-cassandra/src/it/scala/io/lenses/streamreactor/connect/cassandra/TestCassandraConnectionSecure.scala
@@ -23,8 +23,6 @@ import org.scalatest.wordspec.AnyWordSpec
 import org.scalatest.DoNotDiscover
 import org.scalatest.Suite
 
-import scala.jdk.CollectionConverters.MapHasAsJava
-
 /**
   * Created by andrew@datamountaineer.com on 14/04/16.
   * stream-reactor
@@ -41,7 +39,7 @@ class TestCassandraConnectionSecure extends AnyWordSpec with Matchers with ItTes
       CassandraConfigConstants.USERNAME       -> "cassandra",
       CassandraConfigConstants.PASSWD         -> "cassandra",
       CassandraConfigConstants.KCQL           -> "INSERT INTO TABLE SELECT * FROM TOPIC",
-    ).asJava
+    )
 
     val taskConfig = CassandraConfigSink(props)
     val conn       = CassandraConnection(taskConfig)

--- a/kafka-connect-cassandra/src/it/scala/io/lenses/streamreactor/connect/cassandra/sink/TestCassandraJsonWriter.scala
+++ b/kafka-connect-cassandra/src/it/scala/io/lenses/streamreactor/connect/cassandra/sink/TestCassandraJsonWriter.scala
@@ -181,7 +181,7 @@ class TestCassandraJsonWriter
       CassandraConfigConstants.PASSWD         -> password,
       CassandraConfigConstants.KCQL           -> s"INSERT INTO $table SELECT id, int_field1, double_field1,timestamp_field1 FROM TOPICA; INSERT INTO $table1 SELECT id, int_field2, double_field2,timestamp_field2 FROM TOPICA",
       CassandraConfigConstants.ERROR_POLICY   -> ErrorPolicyEnum.NOOP.toString,
-    ).asJava
+    )
 
     val taskConfig = new CassandraConfigSink(props)
 
@@ -267,7 +267,7 @@ class TestCassandraJsonWriter
       CassandraConfigConstants.PASSWD         -> password,
       CassandraConfigConstants.KCQL           -> s"INSERT INTO $table SELECT * FROM TOPICA; INSERT INTO $table SELECT * FROM TOPICB",
       CassandraConfigConstants.ERROR_POLICY   -> ErrorPolicyEnum.THROW.toString,
-    ).asJava
+    )
 
     val taskConfig = new CassandraConfigSink(props)
 
@@ -335,7 +335,7 @@ class TestCassandraJsonWriter
       CassandraConfigConstants.PASSWD         -> password,
       CassandraConfigConstants.KCQL           -> s"INSERT INTO $table SELECT id, inner1.int_field, inner2.* FROM TOPIC",
       CassandraConfigConstants.ERROR_POLICY   -> ErrorPolicyEnum.NOOP.toString,
-    ).asJava
+    )
     val taskConfig = new CassandraConfigSink(props)
 
     val writer = CassandraWriter(taskConfig, context)
@@ -424,7 +424,7 @@ class TestCassandraJsonWriter
       CassandraConfigConstants.PASSWD         -> password,
       CassandraConfigConstants.KCQL           -> s"INSERT INTO $table SELECT id, inner1.int_field, inner2.* FROM TOPIC",
       CassandraConfigConstants.ERROR_POLICY   -> ErrorPolicyEnum.NOOP.toString,
-    ).asJava
+    )
 
     val taskConfig = new CassandraConfigSink(props)
 
@@ -475,7 +475,7 @@ class TestCassandraJsonWriter
       CassandraConfigConstants.USERNAME       -> userName,
       CassandraConfigConstants.PASSWD         -> password,
       CassandraConfigConstants.KCQL           -> kcql,
-    ).asJava
+    )
 
     val taskConfig = new CassandraConfigSink(props)
 
@@ -560,7 +560,7 @@ class TestCassandraJsonWriter
       CassandraConfigConstants.KCQL                 -> kcql,
       CassandraConfigConstants.ERROR_POLICY         -> ErrorPolicyEnum.RETRY.toString,
       CassandraConfigConstants.ERROR_RETRY_INTERVAL -> "500",
-    ).asJava
+    )
 
     val taskConfig = new CassandraConfigSink(props)
     val writer     = CassandraWriter(taskConfig, context)
@@ -619,7 +619,7 @@ class TestCassandraJsonWriter
       CassandraConfigConstants.PASSWD         -> password,
       CassandraConfigConstants.KCQL           -> kcql,
       CassandraConfigConstants.ERROR_POLICY   -> ErrorPolicyEnum.NOOP.toString,
-    ).asJava
+    )
 
     val taskConfig = new CassandraConfigSink(props)
     val writer     = CassandraWriter(taskConfig, context)
@@ -852,7 +852,7 @@ class TestCassandraJsonWriter
       CassandraConfigConstants.PASSWD               -> password,
       CassandraConfigConstants.KCQL                 -> kql,
       CassandraConfigConstants.DELETE_ROW_ENABLED   -> "true",
-    ).asJava
+    )
 
     val taskConfig = new CassandraConfigSink(props)
 
@@ -904,7 +904,7 @@ class TestCassandraJsonWriter
       CassandraConfigConstants.PASSWD               -> password,
       CassandraConfigConstants.KCQL                 -> kql,
       CassandraConfigConstants.DELETE_ROW_ENABLED   -> "true",
-    ).asJava
+    )
 
     val taskConfig = new CassandraConfigSink(props)
 
@@ -967,7 +967,7 @@ class TestCassandraJsonWriter
       CassandraConfigConstants.PASSWD                 -> password,
       CassandraConfigConstants.KCQL                   -> kql,
       CassandraConfigConstants.DELETE_ROW_ENABLED     -> "true",
-    ).asJava
+    )
 
     val taskConfig = new CassandraConfigSink(props)
 
@@ -1032,7 +1032,7 @@ class TestCassandraJsonWriter
       CassandraConfigConstants.PASSWD                 -> password,
       CassandraConfigConstants.KCQL                   -> kql,
       CassandraConfigConstants.DELETE_ROW_ENABLED     -> "true",
-    ).asJava
+    )
 
     val taskConfig = new CassandraConfigSink(props)
 
@@ -1095,7 +1095,7 @@ class TestCassandraJsonWriter
       CassandraConfigConstants.PASSWD                 -> password,
       CassandraConfigConstants.KCQL                   -> kql,
       CassandraConfigConstants.DELETE_ROW_ENABLED     -> "true",
-    ).asJava
+    )
 
     val taskConfig = new CassandraConfigSink(props)
 
@@ -1152,7 +1152,7 @@ class TestCassandraJsonWriter
       CassandraConfigConstants.PASSWD                 -> password,
       CassandraConfigConstants.KCQL                   -> kql,
       CassandraConfigConstants.DELETE_ROW_ENABLED     -> "true",
-    ).asJava
+    )
 
     val taskConfig = new CassandraConfigSink(props)
 
@@ -1198,7 +1198,7 @@ class TestCassandraJsonWriter
       CassandraConfigConstants.USERNAME       -> userName,
       CassandraConfigConstants.PASSWD         -> password,
       CassandraConfigConstants.KCQL           -> s"INSERT INTO $table SELECT key, name FROM TOPIC",
-    ).asJava
+    )
 
     val taskConfig = new CassandraConfigSink(props)
 

--- a/kafka-connect-cassandra/src/it/scala/io/lenses/streamreactor/connect/cassandra/source/TestCassandraSourceTaskTimestamp.scala
+++ b/kafka-connect-cassandra/src/it/scala/io/lenses/streamreactor/connect/cassandra/source/TestCassandraSourceTaskTimestamp.scala
@@ -32,6 +32,7 @@ import org.scalatest.wordspec.AnyWordSpec
 
 import scala.annotation.nowarn
 import scala.jdk.CollectionConverters.ListHasAsScala
+import scala.jdk.CollectionConverters.MapHasAsJava
 
 @DoNotDiscover
 @nowarn
@@ -65,7 +66,7 @@ class TestCassandraSourceTaskTimestamp
     task.initialize(taskContext)
 
     //start task
-    task.start(config)
+    task.start(config.asJava)
 
     insertIntoTimestampTable(session, keyspace, tableName, "id1", "magic_string", getFormattedDateNow(), 1.toByte)
 
@@ -100,7 +101,7 @@ class TestCassandraSourceTaskTimestamp
     task.initialize(taskContext)
 
     //start task
-    task.start(config)
+    task.start(config.asJava)
 
     insertIntoTimestampTable(session, keyspace, tableName, "id1", "magic_string", getFormattedDateNow(), 1.toByte)
 
@@ -126,7 +127,7 @@ class TestCassandraSourceTaskTimestamp
     task.initialize(taskContext)
 
     //start task
-    task.start(config)
+    task.start(config.asJava)
 
     for (i <- 1 to 10) {
       insertIntoTimestampTable(session,
@@ -160,7 +161,7 @@ class TestCassandraSourceTaskTimestamp
     val mapper = new ObjectMapper()
 
     //start task
-    task.start(config)
+    task.start(config.asJava)
 
     insertIntoTimestampTable(session, keyspace, tableName, "id1", "magic_string", getFormattedDateNow(), 1.toByte)
 
@@ -188,7 +189,7 @@ class TestCassandraSourceTaskTimestamp
     insertIntoTimestampTable(session, keyspace, tableName, "id1", "magic_string", getFormattedDateNow(), 1.toByte)
 
     try {
-      task.start(config)
+      task.start(config.asJava)
       fail()
     } catch {
       case _: ConfigException => // Expected, so continue

--- a/kafka-connect-cassandra/src/it/scala/io/lenses/streamreactor/connect/cassandra/source/TestCassandraSourceTaskTimeuuid.scala
+++ b/kafka-connect-cassandra/src/it/scala/io/lenses/streamreactor/connect/cassandra/source/TestCassandraSourceTaskTimeuuid.scala
@@ -31,6 +31,7 @@ import org.scalatest.Suite
 
 import scala.annotation.nowarn
 import scala.jdk.CollectionConverters.ListHasAsScala
+import scala.jdk.CollectionConverters.MapHasAsJava
 
 @DoNotDiscover
 @nowarn
@@ -64,7 +65,7 @@ class TestCassandraSourceTaskTimeuuid
     task.initialize(taskContext)
 
     //start task
-    task.start(config)
+    task.start(config.asJava)
 
     insertIntoTimeuuidTable(session, keyspace, tableName, "id1", "magic_string")
 
@@ -97,7 +98,7 @@ class TestCassandraSourceTaskTimeuuid
     task.initialize(taskContext)
 
     //start task
-    task.start(config)
+    task.start(config.asJava)
 
     insertIntoTimeuuidTable(session, keyspace, tableName, "id1", "magic_string")
 
@@ -122,7 +123,7 @@ class TestCassandraSourceTaskTimeuuid
     task.initialize(taskContext)
 
     //start task
-    task.start(config)
+    task.start(config.asJava)
 
     for (i <- 1 to 10) {
       insertIntoTimeuuidTable(session, keyspace, tableName, s"id$i", s"magic_string_$i")
@@ -145,7 +146,7 @@ class TestCassandraSourceTaskTimeuuid
     insertIntoTimeuuidTable(session, keyspace, tableName, "id1", "magic_string")
 
     try {
-      task.start(config)
+      task.start(config.asJava)
       fail()
     } catch {
       case _: ConfigException => // Expected, so continue

--- a/kafka-connect-cassandra/src/it/scala/io/lenses/streamreactor/connect/cassandra/source/TestCassandraSourceUtil.scala
+++ b/kafka-connect-cassandra/src/it/scala/io/lenses/streamreactor/connect/cassandra/source/TestCassandraSourceUtil.scala
@@ -5,10 +5,7 @@ import com.datastax.driver.core.Session
 
 import java.text.SimpleDateFormat
 import java.util.Date
-import java.util.Map
 import java.util.UUID
-
-import scala.jdk.CollectionConverters.MapHasAsJava
 
 trait TestCassandraSourceUtil {
 
@@ -135,5 +132,5 @@ trait TestCassandraSourceUtil {
       CassandraConfigConstants.TIMESLICE_DELAY    -> "0",
       CassandraConfigConstants.POLL_INTERVAL      -> "500",
       CassandraConfigConstants.FETCH_SIZE         -> "2",
-    ).asJava
+    )
 }

--- a/kafka-connect-cassandra/src/main/scala/io/lenses/streamreactor/connect/cassandra/config/CassandraConfig.scala
+++ b/kafka-connect-cassandra/src/main/scala/io/lenses/streamreactor/connect/cassandra/config/CassandraConfig.scala
@@ -22,7 +22,6 @@ import io.lenses.streamreactor.common.config.base.traits.KcqlSettings
 import io.lenses.streamreactor.common.config.base.traits.NumberRetriesSettings
 import io.lenses.streamreactor.common.config.base.traits.ThreadPoolSettings
 
-import java.util
 import com.datastax.driver.core.ConsistencyLevel
 import org.apache.kafka.common.config.ConfigDef
 import org.apache.kafka.common.config.ConfigDef.Importance
@@ -430,7 +429,7 @@ object CassandraConfigSource {
 
 }
 
-case class CassandraConfigSource(props: util.Map[String, String])
+case class CassandraConfigSource(props: Map[String, String])
     extends BaseConfig(CassandraConfigConstants.CONNECTOR_PREFIX, CassandraConfigSource.sourceConfig, props)
     with ErrorPolicySettings
     with ConsistencyLevelSettings[ConsistencyLevel]
@@ -522,7 +521,7 @@ object CassandraConfigSink {
 
 }
 
-case class CassandraConfigSink(props: util.Map[String, String])
+case class CassandraConfigSink(props: Map[String, String])
     extends BaseConfig(CassandraConfigConstants.CONNECTOR_PREFIX, CassandraConfigSink.sinkConfig, props)
     with KcqlSettings
     with ErrorPolicySettings

--- a/kafka-connect-cassandra/src/main/scala/io/lenses/streamreactor/connect/cassandra/sink/CassandraSinkConnector.scala
+++ b/kafka-connect-cassandra/src/main/scala/io/lenses/streamreactor/connect/cassandra/sink/CassandraSinkConnector.scala
@@ -68,7 +68,7 @@ class CassandraSinkConnector extends SinkConnector with StrictLogging {
     //check input topics
     Helpers.checkInputTopics(CassandraConfigConstants.KCQL, props.asScala.toMap)
     configProps = props
-    Try(new CassandraConfigSink(props)) match {
+    Try(new CassandraConfigSink(props.asScala.toMap)) match {
       case Failure(f) =>
         throw new ConnectException(s"Couldn't start Cassandra sink due to configuration error: ${f.getMessage}", f)
       case _ =>

--- a/kafka-connect-cassandra/src/main/scala/io/lenses/streamreactor/connect/cassandra/sink/CassandraSinkTask.scala
+++ b/kafka-connect-cassandra/src/main/scala/io/lenses/streamreactor/connect/cassandra/sink/CassandraSinkTask.scala
@@ -30,6 +30,7 @@ import org.apache.kafka.connect.sink.SinkRecord
 import org.apache.kafka.connect.sink.SinkTask
 
 import scala.jdk.CollectionConverters.CollectionHasAsScala
+import scala.jdk.CollectionConverters.MapHasAsScala
 import scala.util.Failure
 import scala.util.Success
 import scala.util.Try
@@ -55,7 +56,7 @@ class CassandraSinkTask extends SinkTask with StrictLogging {
 
     val config = if (context.configs().isEmpty) props else context.configs()
 
-    val taskConfig = Try(new CassandraConfigSink(config)) match {
+    val taskConfig = Try(new CassandraConfigSink(config.asScala.toMap)) match {
       case Failure(f) => throw new ConnectException("Couldn't start CassandraSink due to configuration error.", f)
       case Success(s) => s
     }

--- a/kafka-connect-cassandra/src/main/scala/io/lenses/streamreactor/connect/cassandra/source/CassandraSourceTask.scala
+++ b/kafka-connect-cassandra/src/main/scala/io/lenses/streamreactor/connect/cassandra/source/CassandraSourceTask.scala
@@ -33,6 +33,7 @@ import org.apache.kafka.connect.source.SourceTask
 
 import scala.collection.mutable
 import scala.jdk.CollectionConverters.ListHasAsScala
+import scala.jdk.CollectionConverters.MapHasAsScala
 import scala.jdk.CollectionConverters.SeqHasAsJava
 import scala.util.Failure
 import scala.util.Success
@@ -68,7 +69,7 @@ class CassandraSourceTask extends SourceTask with StrictLogging {
     val config = if (context.configs().isEmpty) props else context.configs()
 
     //get configuration for this task
-    taskConfig = Try(new CassandraConfigSource(config)) match {
+    taskConfig = Try(new CassandraConfigSource(config.asScala.toMap)) match {
       case Failure(f) => throw new ConnectException("Couldn't start CassandraSource due to configuration error.", f)
       case Success(s) => Some(s)
     }

--- a/kafka-connect-cassandra/src/test/scala/io/lenses/streamreactor/connect/cassandra/config/TestCassandraSinkConfig.scala
+++ b/kafka-connect-cassandra/src/test/scala/io/lenses/streamreactor/connect/cassandra/config/TestCassandraSinkConfig.scala
@@ -20,8 +20,6 @@ import org.scalatest.BeforeAndAfter
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 
-import scala.jdk.CollectionConverters.MapHasAsJava
-
 class TestCassandraSinkConfig extends AnyWordSpec with BeforeAndAfter with Matchers with TestConfig {
 
   "A CassandraConfig should return configured for username and password" in {
@@ -31,7 +29,7 @@ class TestCassandraSinkConfig extends AnyWordSpec with BeforeAndAfter with Match
       CassandraConfigConstants.USERNAME       -> USERNAME,
       CassandraConfigConstants.PASSWD         -> PASSWD,
       CassandraConfigConstants.KCQL           -> QUERY_ALL,
-    ).asJava
+    )
 
     val taskConfig = CassandraConfigSink(props)
     taskConfig.getString(CassandraConfigConstants.CONTACT_POINTS) shouldBe CONTACT_POINT
@@ -54,7 +52,7 @@ class TestCassandraSinkConfig extends AnyWordSpec with BeforeAndAfter with Match
       CassandraConfigConstants.TRUST_STORE_PATH   -> TRUST_STORE_PATH,
       CassandraConfigConstants.TRUST_STORE_PASSWD -> TRUST_STORE_PASSWORD,
       CassandraConfigConstants.KCQL               -> QUERY_ALL,
-    ).asJava
+    )
 
     val taskConfig = CassandraConfigSink(props)
     taskConfig.getString(CassandraConfigConstants.CONTACT_POINTS) shouldBe CONTACT_POINT
@@ -81,7 +79,7 @@ class TestCassandraSinkConfig extends AnyWordSpec with BeforeAndAfter with Match
       CassandraConfigConstants.KEY_STORE_PATH     -> KEYSTORE_PATH,
       CassandraConfigConstants.KEY_STORE_PASSWD   -> KEYSTORE_PASSWORD,
       CassandraConfigConstants.KCQL               -> QUERY_ALL,
-    ).asJava
+    )
 
     val taskConfig = CassandraConfigSink(props)
     taskConfig.getString(CassandraConfigConstants.CONTACT_POINTS) shouldBe CONTACT_POINT

--- a/kafka-connect-cassandra/src/test/scala/io/lenses/streamreactor/connect/cassandra/config/TestCassandraSinkSettings.scala
+++ b/kafka-connect-cassandra/src/test/scala/io/lenses/streamreactor/connect/cassandra/config/TestCassandraSinkSettings.scala
@@ -15,19 +15,16 @@
  */
 package io.lenses.streamreactor.connect.cassandra.config
 
-import java.util
+import com.datastax.driver.core.ConsistencyLevel
 import io.lenses.kcql.Kcql
 import io.lenses.streamreactor.common.errors.ErrorPolicyEnum
 import io.lenses.streamreactor.common.errors.RetryErrorPolicy
 import io.lenses.streamreactor.connect.cassandra.TestConfig
-import com.datastax.driver.core.ConsistencyLevel
 import org.apache.kafka.common.config.ConfigException
 import org.apache.kafka.connect.sink.SinkTaskContext
 import org.mockito.MockitoSugar
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
-
-import scala.jdk.CollectionConverters.MapHasAsJava
 
 /**
   * Created by andrew@datamountaineer.com on 28/04/16.
@@ -44,7 +41,7 @@ class TestCassandraSinkSettings extends AnyWordSpec with Matchers with MockitoSu
       CassandraConfigConstants.KCQL                 -> QUERY_ALL,
       CassandraConfigConstants.ERROR_POLICY         -> ErrorPolicyEnum.RETRY.toString,
       CassandraConfigConstants.ERROR_RETRY_INTERVAL -> "500",
-    ).asJava
+    )
 
   "CassandraSettings should return setting for a sink" in {
     val context = mock[SinkTaskContext]
@@ -67,30 +64,27 @@ class TestCassandraSinkSettings extends AnyWordSpec with Matchers with MockitoSu
   }
 
   "CassandraSettings should throw an exception if the consistency level is not valid for a sink" in {
-    val map = new util.HashMap[String, String](getCassandraConfigSinkPropsRetry)
-    map.put(CassandraConfigConstants.CONSISTENCY_LEVEL_CONFIG, "INvalid")
+    val map = getCassandraConfigSinkPropsRetry + (CassandraConfigConstants.CONSISTENCY_LEVEL_CONFIG -> "INvalid")
     intercept[ConfigException] {
       CassandraSettings.configureSink(CassandraConfigSink(map))
     }
   }
 
   "CassandraSettings should allow setting the consistency level as Quorum for a sink" in {
-    val map = new util.HashMap[String, String](getCassandraConfigSinkPropsRetry)
-    map.put(CassandraConfigConstants.CONSISTENCY_LEVEL_CONFIG, ConsistencyLevel.QUORUM.name())
+    val map =
+      getCassandraConfigSinkPropsRetry + (CassandraConfigConstants.CONSISTENCY_LEVEL_CONFIG -> ConsistencyLevel.QUORUM.name())
     val settings = CassandraSettings.configureSink(CassandraConfigSink(map))
     settings.consistencyLevel shouldBe Some(ConsistencyLevel.QUORUM)
   }
 
   "CassandraSettings should allow setting the sink thread pool to 64" in {
-    val map = new util.HashMap[String, String](getCassandraConfigSinkPropsRetry)
-    map.put(CassandraConfigConstants.THREAD_POOL_CONFIG, "64")
+    val map      = getCassandraConfigSinkPropsRetry + (CassandraConfigConstants.THREAD_POOL_CONFIG -> "64")
     val settings = CassandraSettings.configureSink(CassandraConfigSink(map))
     settings.threadPoolSize shouldBe 64
   }
 
   "CassandraSettings should handle setting the sink thread pool to 0 and return a non zero value" in {
-    val map = new util.HashMap[String, String](getCassandraConfigSinkPropsRetry)
-    map.put(CassandraConfigConstants.THREAD_POOL_CONFIG, "0")
+    val map      = getCassandraConfigSinkPropsRetry + (CassandraConfigConstants.THREAD_POOL_CONFIG -> "0")
     val settings = CassandraSettings.configureSink(CassandraConfigSink(map))
     settings.threadPoolSize shouldBe 4 * Runtime.getRuntime.availableProcessors()
   }
@@ -105,10 +99,9 @@ class TestCassandraSinkSettings extends AnyWordSpec with Matchers with MockitoSu
       CassandraConfigConstants.KCQL            -> "INSERT INTO TABLE SELECT * FROM TOPIC",
       CassandraConfigConstants.ASSIGNED_TABLES -> ASSIGNED_TABLES,
       CassandraConfigConstants.POLL_INTERVAL   -> "1000",
-    ).asJava
+    )
 
-    val map = new util.HashMap[String, String](props)
-    map.put(CassandraConfigConstants.CONSISTENCY_LEVEL_CONFIG, "InvaliD")
+    val map = props + (CassandraConfigConstants.CONSISTENCY_LEVEL_CONFIG -> "InvaliD")
     intercept[ConfigException] {
       CassandraSettings.configureSource(CassandraConfigSource(map))
     }
@@ -116,18 +109,17 @@ class TestCassandraSinkSettings extends AnyWordSpec with Matchers with MockitoSu
 
   "CassandraSettings should allow setting the consistency level as Quorum for a source" in {
     val props = Map(
-      CassandraConfigConstants.CONTACT_POINTS  -> CONTACT_POINT,
-      CassandraConfigConstants.KEY_SPACE       -> CASSANDRA_SOURCE_KEYSPACE,
-      CassandraConfigConstants.USERNAME        -> USERNAME,
-      CassandraConfigConstants.PASSWD          -> PASSWD,
-      CassandraConfigConstants.KCQL            -> "INSERT INTO TABLE SELECT * FROM TOPIC",
-      CassandraConfigConstants.ASSIGNED_TABLES -> ASSIGNED_TABLES,
-      CassandraConfigConstants.POLL_INTERVAL   -> "1000",
-    ).asJava
+      CassandraConfigConstants.CONTACT_POINTS           -> CONTACT_POINT,
+      CassandraConfigConstants.KEY_SPACE                -> CASSANDRA_SOURCE_KEYSPACE,
+      CassandraConfigConstants.USERNAME                 -> USERNAME,
+      CassandraConfigConstants.PASSWD                   -> PASSWD,
+      CassandraConfigConstants.KCQL                     -> "INSERT INTO TABLE SELECT * FROM TOPIC",
+      CassandraConfigConstants.ASSIGNED_TABLES          -> ASSIGNED_TABLES,
+      CassandraConfigConstants.POLL_INTERVAL            -> "1000",
+      CassandraConfigConstants.CONSISTENCY_LEVEL_CONFIG -> ConsistencyLevel.QUORUM.name(),
+    )
 
-    val map = new util.HashMap[String, String](props)
-    map.put(CassandraConfigConstants.CONSISTENCY_LEVEL_CONFIG, ConsistencyLevel.QUORUM.name())
-    val settingsSet = CassandraSettings.configureSource(CassandraConfigSource(map))
+    val settingsSet = CassandraSettings.configureSource(CassandraConfigSource(props))
     settingsSet.head.consistencyLevel shouldBe Some(ConsistencyLevel.QUORUM)
   }
 }

--- a/kafka-connect-cassandra/src/test/scala/io/lenses/streamreactor/connect/cassandra/config/TestCassandraSourceSettings.scala
+++ b/kafka-connect-cassandra/src/test/scala/io/lenses/streamreactor/connect/cassandra/config/TestCassandraSourceSettings.scala
@@ -19,8 +19,6 @@ import io.lenses.streamreactor.connect.cassandra.TestConfig
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 
-import scala.jdk.CollectionConverters.MapHasAsJava
-
 /**
   * Created by andrew@datamountaineer.com on 28/04/16.
   * stream-reactor
@@ -35,7 +33,7 @@ class TestCassandraSourceSettings extends AnyWordSpec with Matchers with TestCon
       CassandraConfigConstants.KCQL            -> IMPORT_QUERY_ALL,
       CassandraConfigConstants.ASSIGNED_TABLES -> ASSIGNED_TABLES,
       CassandraConfigConstants.POLL_INTERVAL   -> "1000",
-    ).asJava
+    )
 
     val taskConfig = CassandraConfigSource(props)
     val settings   = CassandraSettings.configureSource(taskConfig).toList
@@ -57,7 +55,7 @@ class TestCassandraSourceSettings extends AnyWordSpec with Matchers with TestCon
       CassandraConfigConstants.KCQL           -> "INSERT INTO cassandra-source SELECT * FROM orders PK created",
       CassandraConfigConstants.POLL_INTERVAL  -> "1000",
     )
-    val taskConfig = CassandraConfigSource(map.asJava)
+    val taskConfig = CassandraConfigSource(map)
     val settings   = CassandraSettings.configureSource(taskConfig).toList
     settings.size shouldBe 1
   }

--- a/kafka-connect-cassandra/src/test/scala/io/lenses/streamreactor/connect/cassandra/source/TestCassandraTypeConverter.scala
+++ b/kafka-connect-cassandra/src/test/scala/io/lenses/streamreactor/connect/cassandra/source/TestCassandraTypeConverter.scala
@@ -35,7 +35,6 @@ import org.scalatest.wordspec.AnyWordSpec
 
 import scala.jdk.CollectionConverters.IterableHasAsScala
 import scala.jdk.CollectionConverters.ListHasAsScala
-import scala.jdk.CollectionConverters.MapHasAsJava
 
 class TestCassandraTypeConverter extends AnyWordSpec with TestConfig with Matchers with MockitoSugar {
 
@@ -285,7 +284,7 @@ class TestCassandraTypeConverter extends AnyWordSpec with TestConfig with Matche
       CassandraConfigConstants.POLL_INTERVAL              -> "1000",
       CassandraConfigConstants.MAPPING_COLLECTION_TO_JSON -> mappingCollectionToJson.toString,
     )
-    val taskConfig = CassandraConfigSource(config.asJava);
+    val taskConfig = CassandraConfigSource(config)
     CassandraSettings.configureSource(taskConfig).toList.head
   }
 

--- a/kafka-connect-cassandra/src/test/scala/io/lenses/streamreactor/connect/cassandra/source/TestCqlGenerator.scala
+++ b/kafka-connect-cassandra/src/test/scala/io/lenses/streamreactor/connect/cassandra/source/TestCqlGenerator.scala
@@ -25,7 +25,6 @@ import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 
 import scala.annotation.nowarn
-import scala.jdk.CollectionConverters.MapHasAsJava
 
 /**
   */
@@ -107,7 +106,7 @@ class TestCqlGenerator extends AnyWordSpec with Matchers with MockitoSugar with 
         CassandraConfigConstants.POLL_INTERVAL   -> "1000",
         CassandraConfigConstants.FETCH_SIZE      -> "500",
         CassandraConfigConstants.BATCH_SIZE      -> "800",
-      ).asJava
+      )
     }
     val configSource = new CassandraConfigSource(configMap)
     CassandraSettings.configureSource(configSource).head
@@ -124,7 +123,7 @@ class TestCqlGenerator extends AnyWordSpec with Matchers with MockitoSugar with 
         CassandraConfigConstants.POLL_INTERVAL   -> "1000",
         CassandraConfigConstants.FETCH_SIZE      -> "500",
         CassandraConfigConstants.BATCH_SIZE      -> "800",
-      ).asJava
+      )
     }
     val configSource = new CassandraConfigSource(configMap)
     CassandraSettings.configureSource(configSource).head
@@ -141,7 +140,7 @@ class TestCqlGenerator extends AnyWordSpec with Matchers with MockitoSugar with 
         CassandraConfigConstants.POLL_INTERVAL   -> "1000",
         CassandraConfigConstants.FETCH_SIZE      -> "500",
         CassandraConfigConstants.BATCH_SIZE      -> "800",
-      ).asJava
+      )
     }
     val configSource = new CassandraConfigSource(configMap)
     CassandraSettings.configureSource(configSource).head
@@ -160,7 +159,7 @@ class TestCqlGenerator extends AnyWordSpec with Matchers with MockitoSugar with 
         CassandraConfigConstants.BATCH_SIZE                -> "800",
         CassandraConfigConstants.BUCKET_TIME_SERIES_MODE   -> "MINUTE",
         CassandraConfigConstants.BUCKET_TIME_SERIES_FORMAT -> "yyMMddHHmm",
-      ).asJava
+      )
     }
     val configSource = new CassandraConfigSource(configMap)
     CassandraSettings.configureSource(configSource).head

--- a/kafka-connect-cloud-common/src/main/scala/io/lenses/streamreactor/connect/cloud/common/config/ConnectorTaskId.scala
+++ b/kafka-connect-cloud-common/src/main/scala/io/lenses/streamreactor/connect/cloud/common/config/ConnectorTaskId.scala
@@ -20,8 +20,6 @@ import cats.implicits.toBifunctorOps
 import io.lenses.streamreactor.common.config.base.traits.WithConnectorPrefix
 import io.lenses.streamreactor.connect.cloud.common.source.config.distribution.PartitionHasher
 
-import java.util
-
 case class ConnectorTaskId(name: String, maxTasks: Int, taskNo: Int) {
   def ownsDir(dirPath: String): Boolean =
     if (maxTasks == 1) true
@@ -43,9 +41,9 @@ object ConnectorTaskId {
 }
 
 class ConnectorTaskIdCreator(val connectorPrefix: String) extends TaskIndexKey {
-  def fromProps(props: util.Map[String, String]): Either[Throwable, ConnectorTaskId] = {
+  def fromProps(props: Map[String, String]): Either[Throwable, ConnectorTaskId] = {
     for {
-      taskIndexString <- Option(props.get(TASK_INDEX)).toRight(s"Missing $TASK_INDEX")
+      taskIndexString <- props.get(TASK_INDEX).toRight(s"Missing $TASK_INDEX")
       taskIndex        = taskIndexString.split(":")
       _               <- if (taskIndex.size != 2) Left(s"Invalid $TASK_INDEX. Expecting TaskNumber:MaxTask format.") else Right(())
       maxTasks <- taskIndex(1).toIntOption.toRight(
@@ -58,7 +56,7 @@ class ConnectorTaskIdCreator(val connectorPrefix: String) extends TaskIndexKey {
       )
       _ <- if (taskNumber < 0) Left(s"Invalid $TASK_INDEX. Expecting a positive integer but found:${taskIndex(0)}")
       else Right(())
-      maybeTaskName <- Option(props.get("name")).filter(_.trim.nonEmpty).toRight("Missing connector name")
+      maybeTaskName <- props.get("name").filter(_.trim.nonEmpty).toRight("Missing connector name")
     } yield ConnectorTaskId(maybeTaskName, maxTasks, taskNumber)
   }.leftMap(new IllegalArgumentException(_))
 

--- a/kafka-connect-cloud-common/src/main/scala/io/lenses/streamreactor/connect/cloud/common/sink/CloudSinkTask.scala
+++ b/kafka-connect-cloud-common/src/main/scala/io/lenses/streamreactor/connect/cloud/common/sink/CloudSinkTask.scala
@@ -62,7 +62,7 @@ abstract class CloudSinkTask[SM <: FileMetadata](
 
     printAsciiHeader(manifest, sinkAsciiArtResource)
 
-    new ConnectorTaskIdCreator(connectorPrefix).fromProps(fallbackProps) match {
+    new ConnectorTaskIdCreator(connectorPrefix).fromProps(fallbackProps.asScala.toMap) match {
       case Left(value)  => throw new IllegalArgumentException(value)
       case Right(value) => connectorTaskId = value
     }

--- a/kafka-connect-cloud-common/src/test/scala/io/lenses/streamreactor/connect/cloud/common/config/ConnectorTaskIdTest.scala
+++ b/kafka-connect-cloud-common/src/test/scala/io/lenses/streamreactor/connect/cloud/common/config/ConnectorTaskIdTest.scala
@@ -20,20 +20,18 @@ import io.lenses.streamreactor.connect.cloud.common.source.config.distribution.P
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 
-import scala.jdk.CollectionConverters._
 class ConnectorTaskIdTest extends AnyWordSpec with Matchers with TaskIndexKey {
   private val connectorName = "connectorName"
   "ConnectorTaskId" should {
     "create the instance" in {
       val from = Map("a" -> "1", "b" -> "2", TASK_INDEX -> "0:2", "name" -> connectorName)
-      new ConnectorTaskIdCreator(connectorPrefix).fromProps(from.asJava) shouldBe ConnectorTaskId(connectorName,
-                                                                                                  2,
-                                                                                                  0,
-      ).asRight[String]
+      new ConnectorTaskIdCreator(connectorPrefix).fromProps(from) shouldBe ConnectorTaskId(connectorName, 2, 0).asRight[
+        String,
+      ]
     }
     "fail if max tasks is not valid integer" in {
       val from   = Map("a" -> "1", "b" -> "2", TASK_INDEX -> "0:2a", "name" -> connectorName)
-      val actual = new ConnectorTaskIdCreator(connectorPrefix).fromProps(from.asJava)
+      val actual = new ConnectorTaskIdCreator(connectorPrefix).fromProps(from)
       actual match {
         case Left(e)  => e.getMessage shouldBe s"Invalid $TASK_INDEX. Expecting an integer but found:2a"
         case Right(_) => fail("Should have failed")
@@ -41,14 +39,14 @@ class ConnectorTaskIdTest extends AnyWordSpec with Matchers with TaskIndexKey {
     }
     "fail if task number is not a valid integer" in {
       val from = Map("a" -> "1", "b" -> "2", TASK_INDEX -> "0a:2", "name" -> connectorName)
-      new ConnectorTaskIdCreator(connectorPrefix).fromProps(from.asJava) match {
+      new ConnectorTaskIdCreator(connectorPrefix).fromProps(from) match {
         case Left(value) => value.getMessage shouldBe s"Invalid $TASK_INDEX. Expecting an integer but found:0a"
         case Right(_)    => fail("Should have failed")
       }
     }
     "fail if task number < 0" in {
       val from = Map("a" -> "1", "b" -> "2", TASK_INDEX -> "-1:2", "name" -> connectorName)
-      new ConnectorTaskIdCreator(connectorPrefix).fromProps(from.asJava) match {
+      new ConnectorTaskIdCreator(connectorPrefix).fromProps(from) match {
         case Left(value)  => value.getMessage shouldBe s"Invalid $TASK_INDEX. Expecting a positive integer but found:-1"
         case Right(value) => fail(s"Should have failed but got $value")
       }
@@ -56,14 +54,14 @@ class ConnectorTaskIdTest extends AnyWordSpec with Matchers with TaskIndexKey {
     }
     "fail if max tasks is zero" in {
       val from = Map("a" -> "1", "b" -> "2", TASK_INDEX -> "0:0", "name" -> connectorName)
-      new ConnectorTaskIdCreator(connectorPrefix).fromProps(from.asJava) match {
+      new ConnectorTaskIdCreator(connectorPrefix).fromProps(from) match {
         case Left(value)  => value.getMessage shouldBe s"Invalid $TASK_INDEX. Expecting a positive integer but found:0"
         case Right(value) => fail(s"Should have failed but got $value")
       }
     }
     "fail if max tasks is negative" in {
       val from = Map("a" -> "1", "b" -> "2", TASK_INDEX -> "0:-1", "name" -> connectorName)
-      new ConnectorTaskIdCreator(connectorPrefix).fromProps(from.asJava) match {
+      new ConnectorTaskIdCreator(connectorPrefix).fromProps(from) match {
         case Left(value)  => value.getMessage shouldBe s"Invalid $TASK_INDEX. Expecting a positive integer but found:-1"
         case Right(value) => fail(s"Should have failed but got $value")
       }
@@ -72,7 +70,7 @@ class ConnectorTaskIdTest extends AnyWordSpec with Matchers with TaskIndexKey {
     "own the partitions when max task is 1" in {
       val from = Map("a" -> "1", "b" -> "2", TASK_INDEX -> "0:1", "name" -> connectorName)
       val actual =
-        new ConnectorTaskIdCreator(connectorPrefix).fromProps(from.asJava).getOrElse(fail("Should be valid"))
+        new ConnectorTaskIdCreator(connectorPrefix).fromProps(from).getOrElse(fail("Should be valid"))
 
       Seq("/myTopic/", "/anotherTopic/", "/thirdTopic/")
         .flatMap { value =>
@@ -89,12 +87,12 @@ class ConnectorTaskIdTest extends AnyWordSpec with Matchers with TaskIndexKey {
                                                                           "b"        -> "2",
                                                                           TASK_INDEX -> "0:2",
                                                                           "name"     -> connectorName,
-      ).asJava).getOrElse(fail("Should be valid"))
+      )).getOrElse(fail("Should be valid"))
       val two = new ConnectorTaskIdCreator(connectorPrefix).fromProps(Map("a" -> "1",
                                                                           "b"        -> "2",
                                                                           TASK_INDEX -> "1:2",
                                                                           "name"     -> connectorName,
-      ).asJava).getOrElse(fail("Should be valid"))
+      )).getOrElse(fail("Should be valid"))
 
       PartitionHasher.hash(2, "1") shouldBe 1
       one.ownsDir("1") shouldBe false
@@ -111,17 +109,17 @@ class ConnectorTaskIdTest extends AnyWordSpec with Matchers with TaskIndexKey {
                                                                           "b"        -> "2",
                                                                           TASK_INDEX -> "0:3",
                                                                           "name"     -> connectorName,
-      ).asJava).getOrElse(fail("Should be valid"))
+      )).getOrElse(fail("Should be valid"))
       val two = new ConnectorTaskIdCreator(connectorPrefix).fromProps(Map("a" -> "1",
                                                                           "b"        -> "2",
                                                                           TASK_INDEX -> "1:3",
                                                                           "name"     -> connectorName,
-      ).asJava).getOrElse(fail("Should be valid"))
+      )).getOrElse(fail("Should be valid"))
       val three = new ConnectorTaskIdCreator(connectorPrefix).fromProps(Map("a" -> "1",
                                                                             "b"        -> "2",
                                                                             TASK_INDEX -> "2:3",
                                                                             "name"     -> connectorName,
-      ).asJava).getOrElse(fail("Should be valid"))
+      )).getOrElse(fail("Should be valid"))
 
       PartitionHasher.hash(3, "1") shouldBe 1
       one.ownsDir("1") shouldBe false

--- a/kafka-connect-cloud-common/src/test/scala/io/lenses/streamreactor/connect/cloud/common/sink/config/TestConfigDefBuilder.scala
+++ b/kafka-connect-cloud-common/src/test/scala/io/lenses/streamreactor/connect/cloud/common/sink/config/TestConfigDefBuilder.scala
@@ -18,15 +18,11 @@ package io.lenses.streamreactor.connect.cloud.common.sink.config
 import io.lenses.streamreactor.common.config.base.traits.BaseConfig
 import io.lenses.streamreactor.connect.cloud.common.sink.config.padding.PaddingStrategyConfigKeys
 import io.lenses.streamreactor.connect.cloud.common.sink.config.padding.PaddingStrategySettings
-import io.lenses.streamreactor.connect.cloud.common.sink.config.LocalStagingAreaConfigKeys
-import io.lenses.streamreactor.connect.cloud.common.sink.config.LocalStagingAreaSettings
 import org.apache.kafka.common.config.ConfigDef
 
-import java.util
-import scala.jdk.CollectionConverters.MapHasAsJava
 import scala.jdk.CollectionConverters.MapHasAsScala
 
-case class TestConfigDefBuilder(configDef: ConfigDef, props: util.Map[String, String])
+case class TestConfigDefBuilder(configDef: ConfigDef, props: Map[String, String])
     extends BaseConfig("connect.testing", configDef, props)
     with PaddingStrategySettings
     with LocalStagingAreaSettings {
@@ -51,7 +47,7 @@ object TestConfig {
     val newMap = map + {
       "connect.s3.kcql" -> "dummy value"
     }
-    TestConfigDefBuilder(defineProps(new ConfigDef()), newMap.asJava)
+    TestConfigDefBuilder(defineProps(new ConfigDef()), newMap)
   }
 
 }

--- a/kafka-connect-common/src/main/scala/io/lenses/streamreactor/common/config/base/traits/BaseConfig.scala
+++ b/kafka-connect-common/src/main/scala/io/lenses/streamreactor/common/config/base/traits/BaseConfig.scala
@@ -15,12 +15,12 @@
  */
 package io.lenses.streamreactor.common.config.base.traits
 
-import java.util
-
 import org.apache.kafka.common.config.AbstractConfig
 import org.apache.kafka.common.config.ConfigDef
 
-abstract class BaseConfig(connectorPrefixStr: String, confDef: ConfigDef, props: util.Map[String, String])
-    extends AbstractConfig(confDef, props) {
+import scala.jdk.CollectionConverters.MapHasAsJava
+
+abstract class BaseConfig(connectorPrefixStr: String, confDef: ConfigDef, props: Map[String, String])
+    extends AbstractConfig(confDef, props.asJava) {
   val connectorPrefix: String = connectorPrefixStr
 }

--- a/kafka-connect-elastic6/src/it/scala/io/lenses/streamreactor/connect/elastic6/ElasticWriterTest.scala
+++ b/kafka-connect-elastic6/src/it/scala/io/lenses/streamreactor/connect/elastic6/ElasticWriterTest.scala
@@ -53,7 +53,7 @@ class ElasticWriterTest extends ITBase with MockitoSugar with BeforeAndAfterEach
       dirFile
     }
 
-    def writeTestRecords(props: java.util.Map[String, String]) = {
+    def writeTestRecords(props: Map[String, String]) = {
 
       val localNode = createLocalNode()
 

--- a/kafka-connect-elastic6/src/it/scala/io/lenses/streamreactor/connect/elastic6/ITBase.scala
+++ b/kafka-connect-elastic6/src/it/scala/io/lenses/streamreactor/connect/elastic6/ITBase.scala
@@ -31,7 +31,6 @@ import java.time.LocalDateTime
 import java.time.format.DateTimeFormatter._
 import java.util
 import scala.collection.mutable
-import scala.jdk.CollectionConverters.MapHasAsJava
 import scala.jdk.CollectionConverters.SetHasAsScala
 
 trait ITBase extends AnyWordSpec with Matchers with BeforeAndAfter {
@@ -189,57 +188,57 @@ trait ITBase extends AnyWordSpec with Matchers with BeforeAndAfter {
 
   def getElasticSinkConfigProps(
     clusterName: String = ElasticConfigConstants.ES_CLUSTER_NAME_DEFAULT,
-  ): util.Map[String, String] =
+  ): Map[String, String] =
     getBaseElasticSinkConfigProps(QUERY, clusterName)
 
   def getElasticSinkConfigPropsSelection(
     clusterName: String = ElasticConfigConstants.ES_CLUSTER_NAME_DEFAULT,
-  ): util.Map[String, String] =
+  ): Map[String, String] =
     getBaseElasticSinkConfigProps(QUERY_SELECTION, clusterName)
 
   def getElasticSinkConfigPropsPk(
     clusterName: String = ElasticConfigConstants.ES_CLUSTER_NAME_DEFAULT,
-  ): util.Map[String, String] =
+  ): Map[String, String] =
     getBaseElasticSinkConfigProps(QUERY_PK, clusterName)
 
   def getElasticSinkUpdateConfigProps(
     clusterName: String = ElasticConfigConstants.ES_CLUSTER_NAME_DEFAULT,
-  ): util.Map[String, String] =
+  ): Map[String, String] =
     getBaseElasticSinkConfigProps(UPDATE_QUERY, clusterName)
 
   def getElasticSinkUpdateConfigPropsSelection(
     clusterName: String = ElasticConfigConstants.ES_CLUSTER_NAME_DEFAULT,
-  ): util.Map[String, String] =
+  ): Map[String, String] =
     getBaseElasticSinkConfigProps(UPDATE_QUERY_SELECTION, clusterName)
 
   def getBaseElasticSinkConfigProps(
     query:       String,
     clusterName: String = ElasticConfigConstants.ES_CLUSTER_NAME_DEFAULT,
-  ): util.Map[String, String] =
+  ): Map[String, String] =
     Map(
       "topics"                               -> TOPIC,
       ElasticConfigConstants.HOSTS           -> ELASTIC_SEARCH_HOSTNAMES,
       ElasticConfigConstants.ES_CLUSTER_NAME -> clusterName,
       ElasticConfigConstants.PROTOCOL        -> ElasticConfigConstants.PROTOCOL_DEFAULT,
       ElasticConfigConstants.KCQL            -> query,
-    ).asJava
+    )
 
   def getElasticSinkConfigPropsWithDateSuffixAndIndexAutoCreation(
     autoCreate:  Boolean,
     clusterName: String = ElasticConfigConstants.ES_CLUSTER_NAME_DEFAULT,
-  ): util.Map[String, String] =
+  ): Map[String, String] =
     Map(
       ElasticConfigConstants.HOSTS           -> ELASTIC_SEARCH_HOSTNAMES,
       ElasticConfigConstants.ES_CLUSTER_NAME -> clusterName,
       ElasticConfigConstants.PROTOCOL        -> ElasticConfigConstants.PROTOCOL_DEFAULT,
       ElasticConfigConstants.KCQL -> (QUERY + (if (autoCreate) " AUTOCREATE "
                                                else "") + " WITHINDEXSUFFIX=_{YYYY-MM-dd}"),
-    ).asJava
+    )
 
   def getElasticSinkConfigPropsHTTPClient(
     auth:        Boolean = false,
     clusterName: String  = ElasticConfigConstants.ES_CLUSTER_NAME_DEFAULT,
-  ): util.Map[String, String] =
+  ): Map[String, String] =
     Map(
       ElasticConfigConstants.HOSTS           -> ELASTIC_SEARCH_HOSTNAMES,
       ElasticConfigConstants.ES_CLUSTER_NAME -> clusterName,
@@ -251,5 +250,5 @@ trait ITBase extends AnyWordSpec with Matchers with BeforeAndAfter {
       ElasticConfigConstants.CLIENT_HTTP_BASIC_AUTH_PASSWORD -> (if (auth) BASIC_AUTH_PASSWORD
                                                                  else
                                                                    ElasticConfigConstants.CLIENT_HTTP_BASIC_AUTH_PASSWORD_DEFAULT),
-    ).asJava
+    )
 }

--- a/kafka-connect-elastic6/src/main/scala/io/lenses/streamreactor/connect/elastic6/ElasticSinkTask.scala
+++ b/kafka-connect-elastic6/src/main/scala/io/lenses/streamreactor/connect/elastic6/ElasticSinkTask.scala
@@ -30,6 +30,7 @@ import org.apache.kafka.connect.sink.SinkTask
 
 import java.util
 import scala.jdk.CollectionConverters.IterableHasAsScala
+import scala.jdk.CollectionConverters.MapHasAsScala
 
 class ElasticSinkTask extends SinkTask with StrictLogging {
   private var writer: Option[ElasticJsonWriter] = None
@@ -46,7 +47,7 @@ class ElasticSinkTask extends SinkTask with StrictLogging {
     val conf = if (context.configs().isEmpty) props else context.configs()
 
     ElasticConfig.config.parse(conf)
-    val sinkConfig = ElasticConfig(conf)
+    val sinkConfig = ElasticConfig(conf.asScala.toMap)
     enableProgress = sinkConfig.getBoolean(ElasticConfigConstants.PROGRESS_COUNTER_ENABLED)
 
     //if error policy is retry set retry interval

--- a/kafka-connect-elastic6/src/main/scala/io/lenses/streamreactor/connect/elastic6/config/ElasticConfig.scala
+++ b/kafka-connect-elastic6/src/main/scala/io/lenses/streamreactor/connect/elastic6/config/ElasticConfig.scala
@@ -15,7 +15,6 @@
  */
 package io.lenses.streamreactor.connect.elastic6.config
 
-import java.util
 import io.lenses.kcql.Kcql
 import io.lenses.streamreactor.common.config.base.traits.BaseConfig
 import io.lenses.streamreactor.common.config.base.traits.ErrorPolicySettings
@@ -199,7 +198,7 @@ object ElasticConfig {
   *
   * Holds config, extends AbstractConfig.
   */
-case class ElasticConfig(props: util.Map[String, String])
+case class ElasticConfig(props: Map[String, String])
     extends BaseConfig(ElasticConfigConstants.CONNECTOR_PREFIX, ElasticConfig.config, props)
     with WriteTimeoutSettings
     with ErrorPolicySettings

--- a/kafka-connect-elastic6/src/test/scala/io/lenses/streamreactor/connect/elastic6/ElasticSinkConnectorTest.scala
+++ b/kafka-connect-elastic6/src/test/scala/io/lenses/streamreactor/connect/elastic6/ElasticSinkConnectorTest.scala
@@ -18,6 +18,7 @@ package io.lenses.streamreactor.connect.elastic6
 import io.lenses.streamreactor.connect.elastic6.config.ElasticConfigConstants
 
 import scala.jdk.CollectionConverters.ListHasAsScala
+import scala.jdk.CollectionConverters.MapHasAsJava
 
 class ElasticSinkConnectorTest extends TestBase {
   "Should start a Elastic Search Connector" in {
@@ -26,7 +27,7 @@ class ElasticSinkConnectorTest extends TestBase {
     //get connector
     val connector = new ElasticSinkConnector()
     //start with config
-    connector.start(config)
+    connector.start(config.asJava)
     //check config
     val taskConfigs = connector.taskConfigs(10)
     taskConfigs.asScala.head.get(ElasticConfigConstants.HOSTS) shouldBe ELASTIC_SEARCH_HOSTNAMES

--- a/kafka-connect-elastic6/src/test/scala/io/lenses/streamreactor/connect/elastic6/ElasticSinkTaskTest.scala
+++ b/kafka-connect-elastic6/src/test/scala/io/lenses/streamreactor/connect/elastic6/ElasticSinkTaskTest.scala
@@ -18,6 +18,8 @@ package io.lenses.streamreactor.connect.elastic6
 import org.apache.kafka.connect.sink.SinkTaskContext
 import org.mockito.MockitoSugar
 
+import scala.jdk.CollectionConverters.MapHasAsJava
+
 class ElasticSinkTaskTest extends TestBase with MockitoSugar {
   "A ElasticSinkTask should start and write to Elastic Search" in {
     //mock the context to return our assignment when called
@@ -32,7 +34,7 @@ class ElasticSinkTaskTest extends TestBase with MockitoSugar {
     //check version
     task.version() shouldBe ""
     //start task
-    task.start(config)
+    task.start(config.asJava)
     //simulate the call from Connect
     //task.put(testRecords.asJava)
     //stop task

--- a/kafka-connect-elastic6/src/test/scala/io/lenses/streamreactor/connect/elastic6/TestBase.scala
+++ b/kafka-connect-elastic6/src/test/scala/io/lenses/streamreactor/connect/elastic6/TestBase.scala
@@ -24,7 +24,6 @@ import org.scalatest.wordspec.AnyWordSpec
 import java.time.LocalDateTime
 import java.time.format.DateTimeFormatter._
 import java.util
-import scala.jdk.CollectionConverters.MapHasAsJava
 
 trait TestBase extends AnyWordSpec with Matchers with BeforeAndAfter {
   val ELASTIC_SEARCH_HOSTNAMES = "localhost:9300"
@@ -54,25 +53,25 @@ trait TestBase extends AnyWordSpec with Matchers with BeforeAndAfter {
 
   def getElasticSinkConfigProps(
     clusterName: String = ElasticConfigConstants.ES_CLUSTER_NAME_DEFAULT,
-  ): util.Map[String, String] =
+  ): Map[String, String] =
     getBaseElasticSinkConfigProps(QUERY, clusterName)
 
   def getBaseElasticSinkConfigProps(
     query:       String,
     clusterName: String = ElasticConfigConstants.ES_CLUSTER_NAME_DEFAULT,
-  ): util.Map[String, String] =
+  ): Map[String, String] =
     Map(
       "topics"                               -> TOPIC,
       ElasticConfigConstants.HOSTS           -> ELASTIC_SEARCH_HOSTNAMES,
       ElasticConfigConstants.ES_CLUSTER_NAME -> clusterName,
       ElasticConfigConstants.PROTOCOL        -> ElasticConfigConstants.PROTOCOL_DEFAULT,
       ElasticConfigConstants.KCQL            -> query,
-    ).asJava
+    )
 
   def getElasticSinkConfigPropsHTTPClient(
     auth:        Boolean = false,
     clusterName: String  = ElasticConfigConstants.ES_CLUSTER_NAME_DEFAULT,
-  ): util.Map[String, String] =
+  ): Map[String, String] =
     Map(
       ElasticConfigConstants.HOSTS           -> ELASTIC_SEARCH_HOSTNAMES,
       ElasticConfigConstants.ES_CLUSTER_NAME -> clusterName,
@@ -84,5 +83,5 @@ trait TestBase extends AnyWordSpec with Matchers with BeforeAndAfter {
       ElasticConfigConstants.CLIENT_HTTP_BASIC_AUTH_PASSWORD -> (if (auth) BASIC_AUTH_PASSWORD
                                                                  else
                                                                    ElasticConfigConstants.CLIENT_HTTP_BASIC_AUTH_PASSWORD_DEFAULT),
-    ).asJava
+    )
 }

--- a/kafka-connect-elastic7/src/it/scala/io/lenses/streamreactor/connect/elastic7/ElasticWriterTest.scala
+++ b/kafka-connect-elastic7/src/it/scala/io/lenses/streamreactor/connect/elastic7/ElasticWriterTest.scala
@@ -53,7 +53,7 @@ class ElasticWriterTest extends ITBase with MockitoSugar with BeforeAndAfterEach
     }
 
     // TODO: Ensure these Settings properties are used
-    def writeTestRecords(props: java.util.Map[String, String]) = {
+    def writeTestRecords(props: Map[String, String]) = {
 
       val localNode = createLocalNode()
 

--- a/kafka-connect-elastic7/src/it/scala/io/lenses/streamreactor/connect/elastic7/ITBase.scala
+++ b/kafka-connect-elastic7/src/it/scala/io/lenses/streamreactor/connect/elastic7/ITBase.scala
@@ -31,7 +31,6 @@ import java.time.LocalDateTime
 import java.time.format.DateTimeFormatter._
 import java.util
 import scala.collection.mutable
-import scala.jdk.CollectionConverters.MapHasAsJava
 import scala.jdk.CollectionConverters.SetHasAsScala
 
 trait ITBase extends AnyWordSpec with Matchers with BeforeAndAfter {
@@ -189,57 +188,57 @@ trait ITBase extends AnyWordSpec with Matchers with BeforeAndAfter {
 
   def getElasticSinkConfigProps(
     clusterName: String = ElasticConfigConstants.ES_CLUSTER_NAME_DEFAULT,
-  ): util.Map[String, String] =
+  ): Map[String, String] =
     getBaseElasticSinkConfigProps(QUERY, clusterName)
 
   def getElasticSinkConfigPropsSelection(
     clusterName: String = ElasticConfigConstants.ES_CLUSTER_NAME_DEFAULT,
-  ): util.Map[String, String] =
+  ): Map[String, String] =
     getBaseElasticSinkConfigProps(QUERY_SELECTION, clusterName)
 
   def getElasticSinkConfigPropsPk(
     clusterName: String = ElasticConfigConstants.ES_CLUSTER_NAME_DEFAULT,
-  ): util.Map[String, String] =
+  ): Map[String, String] =
     getBaseElasticSinkConfigProps(QUERY_PK, clusterName)
 
   def getElasticSinkUpdateConfigProps(
     clusterName: String = ElasticConfigConstants.ES_CLUSTER_NAME_DEFAULT,
-  ): util.Map[String, String] =
+  ): Map[String, String] =
     getBaseElasticSinkConfigProps(UPDATE_QUERY, clusterName)
 
   def getElasticSinkUpdateConfigPropsSelection(
     clusterName: String = ElasticConfigConstants.ES_CLUSTER_NAME_DEFAULT,
-  ): util.Map[String, String] =
+  ): Map[String, String] =
     getBaseElasticSinkConfigProps(UPDATE_QUERY_SELECTION, clusterName)
 
   def getBaseElasticSinkConfigProps(
     query:       String,
     clusterName: String = ElasticConfigConstants.ES_CLUSTER_NAME_DEFAULT,
-  ): util.Map[String, String] =
+  ): Map[String, String] =
     Map(
       "topics"                               -> TOPIC,
       ElasticConfigConstants.HOSTS           -> ELASTIC_SEARCH_HOSTNAMES,
       ElasticConfigConstants.ES_CLUSTER_NAME -> clusterName,
       ElasticConfigConstants.PROTOCOL        -> ElasticConfigConstants.PROTOCOL_DEFAULT,
       ElasticConfigConstants.KCQL            -> query,
-    ).asJava
+    )
 
   def getElasticSinkConfigPropsWithDateSuffixAndIndexAutoCreation(
     autoCreate:  Boolean,
     clusterName: String = ElasticConfigConstants.ES_CLUSTER_NAME_DEFAULT,
-  ): util.Map[String, String] =
+  ): Map[String, String] =
     Map(
       ElasticConfigConstants.HOSTS           -> ELASTIC_SEARCH_HOSTNAMES,
       ElasticConfigConstants.ES_CLUSTER_NAME -> clusterName,
       ElasticConfigConstants.PROTOCOL        -> ElasticConfigConstants.PROTOCOL_DEFAULT,
       ElasticConfigConstants.KCQL -> (QUERY + (if (autoCreate) " AUTOCREATE "
                                                else "") + " WITHINDEXSUFFIX=_{YYYY-MM-dd}"),
-    ).asJava
+    )
 
   def getElasticSinkConfigPropsHTTPClient(
     auth:        Boolean = false,
     clusterName: String  = ElasticConfigConstants.ES_CLUSTER_NAME_DEFAULT,
-  ): util.Map[String, String] =
+  ): Map[String, String] =
     Map(
       ElasticConfigConstants.HOSTS           -> ELASTIC_SEARCH_HOSTNAMES,
       ElasticConfigConstants.ES_CLUSTER_NAME -> clusterName,
@@ -251,5 +250,5 @@ trait ITBase extends AnyWordSpec with Matchers with BeforeAndAfter {
       ElasticConfigConstants.CLIENT_HTTP_BASIC_AUTH_PASSWORD -> (if (auth) BASIC_AUTH_PASSWORD
                                                                  else
                                                                    ElasticConfigConstants.CLIENT_HTTP_BASIC_AUTH_PASSWORD_DEFAULT),
-    ).asJava
+    )
 }

--- a/kafka-connect-elastic7/src/main/scala/io/lenses/streamreactor/connect/elastic7/ElasticSinkTask.scala
+++ b/kafka-connect-elastic7/src/main/scala/io/lenses/streamreactor/connect/elastic7/ElasticSinkTask.scala
@@ -30,6 +30,7 @@ import org.apache.kafka.connect.sink.SinkTask
 
 import java.util
 import scala.jdk.CollectionConverters.IterableHasAsScala
+import scala.jdk.CollectionConverters.MapHasAsScala
 
 class ElasticSinkTask extends SinkTask with StrictLogging {
   private var writer: Option[ElasticJsonWriter] = None
@@ -46,7 +47,7 @@ class ElasticSinkTask extends SinkTask with StrictLogging {
     val conf = if (context.configs().isEmpty) props else context.configs()
 
     ElasticConfig.config.parse(conf)
-    val sinkConfig = ElasticConfig(conf)
+    val sinkConfig = ElasticConfig(conf.asScala.toMap)
     enableProgress = sinkConfig.getBoolean(ElasticConfigConstants.PROGRESS_COUNTER_ENABLED)
 
     //if error policy is retry set retry interval

--- a/kafka-connect-elastic7/src/main/scala/io/lenses/streamreactor/connect/elastic7/config/ElasticConfig.scala
+++ b/kafka-connect-elastic7/src/main/scala/io/lenses/streamreactor/connect/elastic7/config/ElasticConfig.scala
@@ -15,7 +15,6 @@
  */
 package io.lenses.streamreactor.connect.elastic7.config
 
-import java.util
 import io.lenses.kcql.Kcql
 import io.lenses.streamreactor.common.config.base.traits.BaseConfig
 import io.lenses.streamreactor.common.config.base.traits.ErrorPolicySettings
@@ -199,7 +198,7 @@ object ElasticConfig {
   *
   * Holds config, extends AbstractConfig.
   */
-case class ElasticConfig(props: util.Map[String, String])
+case class ElasticConfig(props: Map[String, String])
     extends BaseConfig(ElasticConfigConstants.CONNECTOR_PREFIX, ElasticConfig.config, props)
     with WriteTimeoutSettings
     with ErrorPolicySettings

--- a/kafka-connect-elastic7/src/test/scala/io/lenses/streamreactor/connect/elastic7/ElasticSinkConnectorTest.scala
+++ b/kafka-connect-elastic7/src/test/scala/io/lenses/streamreactor/connect/elastic7/ElasticSinkConnectorTest.scala
@@ -18,6 +18,7 @@ package io.lenses.streamreactor.connect.elastic7
 import io.lenses.streamreactor.connect.elastic7.config.ElasticConfigConstants
 
 import scala.jdk.CollectionConverters.ListHasAsScala
+import scala.jdk.CollectionConverters.MapHasAsJava
 
 class ElasticSinkConnectorTest extends TestBase {
   "Should start a Elastic Search Connector" in {
@@ -26,7 +27,7 @@ class ElasticSinkConnectorTest extends TestBase {
     //get connector
     val connector = new ElasticSinkConnector()
     //start with config
-    connector.start(config)
+    connector.start(config.asJava)
     //check config
     val taskConfigs = connector.taskConfigs(10)
     taskConfigs.asScala.head.get(ElasticConfigConstants.HOSTS) shouldBe ELASTIC_SEARCH_HOSTNAMES

--- a/kafka-connect-elastic7/src/test/scala/io/lenses/streamreactor/connect/elastic7/ElasticSinkTaskTest.scala
+++ b/kafka-connect-elastic7/src/test/scala/io/lenses/streamreactor/connect/elastic7/ElasticSinkTaskTest.scala
@@ -18,6 +18,8 @@ package io.lenses.streamreactor.connect.elastic7
 import org.apache.kafka.connect.sink.SinkTaskContext
 import org.mockito.MockitoSugar
 
+import scala.jdk.CollectionConverters.MapHasAsJava
+
 class ElasticSinkTaskTest extends TestBase with MockitoSugar {
   "A ElasticSinkTask should start and write to Elastic Search" in {
     //mock the context to return our assignment when called
@@ -32,7 +34,7 @@ class ElasticSinkTaskTest extends TestBase with MockitoSugar {
     //check version
     task.version() shouldBe ""
     //start task
-    task.start(config)
+    task.start(config.asJava)
     //simulate the call from Connect
     //task.put(testRecords.asJava)
     //stop task

--- a/kafka-connect-elastic7/src/test/scala/io/lenses/streamreactor/connect/elastic7/TestBase.scala
+++ b/kafka-connect-elastic7/src/test/scala/io/lenses/streamreactor/connect/elastic7/TestBase.scala
@@ -24,7 +24,6 @@ import org.scalatest.wordspec.AnyWordSpec
 import java.time.LocalDateTime
 import java.time.format.DateTimeFormatter._
 import java.util
-import scala.jdk.CollectionConverters.MapHasAsJava
 
 trait TestBase extends AnyWordSpec with Matchers with BeforeAndAfter {
   val ELASTIC_SEARCH_HOSTNAMES = "localhost:9300"
@@ -54,25 +53,25 @@ trait TestBase extends AnyWordSpec with Matchers with BeforeAndAfter {
 
   def getElasticSinkConfigProps(
     clusterName: String = ElasticConfigConstants.ES_CLUSTER_NAME_DEFAULT,
-  ): util.Map[String, String] =
+  ): Map[String, String] =
     getBaseElasticSinkConfigProps(QUERY, clusterName)
 
   def getBaseElasticSinkConfigProps(
     query:       String,
     clusterName: String = ElasticConfigConstants.ES_CLUSTER_NAME_DEFAULT,
-  ): util.Map[String, String] =
+  ): Map[String, String] =
     Map(
       "topics"                               -> TOPIC,
       ElasticConfigConstants.HOSTS           -> ELASTIC_SEARCH_HOSTNAMES,
       ElasticConfigConstants.ES_CLUSTER_NAME -> clusterName,
       ElasticConfigConstants.PROTOCOL        -> ElasticConfigConstants.PROTOCOL_DEFAULT,
       ElasticConfigConstants.KCQL            -> query,
-    ).asJava
+    )
 
   def getElasticSinkConfigPropsHTTPClient(
     auth:        Boolean = false,
     clusterName: String  = ElasticConfigConstants.ES_CLUSTER_NAME_DEFAULT,
-  ): util.Map[String, String] =
+  ): Map[String, String] =
     Map(
       ElasticConfigConstants.HOSTS           -> ELASTIC_SEARCH_HOSTNAMES,
       ElasticConfigConstants.ES_CLUSTER_NAME -> clusterName,
@@ -84,5 +83,5 @@ trait TestBase extends AnyWordSpec with Matchers with BeforeAndAfter {
       ElasticConfigConstants.CLIENT_HTTP_BASIC_AUTH_PASSWORD -> (if (auth) BASIC_AUTH_PASSWORD
                                                                  else
                                                                    ElasticConfigConstants.CLIENT_HTTP_BASIC_AUTH_PASSWORD_DEFAULT),
-    ).asJava
+    )
 }

--- a/kafka-connect-gcp-storage/src/main/scala/io/lenses/streamreactor/connect/gcp/storage/sink/GCPStorageSinkTask.scala
+++ b/kafka-connect-gcp-storage/src/main/scala/io/lenses/streamreactor/connect/gcp/storage/sink/GCPStorageSinkTask.scala
@@ -28,7 +28,6 @@ import io.lenses.streamreactor.connect.gcp.storage.sink.config.GCPStorageSinkCon
 import io.lenses.streamreactor.connect.gcp.storage.storage.GCPStorageFileMetadata
 import io.lenses.streamreactor.connect.gcp.storage.storage.GCPStorageStorageInterface
 
-import scala.jdk.CollectionConverters.MapHasAsJava
 import scala.util.Try
 
 object GCPStorageSinkTask {}
@@ -45,7 +44,7 @@ class GCPStorageSinkTask
 
   def createWriterMan(props: Map[String, String]): Either[Throwable, WriterManager[GCPStorageFileMetadata]] =
     for {
-      config          <- GCPStorageSinkConfig.fromProps(props.asJava)
+      config          <- GCPStorageSinkConfig.fromProps(props)
       gcpClient       <- GCPStorageClientCreator.make(config.gcpConfig)
       storageInterface = new GCPStorageStorageInterface(connectorTaskId, gcpClient, config.avoidResumableUpload)
       _               <- Try(setErrorRetryInterval(config.gcpConfig)).toEither

--- a/kafka-connect-gcp-storage/src/main/scala/io/lenses/streamreactor/connect/gcp/storage/sink/config/GCPStorageSinkConfig.scala
+++ b/kafka-connect-gcp-storage/src/main/scala/io/lenses/streamreactor/connect/gcp/storage/sink/config/GCPStorageSinkConfig.scala
@@ -24,12 +24,10 @@ import io.lenses.streamreactor.connect.cloud.common.sink.config.OffsetSeekerOpti
 import io.lenses.streamreactor.connect.gcp.storage.config.GCPConfig
 import io.lenses.streamreactor.connect.gcp.storage.config.GCPConfigSettings.SEEK_MAX_INDEX_FILES
 
-import java.util
-
 object GCPStorageSinkConfig {
 
   def fromProps(
-    props: util.Map[String, String],
+    props: Map[String, String],
   )(
     implicit
     connectorTaskId:        ConnectorTaskId,

--- a/kafka-connect-gcp-storage/src/main/scala/io/lenses/streamreactor/connect/gcp/storage/sink/config/GCPStorageSinkConfigDefBuilder.scala
+++ b/kafka-connect-gcp-storage/src/main/scala/io/lenses/streamreactor/connect/gcp/storage/sink/config/GCPStorageSinkConfigDefBuilder.scala
@@ -21,10 +21,9 @@ import io.lenses.streamreactor.connect.gcp.storage.config.AuthModeSettings
 import io.lenses.streamreactor.connect.gcp.storage.config.GCPConfigSettings
 import io.lenses.streamreactor.connect.gcp.storage.config.UploadSettings
 
-import java.util
 import scala.jdk.CollectionConverters.MapHasAsScala
 
-case class GCPStorageSinkConfigDefBuilder(props: util.Map[String, String])
+case class GCPStorageSinkConfigDefBuilder(props: Map[String, String])
     extends BaseConfig(GCPConfigSettings.CONNECTOR_PREFIX, GCPStorageSinkConfigDef.config, props)
     with CloudSinkConfigDefBuilder
     with ErrorPolicySettings

--- a/kafka-connect-gcp-storage/src/test/scala/io/lenses/streamreactor/connect/gcp/storage/sink/config/GCPStorageGCPStorageSinkConfigDefBuilderTest.scala
+++ b/kafka-connect-gcp-storage/src/test/scala/io/lenses/streamreactor/connect/gcp/storage/sink/config/GCPStorageGCPStorageSinkConfigDefBuilderTest.scala
@@ -31,7 +31,6 @@ import org.scalatest.matchers.should.Matchers
 
 import scala.concurrent.duration.DurationInt
 import scala.jdk.CollectionConverters.IteratorHasAsScala
-import scala.jdk.CollectionConverters.MapHasAsJava
 
 class GCPStorageGCPStorageSinkConfigDefBuilderTest
     extends AnyFlatSpec
@@ -51,7 +50,7 @@ class GCPStorageGCPStorageSinkConfigDefBuilderTest
       "connect.gcpstorage.kcql" -> s"insert into $BucketName:$PrefixName select * from $TopicName PARTITIONBY _key STOREAS `CSV` WITHPARTITIONER=Values WITH_FLUSH_COUNT = 1",
     )
 
-    val kcql = GCPStorageSinkConfigDefBuilder(props.asJava).getKCQL
+    val kcql = GCPStorageSinkConfigDefBuilder(props).getKCQL
     kcql should have size 1
 
     val element = kcql.head
@@ -68,7 +67,7 @@ class GCPStorageGCPStorageSinkConfigDefBuilderTest
       "connect.gcpstorage.kcql" -> s"insert into mybucket:myprefix select * from $TopicName PARTITIONBY _key STOREAS CSV WITHPARTITIONER=Values WITH_FLUSH_COUNT = 1",
     )
 
-    CloudSinkBucketOptions(GCPStorageSinkConfigDefBuilder(props.asJava)) match {
+    CloudSinkBucketOptions(GCPStorageSinkConfigDefBuilder(props)) match {
       case Left(value)  => fail(value.toString)
       case Right(value) => value.map(_.dataStorage) should be(List(DataStorageSettings.Default))
     }
@@ -79,7 +78,7 @@ class GCPStorageGCPStorageSinkConfigDefBuilderTest
       "connect.gcpstorage.kcql" -> s"insert into mybucket:myprefix select * from $TopicName PARTITIONBY _key STOREAS `JSON` WITHPARTITIONER=Values WITH_FLUSH_COUNT = 1 PROPERTIES('${DataStorageSettings.StoreEnvelopeKey}'=true)",
     )
 
-    CloudSinkBucketOptions(GCPStorageSinkConfigDefBuilder(props.asJava)) match {
+    CloudSinkBucketOptions(GCPStorageSinkConfigDefBuilder(props)) match {
       case Left(value)  => fail(value.toString)
       case Right(value) => value.map(_.dataStorage) should be(List(DataStorageSettings.enabled))
     }
@@ -90,7 +89,7 @@ class GCPStorageGCPStorageSinkConfigDefBuilderTest
       "connect.gcpstorage.kcql" -> s"insert into mybucket:myprefix select * from $TopicName PARTITIONBY _key STOREAS `PARQUET` WITHPARTITIONER=Values WITH_FLUSH_COUNT = 1 PROPERTIES('${DataStorageSettings.StoreEnvelopeKey}'=true, '${DataStorageSettings.StoreKeyKey}'=true, '${DataStorageSettings.StoreValueKey}'=true, '${DataStorageSettings.StoreMetadataKey}'=false, '${DataStorageSettings.StoreHeadersKey}'=false)",
     )
 
-    CloudSinkBucketOptions(GCPStorageSinkConfigDefBuilder(props.asJava)) match {
+    CloudSinkBucketOptions(GCPStorageSinkConfigDefBuilder(props)) match {
       case Left(value) => fail(value.toString)
       case Right(value) =>
         value.map(_.dataStorage) should be(List(DataStorageSettings(true, true, true, false, false)))
@@ -119,7 +118,7 @@ class GCPStorageGCPStorageSinkConfigDefBuilderTest
            |""".stripMargin,
     )
 
-    CloudSinkBucketOptions(GCPStorageSinkConfigDefBuilder(props.asJava)) match {
+    CloudSinkBucketOptions(GCPStorageSinkConfigDefBuilder(props)) match {
       case Left(value) => fail(value.toString)
       case Right(value) =>
         value.map(_.dataStorage) should be(
@@ -137,8 +136,8 @@ class GCPStorageGCPStorageSinkConfigDefBuilderTest
     )
 
     val commitPolicy =
-      GCPStorageSinkConfigDefBuilder(props.asJava).commitPolicy(
-        GCPStorageSinkConfigDefBuilder(props.asJava).getKCQL.head,
+      GCPStorageSinkConfigDefBuilder(props).commitPolicy(
+        GCPStorageSinkConfigDefBuilder(props).getKCQL.head,
       )
 
     commitPolicy.conditions should be(
@@ -157,8 +156,8 @@ class GCPStorageGCPStorageSinkConfigDefBuilderTest
     )
 
     val commitPolicy =
-      GCPStorageSinkConfigDefBuilder(props.asJava).commitPolicy(
-        GCPStorageSinkConfigDefBuilder(props.asJava).getKCQL.head,
+      GCPStorageSinkConfigDefBuilder(props).commitPolicy(
+        GCPStorageSinkConfigDefBuilder(props).getKCQL.head,
       )
 
     commitPolicy.conditions should be(
@@ -175,8 +174,8 @@ class GCPStorageGCPStorageSinkConfigDefBuilderTest
     )
 
     val commitPolicy =
-      GCPStorageSinkConfigDefBuilder(props.asJava).commitPolicy(
-        GCPStorageSinkConfigDefBuilder(props.asJava).getKCQL.head,
+      GCPStorageSinkConfigDefBuilder(props).commitPolicy(
+        GCPStorageSinkConfigDefBuilder(props).getKCQL.head,
       )
 
     commitPolicy.conditions should be(
@@ -193,7 +192,7 @@ class GCPStorageGCPStorageSinkConfigDefBuilderTest
       "connect.gcpstorage.kcql" -> s"insert into $BucketName:$PrefixName select * from $TopicName BATCH = 150 STOREAS `CSV` LIMIT 550",
     )
 
-    val kcql = GCPStorageSinkConfigDefBuilder(props.asJava).getKCQL
+    val kcql = GCPStorageSinkConfigDefBuilder(props).getKCQL
 
     kcql.head.getBatchSize should be(150)
     kcql.head.getLimit should be(550)
@@ -204,7 +203,7 @@ class GCPStorageGCPStorageSinkConfigDefBuilderTest
       "connect.gcpstorage.kcql" -> s"insert into $BucketName:$PrefixName select * from $TopicName STOREAS `JSON` WITH_FLUSH_COUNT = 1 PROPERTIES('${DataStorageSettings.StoreEnvelopeKey}'=true, '${DataStorageSettings.StoreKeyKey}'=true, '${DataStorageSettings.StoreValueKey}'=true, '${DataStorageSettings.StoreMetadataKey}'=false, '${DataStorageSettings.StoreHeadersKey}'=false)",
     )
 
-    CloudSinkBucketOptions(GCPStorageSinkConfigDefBuilder(props.asJava)) match {
+    CloudSinkBucketOptions(GCPStorageSinkConfigDefBuilder(props)) match {
       case Left(value) => fail(value.toString)
       case Right(value) =>
         value.map(_.dataStorage) should be(List(DataStorageSettings(envelope = true,
@@ -221,7 +220,7 @@ class GCPStorageGCPStorageSinkConfigDefBuilderTest
       "connect.gcpstorage.kcql" -> s"insert into $BucketName:$PrefixName select * from $TopicName STOREAS `JSON` WITH_FLUSH_COUNT = 1 PROPERTIES('${DataStorageSettings.StoreEnvelopeKey}'=true, '${DataStorageSettings.StoreKeyKey}'=true, '${DataStorageSettings.StoreValueKey}'=true, '${DataStorageSettings.StoreMetadataKey}'=false, '${DataStorageSettings.StoreHeadersKey}'=false)",
     )
 
-    CloudSinkBucketOptions(GCPStorageSinkConfigDefBuilder(props.asJava)) match {
+    CloudSinkBucketOptions(GCPStorageSinkConfigDefBuilder(props)) match {
       case Left(value) => fail(value.toString)
       case Right(value) =>
         value.map(_.dataStorage) should be(List(DataStorageSettings(envelope = true,
@@ -238,7 +237,7 @@ class GCPStorageGCPStorageSinkConfigDefBuilderTest
       "connect.gcpstorage.kcql" -> s"insert into $BucketName:$PrefixName select * from $TopicName STOREAS `BYTES_VALUEONLY` WITH_FLUSH_COUNT = 1",
     )
 
-    CloudSinkBucketOptions(GCPStorageSinkConfigDefBuilder(props.asJava)).left.value.getMessage should startWith(
+    CloudSinkBucketOptions(GCPStorageSinkConfigDefBuilder(props)).left.value.getMessage should startWith(
       "Unsupported format - BYTES_VALUEONLY.  Please note",
     )
   }
@@ -248,7 +247,7 @@ class GCPStorageGCPStorageSinkConfigDefBuilderTest
       "connect.gcpstorage.kcql" -> s"insert into $BucketName:$PrefixName select * from $TopicName STOREAS `BYTES` WITH_FLUSH_COUNT = 3",
     )
 
-    CloudSinkBucketOptions(GCPStorageSinkConfigDefBuilder(props.asJava)).left.value.getMessage should startWith(
+    CloudSinkBucketOptions(GCPStorageSinkConfigDefBuilder(props)).left.value.getMessage should startWith(
       "FLUSH_COUNT > 1 is not allowed for BYTES",
     )
   }

--- a/kafka-connect-gcp-storage/src/test/scala/io/lenses/streamreactor/connect/gcp/storage/sink/config/GCPStorageSinkConfigTest.scala
+++ b/kafka-connect-gcp-storage/src/test/scala/io/lenses/streamreactor/connect/gcp/storage/sink/config/GCPStorageSinkConfigTest.scala
@@ -23,8 +23,6 @@ import io.lenses.streamreactor.connect.gcp.storage.model.location.GCPStorageLoca
 import org.scalatest.funsuite.AnyFunSuite
 import org.scalatest.matchers.should.Matchers
 
-import scala.jdk.CollectionConverters.MapHasAsJava
-
 class GCPStorageSinkConfigTest extends AnyFunSuite with Matchers {
   private implicit val connectorTaskId = ConnectorTaskId("connector", 1, 0)
   private implicit val cloudLocationValidator: CloudLocationValidator = GCPStorageLocationValidator
@@ -33,7 +31,7 @@ class GCPStorageSinkConfigTest extends AnyFunSuite with Matchers {
       "connect.gcpstorage.kcql" -> s"insert into mybucket:myprefix select * from TopicName PARTITIONBY _key STOREAS `CSV` WITHPARTITIONER=Values WITH_FLUSH_COUNT = 1 PROPERTIES('${DataStorageSettings.StoreEnvelopeKey}'=true)",
     )
 
-    CloudSinkBucketOptions(GCPStorageSinkConfigDefBuilder(props.asJava)) match {
+    CloudSinkBucketOptions(GCPStorageSinkConfigDefBuilder(props)) match {
       case Left(value) => value.getMessage shouldBe "Envelope is not supported for format CSV."
       case Right(_)    => fail("Should fail since envelope and CSV storage is not allowed")
     }
@@ -44,7 +42,7 @@ class GCPStorageSinkConfigTest extends AnyFunSuite with Matchers {
       "connect.gcpstorage.kcql" -> s"insert into mybucket:myprefix select * from TopicName PARTITIONBY _key STOREAS `Parquet` WITHPARTITIONER=Values WITH_FLUSH_COUNT = 1 PROPERTIES('${DataStorageSettings.StoreEnvelopeKey}'=true)",
     )
 
-    CloudSinkBucketOptions(GCPStorageSinkConfigDefBuilder(props.asJava)) match {
+    CloudSinkBucketOptions(GCPStorageSinkConfigDefBuilder(props)) match {
       case Left(error) => fail("Should not fail since envelope and Parquet storage is allowed", error)
       case Right(_)    => succeed
     }
@@ -54,7 +52,7 @@ class GCPStorageSinkConfigTest extends AnyFunSuite with Matchers {
       "connect.gcpstorage.kcql" -> s"insert into mybucket:myprefix select * from TopicName PARTITIONBY _key STOREAS `Avro` WITHPARTITIONER=Values WITH_FLUSH_COUNT = 1 PROPERTIES('${DataStorageSettings.StoreEnvelopeKey}'=true)",
     )
 
-    CloudSinkBucketOptions(GCPStorageSinkConfigDefBuilder(props.asJava)) match {
+    CloudSinkBucketOptions(GCPStorageSinkConfigDefBuilder(props)) match {
       case Left(error) => fail("Should not fail since envelope and Avro storage is allowed", error)
       case Right(_)    => succeed
     }
@@ -64,7 +62,7 @@ class GCPStorageSinkConfigTest extends AnyFunSuite with Matchers {
       "connect.gcpstorage.kcql" -> s"insert into mybucket:myprefix select * from TopicName PARTITIONBY _key STOREAS `Json` WITHPARTITIONER=Values WITH_FLUSH_COUNT = 1 PROPERTIES('${DataStorageSettings.StoreEnvelopeKey}'=true)",
     )
 
-    CloudSinkBucketOptions(GCPStorageSinkConfigDefBuilder(props.asJava)) match {
+    CloudSinkBucketOptions(GCPStorageSinkConfigDefBuilder(props)) match {
       case Left(error) => fail("Should not fail since envelope and Json storage is allowed", error)
       case Right(_)    => succeed
     }
@@ -74,7 +72,7 @@ class GCPStorageSinkConfigTest extends AnyFunSuite with Matchers {
       "connect.gcpstorage.kcql" -> s"insert into mybucket:myprefix select * from TopicName PARTITIONBY _key STOREAS `Text` WITHPARTITIONER=Values WITH_FLUSH_COUNT = 1 PROPERTIES('${DataStorageSettings.StoreEnvelopeKey}'=true)",
     )
 
-    CloudSinkBucketOptions(GCPStorageSinkConfigDefBuilder(props.asJava)) match {
+    CloudSinkBucketOptions(GCPStorageSinkConfigDefBuilder(props)) match {
       case Left(value) => value.getMessage shouldBe "Envelope is not supported for format TEXT."
       case Right(_)    => fail("Should fail since text and envelope storage is not allowed")
     }
@@ -84,7 +82,7 @@ class GCPStorageSinkConfigTest extends AnyFunSuite with Matchers {
       "connect.gcpstorage.kcql" -> s"insert into mybucket:myprefix select * from TopicName PARTITIONBY _key STOREAS `Bytes` WITHPARTITIONER=Values WITH_FLUSH_COUNT = 1 PROPERTIES('${DataStorageSettings.StoreEnvelopeKey}'=true)",
     )
 
-    CloudSinkBucketOptions(GCPStorageSinkConfigDefBuilder(props.asJava)) match {
+    CloudSinkBucketOptions(GCPStorageSinkConfigDefBuilder(props)) match {
       case Left(value) => value.getMessage shouldBe "Envelope is not supported for format BYTES."
       case Right(_)    => fail("Should fail since envelope and bytes storage is not allowed")
     }

--- a/kafka-connect-influxdb/src/main/scala/io/lenses/streamreactor/connect/influx/InfluxSinkTask.scala
+++ b/kafka-connect-influxdb/src/main/scala/io/lenses/streamreactor/connect/influx/InfluxSinkTask.scala
@@ -32,6 +32,7 @@ import org.apache.kafka.connect.sink.SinkTask
 
 import java.util
 import scala.jdk.CollectionConverters.CollectionHasAsScala
+import scala.jdk.CollectionConverters.MapHasAsScala
 
 /**
   * <h1>InfluxSinkTask</h1>
@@ -54,7 +55,7 @@ class InfluxSinkTask extends SinkTask with StrictLogging {
     val conf = if (context.configs().isEmpty) props else context.configs()
 
     InfluxConfig.config.parse(conf)
-    val sinkConfig = InfluxConfig(conf)
+    val sinkConfig = InfluxConfig(conf.asScala.toMap)
     enableProgress = sinkConfig.getBoolean(InfluxConfigConstants.PROGRESS_COUNTER_ENABLED)
     val influxSettings = InfluxSettings(sinkConfig)
 

--- a/kafka-connect-influxdb/src/main/scala/io/lenses/streamreactor/connect/influx/config/InfluxConfig.scala
+++ b/kafka-connect-influxdb/src/main/scala/io/lenses/streamreactor/connect/influx/config/InfluxConfig.scala
@@ -23,8 +23,6 @@ import io.lenses.streamreactor.common.config.base.traits.KcqlSettings
 import io.lenses.streamreactor.common.config.base.traits.NumberRetriesSettings
 import io.lenses.streamreactor.common.config.base.traits.UserSettings
 
-import java.util
-
 import org.apache.kafka.common.config.ConfigDef
 import org.apache.kafka.common.config.ConfigDef.Importance
 import org.apache.kafka.common.config.ConfigDef.Type
@@ -157,7 +155,7 @@ object InfluxConfig {
   *
   * Holds config, extends AbstractConfig.
   */
-case class InfluxConfig(props: util.Map[String, String])
+case class InfluxConfig(props: Map[String, String])
     extends BaseConfig(InfluxConfigConstants.CONNECTOR_PREFIX, InfluxConfig.config, props)
     with KcqlSettings
     with ErrorPolicySettings

--- a/kafka-connect-influxdb/src/test/scala/io/lenses/streamreactor/connect/influx/config/InfluxSettingsTest.scala
+++ b/kafka-connect-influxdb/src/test/scala/io/lenses/streamreactor/connect/influx/config/InfluxSettingsTest.scala
@@ -24,7 +24,6 @@ import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 
 import scala.jdk.CollectionConverters.ListHasAsScala
-import scala.jdk.CollectionConverters.MapHasAsJava
 
 class InfluxSettingsTest extends AnyWordSpec with Matchers with MockitoSugar {
 
@@ -43,7 +42,7 @@ class InfluxSettingsTest extends AnyWordSpec with Matchers with MockitoSugar {
         InfluxConfigConstants.INFLUX_CONNECTION_USER_CONFIG     -> "myuser",
         InfluxConfigConstants.INFLUX_CONNECTION_PASSWORD_CONFIG -> "apass",
         InfluxConfigConstants.KCQL_CONFIG                       -> QUERY_ALL,
-      ).asJava
+      )
 
       val config = InfluxConfig(props)
       InfluxSettings(config)
@@ -58,7 +57,7 @@ class InfluxSettingsTest extends AnyWordSpec with Matchers with MockitoSugar {
         InfluxConfigConstants.INFLUX_CONNECTION_USER_CONFIG     -> "myuser",
         InfluxConfigConstants.INFLUX_CONNECTION_PASSWORD_CONFIG -> "apass",
         InfluxConfigConstants.KCQL_CONFIG                       -> QUERY_ALL,
-      ).asJava
+      )
 
       val config = InfluxConfig(props)
       InfluxSettings(config)
@@ -77,7 +76,7 @@ class InfluxSettingsTest extends AnyWordSpec with Matchers with MockitoSugar {
         InfluxConfigConstants.INFLUX_CONNECTION_USER_CONFIG -> user,
         InfluxConfigConstants.KCQL_CONFIG                   -> QUERY_ALL,
         InfluxConfigConstants.CONSISTENCY_CONFIG            -> "SOMELEVEL",
-      ).asJava
+      )
 
       val config = InfluxConfig(props)
       InfluxSettings(config)
@@ -95,7 +94,7 @@ class InfluxSettingsTest extends AnyWordSpec with Matchers with MockitoSugar {
         InfluxConfigConstants.INFLUX_CONNECTION_USER_CONFIG     -> "",
         InfluxConfigConstants.KCQL_CONFIG                       -> QUERY_ALL,
         InfluxConfigConstants.INFLUX_CONNECTION_PASSWORD_CONFIG -> "apass",
-      ).asJava
+      )
 
       val config = InfluxConfig(props)
       InfluxSettings(config)
@@ -113,7 +112,7 @@ class InfluxSettingsTest extends AnyWordSpec with Matchers with MockitoSugar {
       InfluxConfigConstants.INFLUX_CONNECTION_USER_CONFIG -> user,
       InfluxConfigConstants.KCQL_CONFIG                   -> QUERY_ALL,
       InfluxConfigConstants.CONSISTENCY_CONFIG            -> WriteConsistency.QUORUM.toString,
-    ).asJava
+    )
 
     val config = InfluxConfig(props)
 
@@ -140,7 +139,7 @@ class InfluxSettingsTest extends AnyWordSpec with Matchers with MockitoSugar {
       InfluxConfigConstants.INFLUX_CONNECTION_PASSWORD_CONFIG -> pass,
       InfluxConfigConstants.KCQL_CONFIG                       -> QUERY_SELECT,
       InfluxConfigConstants.CONSISTENCY_CONFIG                -> WriteConsistency.ANY.toString,
-    ).asJava
+    )
 
     val config = InfluxConfig(props)
 
@@ -168,7 +167,7 @@ class InfluxSettingsTest extends AnyWordSpec with Matchers with MockitoSugar {
       InfluxConfigConstants.INFLUX_CONNECTION_PASSWORD_CONFIG -> pass,
       InfluxConfigConstants.KCQL_CONFIG                       -> QUERY_SELECT_AND_TIMESTAMP,
       InfluxConfigConstants.CONSISTENCY_CONFIG                -> WriteConsistency.ONE.toString,
-    ).asJava
+    )
 
     val config = InfluxConfig(props)
 
@@ -197,7 +196,7 @@ class InfluxSettingsTest extends AnyWordSpec with Matchers with MockitoSugar {
       InfluxConfigConstants.INFLUX_CONNECTION_PASSWORD_CONFIG -> pass,
       InfluxConfigConstants.KCQL_CONFIG                       -> QUERY_SELECT_AND_TIMESTAMP_SYSTEM,
       InfluxConfigConstants.CONSISTENCY_CONFIG                -> WriteConsistency.ONE.toString,
-    ).asJava
+    )
 
     val config = InfluxConfig(props)
 

--- a/kafka-connect-jms/src/it/scala/io/lenses/streamreactor/connect/jms/ItTestBase.scala
+++ b/kafka-connect-jms/src/it/scala/io/lenses/streamreactor/connect/jms/ItTestBase.scala
@@ -35,7 +35,6 @@ import java.io.BufferedWriter
 import java.io.ByteArrayOutputStream
 import java.io.FileWriter
 import java.nio.file.Paths
-import java.util
 import java.util.UUID
 import javax.jms.BytesMessage
 import javax.jms.Session
@@ -121,8 +120,8 @@ trait ItTestBase extends AnyWordSpec with Matchers with MockitoSugar {
     topics:           String,
     url:              String,
     customProperties: Map[String, String] = Map(),
-  ): util.Map[String, String] =
-    (Map("topics" -> topics) ++ getProps(kcql, url) ++ customProperties).asJava
+  ): Map[String, String] =
+    Map("topics" -> topics) ++ getProps(kcql, url) ++ customProperties
 
   def getProps(kcql: String, url: String): Map[String, String] =
     Map(

--- a/kafka-connect-jms/src/it/scala/io/lenses/streamreactor/connect/jms/sink/JMSSinkTaskTest.scala
+++ b/kafka-connect-jms/src/it/scala/io/lenses/streamreactor/connect/jms/sink/JMSSinkTaskTest.scala
@@ -37,6 +37,7 @@ import javax.jms.Message
 import javax.jms.MessageListener
 import javax.jms.Session
 import javax.jms.TextMessage
+import scala.jdk.CollectionConverters.MapHasAsJava
 import scala.language.reflectiveCalls
 import scala.reflect.io.Path
 import scala.util.Using.{ resource => using }
@@ -105,16 +106,17 @@ class JMSSinkTaskTest extends ItTestBase with BeforeAndAfterAll with MockitoSuga
 
         val kcql      = s"${getKCQL(topicName, kafkaTopic1, "TOPIC")};${getKCQL(queueName, kafkaTopic2, "QUEUE")}"
         val props     = getSinkProps(kcql, kafkaTopic1, brokerUrl)
+        val javaProps = props.asJava
         val context   = mock[SinkTaskContext]
         val topicsSet = new util.HashSet[TopicPartition]()
         topicsSet.add(new TopicPartition(kafkaTopic1, 0))
         topicsSet.add(new TopicPartition(kafkaTopic2, 0))
         when(context.assignment()).thenReturn(topicsSet)
-        when(context.configs()).thenReturn(props)
+        when(context.configs()).thenReturn(javaProps)
 
         val task = new JMSSinkTask
         task.initialize(context)
-        task.start(props)
+        task.start(javaProps)
 
         val records = new java.util.ArrayList[SinkRecord]
         records.add(record1)

--- a/kafka-connect-jms/src/it/scala/io/lenses/streamreactor/connect/jms/sink/converters/MessageConverterTest.scala
+++ b/kafka-connect-jms/src/it/scala/io/lenses/streamreactor/connect/jms/sink/converters/MessageConverterTest.scala
@@ -39,7 +39,6 @@ import javax.jms.MapMessage
 import javax.jms.ObjectMessage
 import javax.jms.TextMessage
 import scala.jdk.CollectionConverters.ListHasAsScala
-import scala.jdk.CollectionConverters.MapHasAsJava
 import scala.jdk.CollectionConverters.MapHasAsScala
 import scala.reflect.io.Path
 import scala.util.Try
@@ -63,7 +62,7 @@ class MessageConverterTest extends AnyWordSpec with Matchers with ItTestBase wit
       val kcqlT       = getKCQL(topicName, kafkaTopic1, "TOPIC")
       val kcqlQ       = getKCQL(queueName, kafkaTopic1, "QUEUE")
       val props       = getProps(s"$kcqlQ;$kcqlT", JMS_URL)
-      val config      = JMSConfig(props.asJava)
+      val config      = JMSConfig(props)
       val settings    = JMSSettings(config, true)
       val setting     = settings.settings.head
 
@@ -109,7 +108,7 @@ class MessageConverterTest extends AnyWordSpec with Matchers with ItTestBase wit
       val kcqlT       = getKCQL(topicName, kafkaTopic1, "TOPIC")
       val kcqlQ       = getKCQL(queueName, kafkaTopic1, "QUEUE")
       val props       = getProps(s"$kcqlQ;$kcqlT", JMS_URL)
-      val config      = JMSConfig(props.asJava)
+      val config      = JMSConfig(props)
       val settings    = JMSSettings(config, true)
       val setting     = settings.settings.head
 
@@ -159,7 +158,7 @@ class MessageConverterTest extends AnyWordSpec with Matchers with ItTestBase wit
       val queueName   = UUID.randomUUID().toString
       val kcql        = getKCQL(queueName, kafkaTopic1, "QUEUE")
       val props       = getProps(kcql, JMS_URL)
-      val config      = JMSConfig(props.asJava)
+      val config      = JMSConfig(props)
       val settings    = JMSSettings(config, true)
       val setting     = settings.settings.head
 
@@ -195,7 +194,7 @@ class MessageConverterTest extends AnyWordSpec with Matchers with ItTestBase wit
       val kcqlQ = getKCQL(queueName, kafkaTopic1, "QUEUE")
 
       val props    = getProps(s"$kcqlQ;$kcqlT", JMS_URL)
-      val config   = JMSConfig(props.asJava)
+      val config   = JMSConfig(props)
       val settings = JMSSettings(config, true)
       val setting  = settings.settings.head
       using(connectionFactory.createConnection()) { connection =>
@@ -253,7 +252,7 @@ class MessageConverterTest extends AnyWordSpec with Matchers with ItTestBase wit
       val queueName         = UUID.randomUUID().toString
       val kcql              = getKCQL(queueName, kafkaTopic1, "QUEUE")
       val props             = getProps(kcql, JMS_URL)
-      val config            = JMSConfig(props.asJava)
+      val config            = JMSConfig(props)
       val settings          = JMSSettings(config, true)
       val setting           = settings.settings.head
       val connectionFactory = new ActiveMQConnectionFactory("vm://localhost?broker.persistent=false")
@@ -287,7 +286,7 @@ class MessageConverterTest extends AnyWordSpec with Matchers with ItTestBase wit
       val props             = getProps(kcql, JMS_URL)
       val schema            = getProtobufSchema
       val struct            = getProtobufStruct(schema, "addrressed-person", 103, "addressed-person@gmail.com")
-      val config            = JMSConfig(props.asJava)
+      val config            = JMSConfig(props)
       val settings          = JMSSettings(config, true)
       val connectionFactory = new ActiveMQConnectionFactory("vm://localhost?broker.persistent=false")
       using(connectionFactory.createConnection()) { connection =>

--- a/kafka-connect-jms/src/it/scala/io/lenses/streamreactor/connect/jms/source/JMSReaderTest.scala
+++ b/kafka-connect-jms/src/it/scala/io/lenses/streamreactor/connect/jms/source/JMSReaderTest.scala
@@ -35,7 +35,6 @@ import org.scalatest.time.Span
 import java.util.UUID
 import javax.jms.Message
 import javax.jms.Session
-import scala.jdk.CollectionConverters.MapHasAsJava
 import scala.jdk.CollectionConverters.MapHasAsScala
 import scala.reflect.io.Path
 
@@ -64,7 +63,7 @@ class JMSReaderTest extends ItTestBase with BeforeAndAfterAll with Eventually {
     val kcql  = getKCQL(kafkaTopic, queueName, "QUEUE")
     val props = getProps(kcql, brokerUrl)
 
-    val config   = JMSConfig(props.asJava)
+    val config   = JMSConfig(props)
     val settings = JMSSettings(config, false)
     val reader   = JMSReader(settings)
 
@@ -89,7 +88,7 @@ class JMSReaderTest extends ItTestBase with BeforeAndAfterAll with Eventually {
     val avroMessages = getBytesMessage(messageCount, session)
     avroMessages.foreach(m => avroProducer.send(m))
 
-    val config   = JMSConfig(props.asJava)
+    val config   = JMSConfig(props)
     val settings = JMSSettings(config, sink = false)
     val reader   = JMSReader(settings)
 
@@ -125,7 +124,7 @@ class JMSReaderTest extends ItTestBase with BeforeAndAfterAll with Eventually {
     val messageSelector = "Fruit='apples'"
     val kcql            = kcqlWithMessageSelector(kafkaTopic, topicName, messageSelector)
     val props           = getProps(kcql, brokerUrl)
-    val config          = JMSConfig(props.asJava)
+    val config          = JMSConfig(props)
     val settings        = JMSSettings(config, false)
     val reader          = JMSReader(settings)
 

--- a/kafka-connect-jms/src/it/scala/io/lenses/streamreactor/connect/jms/source/JMSSessionProviderTest.scala
+++ b/kafka-connect-jms/src/it/scala/io/lenses/streamreactor/connect/jms/source/JMSSessionProviderTest.scala
@@ -32,7 +32,6 @@ import org.scalatest.concurrent.Eventually
 import java.util.UUID
 import javax.jms.Session
 import javax.naming.NameNotFoundException
-import scala.jdk.CollectionConverters.MapHasAsJava
 import scala.util.Try
 
 class JMSSessionProviderTest extends ItTestBase with BeforeAndAfterAll with Eventually {
@@ -45,7 +44,7 @@ class JMSSessionProviderTest extends ItTestBase with BeforeAndAfterAll with Even
     val queueName  = UUID.randomUUID().toString
     val kcql       = getKCQL(kafkaTopic, queueName, "QUEUE")
     val props      = getProps(kcql, brokerUrl)
-    val config     = JMSConfig(props.asJava)
+    val config     = JMSConfig(props)
     val settings   = JMSSettings(config, forAJmsConsumer)
     val provider   = JMSSessionProvider(settings, forAJmsConsumer)
     provider.queueConsumers.size shouldBe 1
@@ -60,7 +59,7 @@ class JMSSessionProviderTest extends ItTestBase with BeforeAndAfterAll with Even
     val topicName  = UUID.randomUUID().toString
     val kcql       = getKCQL(kafkaTopic, topicName, "TOPIC")
     val props      = getProps(kcql, brokerUrl)
-    val config     = JMSConfig(props.asJava)
+    val config     = JMSConfig(props)
     val settings   = JMSSettings(config, forAJmsConsumer)
     val provider   = JMSSessionProvider(settings, forAJmsConsumer)
     provider.queueConsumers.size shouldBe 0
@@ -75,7 +74,7 @@ class JMSSessionProviderTest extends ItTestBase with BeforeAndAfterAll with Even
     val queueName  = UUID.randomUUID().toString
     val kcql       = getKCQL(kafkaTopic, queueName, "QUEUE")
     val props      = getProps(kcql, brokerUrl)
-    val config     = JMSConfig(props.asJava)
+    val config     = JMSConfig(props)
     val settings   = JMSSettings(config, forAJmsProducer)
     val provider   = JMSSessionProvider(settings, forAJmsProducer)
     provider.queueConsumers.size shouldBe 0
@@ -90,7 +89,7 @@ class JMSSessionProviderTest extends ItTestBase with BeforeAndAfterAll with Even
     val topicName  = UUID.randomUUID().toString
     val kcql       = getKCQL(kafkaTopic, topicName, "TOPIC")
     val props      = getProps(kcql, brokerUrl)
-    val config     = JMSConfig(props.asJava)
+    val config     = JMSConfig(props)
     val settings   = JMSSettings(config, forAJmsProducer)
     val provider   = JMSSessionProvider(settings, forAJmsProducer)
     provider.queueConsumers.size shouldBe 0
@@ -105,7 +104,7 @@ class JMSSessionProviderTest extends ItTestBase with BeforeAndAfterAll with Even
     val topicName  = UUID.randomUUID().toString
     val kcql       = getKCQL(kafkaTopic, topicName, "TOPIC")
     val props      = getProps(kcql, brokerUrl)
-    val config     = JMSConfig(props.asJava)
+    val config     = JMSConfig(props)
     val settings   = JMSSettings(config, forAJmsProducer)
     val provider   = JMSSessionProvider(settings, forAJmsProducer)
     provider.close().isSuccess shouldBe true
@@ -119,7 +118,7 @@ class JMSSessionProviderTest extends ItTestBase with BeforeAndAfterAll with Even
       val topicName       = UUID.randomUUID().toString
       val kcql            = getKCQL(kafkaTopic, topicName, "TOPIC")
       val props           = getProps(kcql, brokerUrl)
-      val config          = JMSConfig(props.asJava)
+      val config          = JMSConfig(props)
       val validSettings   = JMSSettings(config, forAJmsConsumer)
       val invalidSettings = validSettings.copy(destinationSelector = DestinationSelector.JNDI)
 

--- a/kafka-connect-jms/src/main/scala/io/lenses/streamreactor/connect/jms/config/JMSConfig.scala
+++ b/kafka-connect-jms/src/main/scala/io/lenses/streamreactor/connect/jms/config/JMSConfig.scala
@@ -20,8 +20,6 @@ import org.apache.kafka.common.config.ConfigDef
 import org.apache.kafka.common.config.ConfigDef.Importance
 import org.apache.kafka.common.config.ConfigDef.Type
 
-import java.util
-
 object JMSConfig {
 
   val config: ConfigDef = new ConfigDef()
@@ -283,7 +281,7 @@ object JMSConfig {
   *
   * Holds config, extends AbstractConfig.
   */
-case class JMSConfig(props: util.Map[String, String])
+case class JMSConfig(props: Map[String, String])
     extends BaseConfig(JMSConfigConstants.CONNECTOR_PREFIX, JMSConfig.config, props)
     with KcqlSettings
     with ErrorPolicySettings

--- a/kafka-connect-jms/src/main/scala/io/lenses/streamreactor/connect/jms/config/JMSSettings.scala
+++ b/kafka-connect-jms/src/main/scala/io/lenses/streamreactor/connect/jms/config/JMSSettings.scala
@@ -15,6 +15,8 @@
  */
 package io.lenses.streamreactor.connect.jms.config
 
+import com.google.common.base.Splitter
+import com.typesafe.scalalogging.StrictLogging
 import io.lenses.kcql.FormatType
 import io.lenses.kcql.Kcql
 import io.lenses.streamreactor.common.errors.ErrorPolicy
@@ -23,13 +25,10 @@ import io.lenses.streamreactor.connect.converters.source.Converter
 import io.lenses.streamreactor.connect.jms.config.DestinationSelector.DestinationSelector
 import io.lenses.streamreactor.connect.jms.source.converters.CommonJMSMessageConverter
 import io.lenses.streamreactor.connect.jms.source.converters.{ JMSSourceMessageConverter => JMSMessageSourceConverter }
-import com.google.common.base.Splitter
-import com.typesafe.scalalogging.StrictLogging
 import org.apache.kafka.common.config.ConfigException
 import org.apache.kafka.common.config.types.Password
 
 import scala.jdk.CollectionConverters.IterableHasAsScala
-import scala.jdk.CollectionConverters.MapHasAsScala
 
 case class JMSSetting(
   source:           String,
@@ -119,7 +118,7 @@ object JMSSettings extends StrictLogging {
     val settings = kcql.map { r =>
       val jmsName = if (sink) r.getTarget else r.getSource
 
-      val converters = JMSConnectorConverters(sink)(r, config.props.asScala.toMap) match {
+      val converters = JMSConnectorConverters(sink)(r, config.props) match {
         case None                    => throw new ConfigException("Converters should not be empty")
         case Some(Left(exception))   => throw exception
         case Some(Right(converters)) => converters

--- a/kafka-connect-jms/src/main/scala/io/lenses/streamreactor/connect/jms/sink/JMSSinkTask.scala
+++ b/kafka-connect-jms/src/main/scala/io/lenses/streamreactor/connect/jms/sink/JMSSinkTask.scala
@@ -31,6 +31,7 @@ import org.apache.kafka.connect.sink.SinkTask
 
 import java.util
 import scala.jdk.CollectionConverters.IterableHasAsScala
+import scala.jdk.CollectionConverters.MapHasAsScala
 
 /**
   * <h1>JMSSinkTask</h1>
@@ -52,7 +53,7 @@ class JMSSinkTask extends SinkTask with StrictLogging {
 
     val conf = if (context.configs().isEmpty) props else context.configs()
     JMSConfig.config.parse(conf)
-    val sinkConfig = new JMSConfig(conf)
+    val sinkConfig = new JMSConfig(conf.asScala.toMap)
     val settings   = JMSSettings(sinkConfig, sink = true)
     enableProgress = sinkConfig.getBoolean(JMSConfigConstants.PROGRESS_COUNTER_ENABLED)
 

--- a/kafka-connect-jms/src/main/scala/io/lenses/streamreactor/connect/jms/source/JMSSourceConnector.scala
+++ b/kafka-connect-jms/src/main/scala/io/lenses/streamreactor/connect/jms/source/JMSSourceConnector.scala
@@ -35,7 +35,7 @@ import scala.jdk.CollectionConverters.SeqHasAsJava
   * stream-reactor
   */
 class JMSSourceConnector extends SourceConnector with StrictLogging {
-  private var configProps: util.Map[String, String] = _
+  private var configProps: Map[String, String] = _
   private val configDef = JMSConfig.config
   private val manifest  = JarManifest(getClass.getProtectionDomain.getCodeSource.getLocation)
 
@@ -43,31 +43,24 @@ class JMSSourceConnector extends SourceConnector with StrictLogging {
 
   def kcqlTaskScaling(maxTasks: Int): util.List[util.Map[String, String]] = {
     val raw = configProps.get(JMSConfigConstants.KCQL)
-    require(raw != null && raw.nonEmpty, s"No ${JMSConfigConstants.KCQL} provided!")
+    require(raw.nonEmpty, s"No ${JMSConfigConstants.KCQL} provided!")
 
     //sql1, sql2
-    val kcqls  = raw.split(";")
+    val kcqls  = raw.map(_.split(";"))
     val groups = ConnectorUtils.groupPartitions(kcqls.toList.asJava, maxTasks).asScala
 
     //split up the kcql statement based on the number of tasks.
     groups
       .filterNot(_.isEmpty)
       .map { g =>
-        val taskConfigs = new java.util.HashMap[String, String]
-        taskConfigs.putAll(configProps)
-        taskConfigs.put(JMSConfigConstants.KCQL, g.asScala.mkString(";")) //overwrite
-        taskConfigs.asScala.toMap.asJava
+        (configProps + (JMSConfigConstants.KCQL -> g.asScala.mkString(";"))).asJava
       }
   }.asJava
 
   def defaultTaskScaling(maxTasks: Int): util.List[util.Map[String, String]] = {
     val raw = configProps.get(JMSConfigConstants.KCQL)
     require(raw != null && raw.nonEmpty, s"No ${JMSConfigConstants.KCQL} provided!")
-    (1 to maxTasks).map { _ =>
-      val taskConfigs: util.Map[String, String] = new java.util.HashMap[String, String]
-      taskConfigs.putAll(configProps)
-      taskConfigs
-    }.toList.asJava
+    (1 to maxTasks).map(_ => configProps.asJava).toList.asJava
   }
 
   override def taskConfigs(maxTasks: Int): util.List[util.Map[String, String]] = {
@@ -81,7 +74,8 @@ class JMSSourceConnector extends SourceConnector with StrictLogging {
   override def config(): ConfigDef = configDef
 
   override def start(props: util.Map[String, String]): Unit = {
-    val config = new JMSConfig(props)
+    val scalaProps = props.asScala.toMap
+    val config     = new JMSConfig(scalaProps)
     configProps = config.props
   }
 

--- a/kafka-connect-jms/src/main/scala/io/lenses/streamreactor/connect/jms/source/JMSSourceTask.scala
+++ b/kafka-connect-jms/src/main/scala/io/lenses/streamreactor/connect/jms/source/JMSSourceTask.scala
@@ -34,6 +34,7 @@ import java.util.function.BiConsumer
 import javax.jms.Message
 import scala.concurrent.duration.FiniteDuration
 import scala.concurrent.duration._
+import scala.jdk.CollectionConverters.MapHasAsScala
 import scala.jdk.CollectionConverters.SeqHasAsJava
 import scala.util.Failure
 import scala.util.Success
@@ -61,7 +62,7 @@ class JMSSourceTask extends SourceTask with StrictLogging {
     val conf = if (context.configs().isEmpty) props else context.configs()
 
     JMSConfig.config.parse(conf)
-    val config   = new JMSConfig(conf)
+    val config   = new JMSConfig(conf.asScala.toMap)
     val settings = JMSSettings(config, sink = false)
     reader         = JMSReader(settings)
     enableProgress = config.getBoolean(JMSConfigConstants.PROGRESS_COUNTER_ENABLED)

--- a/kafka-connect-jms/src/test/scala/io/lenses/streamreactor/connect/jms/config/JMSSettingsTest.scala
+++ b/kafka-connect-jms/src/test/scala/io/lenses/streamreactor/connect/jms/config/JMSSettingsTest.scala
@@ -30,7 +30,6 @@ import org.scalatest.EitherValues
 
 import java.util.UUID
 import javax.naming.NameNotFoundException
-import scala.jdk.CollectionConverters.MapHasAsJava
 import scala.reflect.io.Path
 
 class JMSSettingsTest extends TestBase with BeforeAndAfterAll with EitherValues {
@@ -44,7 +43,7 @@ class JMSSettingsTest extends TestBase with BeforeAndAfterAll with EitherValues 
     val queueName   = UUID.randomUUID().toString
     val kcql        = getKCQL(kafkaTopic1, queueName, "QUEUE")
     val props       = getProps(kcql, JMS_URL)
-    val config      = JMSConfig(props.asJava)
+    val config      = JMSConfig(props)
     val settings    = JMSSettings(config, false)
     val setting     = settings.settings.head
     setting.source shouldBe queueName
@@ -60,7 +59,7 @@ class JMSSettingsTest extends TestBase with BeforeAndAfterAll with EitherValues 
     val topicName   = UUID.randomUUID().toString
     val kcql        = getKCQL(kafkaTopic1, topicName, "TOPIC")
     val props       = getProps(kcql, JMS_URL)
-    val config      = JMSConfig(props.asJava)
+    val config      = JMSConfig(props)
     val settings    = JMSSettings(config, false)
     val setting     = settings.settings.head
     setting.source shouldBe topicName
@@ -77,7 +76,7 @@ class JMSSettingsTest extends TestBase with BeforeAndAfterAll with EitherValues 
     val kcql        = getKCQL(kafkaTopic1, topicName, "TOPIC")
     val props =
       getProps(kcql, JMS_URL) ++ Map(JMSConfigConstants.DESTINATION_SELECTOR -> DestinationSelector.JNDI.toString)
-    val config   = JMSConfig(props.asJava)
+    val config   = JMSConfig(props)
     val settings = JMSSettings(config, false)
     val setting  = settings.settings.head
     setting.source shouldBe topicName
@@ -100,7 +99,7 @@ class JMSSettingsTest extends TestBase with BeforeAndAfterAll with EitherValues 
     val props = getProps(s"$kcqlQ;$kcqlT", JMS_URL) ++
       Map(JMSConfigConstants.DESTINATION_SELECTOR -> DestinationSelector.JNDI.toString) ++
       Map(JMSConfigConstants.TOPIC_SUBSCRIPTION_NAME -> "subscriptionName")
-    val config   = JMSConfig(props.asJava)
+    val config   = JMSConfig(props)
     val settings = JMSSettings(config, false)
     val queue    = settings.settings.head
 
@@ -136,7 +135,7 @@ class JMSSettingsTest extends TestBase with BeforeAndAfterAll with EitherValues 
       Map(
         JMSConfigConstants.DEFAULT_SOURCE_CONVERTER_CONFIG -> "io.lenses.streamreactor.connect.converters.source.AvroConverter",
       )
-    val config = JMSConfig(props.asJava)
+    val config = JMSConfig(props)
 
     val settings = JMSSettings(config, false)
     val queue    = settings.settings.head
@@ -168,7 +167,7 @@ class JMSSettingsTest extends TestBase with BeforeAndAfterAll with EitherValues 
     val kcqlT = getKCQL(kafkaTopic1, topicName, "TOPIC")
     val props = getProps(s"$kcqlQ;$kcqlT", JMS_URL)
 
-    val config   = JMSConfig(props.asJava)
+    val config   = JMSConfig(props)
     val settings = JMSSettings(config, false)
     val queue    = settings.settings.head
     queue.source shouldBe queueName
@@ -195,7 +194,7 @@ class JMSSettingsTest extends TestBase with BeforeAndAfterAll with EitherValues 
     val kcqlT = getKCQLAvroSinkConverter(kafkaTopic1, topicName, "TOPIC")
     val props = getProps(s"$kcqlQ;$kcqlT", JMS_URL)
 
-    val config   = JMSConfig(props.asJava)
+    val config   = JMSConfig(props)
     val settings = JMSSettings(config, true)
     val queue    = settings.settings.head
     queue.source shouldBe queueName
@@ -222,7 +221,7 @@ class JMSSettingsTest extends TestBase with BeforeAndAfterAll with EitherValues 
     val kcqlQ    = getKCQLFormat(kafkaTopic1, queueName, "QUEUE", "PROTOBUF")
     val kcqlT    = getKCQLFormat(kafkaTopic1, topicName, "TOPIC", "PROTOBUF")
     val props    = getProps(s"$kcqlQ;$kcqlT", JMS_URL)
-    val config   = JMSConfig(props.asJava)
+    val config   = JMSConfig(props)
     val settings = JMSSettings(config, true)
     val queue    = settings.settings.head
     queue.source shouldBe queueName
@@ -250,7 +249,7 @@ class JMSSettingsTest extends TestBase with BeforeAndAfterAll with EitherValues 
     val kcqlQ    = getKCQLStoreAsAddressedPerson(kafkaTopic1, queueName, "QUEUE")
     val kcqlT    = getKCQLEmptyStoredAsNonAddressedPerson(kafkaTopic1, topicName, "TOPIC")
     val props    = getProps(s"$kcqlQ;$kcqlT", JMS_URL)
-    val config   = JMSConfig(props.asJava)
+    val config   = JMSConfig(props)
     val settings = JMSSettings(config, true)
     val queue    = settings.settings.head
     queue.source shouldBe queueName
@@ -284,7 +283,7 @@ class JMSSettingsTest extends TestBase with BeforeAndAfterAll with EitherValues 
         JMSConfigConstants.DEFAULT_SINK_CONVERTER_CONFIG -> "io.lenses.streamreactor.connect.jms.sink.converters.AvroMessageConverter",
       )
 
-    val config   = JMSConfig(props.asJava)
+    val config   = JMSConfig(props)
     val settings = JMSSettings(config, true)
     val queue    = settings.settings.head
     queue.source shouldBe queueName
@@ -309,7 +308,7 @@ class JMSSettingsTest extends TestBase with BeforeAndAfterAll with EitherValues 
 
     val kcqlT    = kcqlWithMessageSelector(kafkaTopic1, topicName, MESSAGE_SELECTOR)
     val props    = getProps(kcqlT, JMS_URL)
-    val config   = JMSConfig(props.asJava)
+    val config   = JMSConfig(props)
     val settings = JMSSettings(config, false)
 
     val topic = settings.settings.head
@@ -334,7 +333,7 @@ class JMSSettingsTest extends TestBase with BeforeAndAfterAll with EitherValues 
         JMSConfigConstants.CONNECTION_FACTORY      -> CONNECTION_FACTORY,
         JMSConfigConstants.JMS_URL                 -> JMS_URL,
         JMSConfigConstants.DESTINATION_SELECTOR    -> DestinationSelector.JNDI.toString,
-      ).asJava
+      )
     val config = jms.config.JMSConfig(props)
     intercept[ConfigException] {
       JMSSettings(config, false)
@@ -351,7 +350,7 @@ class JMSSettingsTest extends TestBase with BeforeAndAfterAll with EitherValues 
         JMSConfigConstants.INITIAL_CONTEXT_FACTORY -> INITIAL_CONTEXT_FACTORY,
         JMSConfigConstants.CONNECTION_FACTORY      -> "plop",
         JMSConfigConstants.JMS_URL                 -> JMS_URL,
-      ).asJava
+      )
     val config   = jms.config.JMSConfig(props)
     val settings = JMSSettings(config, true)
     intercept[NameNotFoundException] {

--- a/kafka-connect-jms/src/test/scala/io/lenses/streamreactor/connect/jms/sink/converters/ProtoDynamicConverterTest.scala
+++ b/kafka-connect-jms/src/test/scala/io/lenses/streamreactor/connect/jms/sink/converters/ProtoDynamicConverterTest.scala
@@ -25,7 +25,6 @@ import org.scalatest.EitherValues
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 
-import scala.jdk.CollectionConverters.MapHasAsJava
 import java.util.UUID
 
 class ProtoDynamicConverterTest
@@ -43,7 +42,7 @@ class ProtoDynamicConverterTest
       val queueName   = UUID.randomUUID().toString
       val kcql        = getKCQL(queueName, kafkaTopic1, "QUEUE")
       val props       = getProps(kcql, JMS_URL)
-      val config      = JMSConfig(props.asJava)
+      val config      = JMSConfig(props)
       val settings    = JMSSettings(config, true)
       val setting     = settings.settings.head
       val schema      = getProtobufSchema

--- a/kafka-connect-jms/src/test/scala/io/lenses/streamreactor/connect/jms/sink/converters/ProtoStoredAsConverterTest.scala
+++ b/kafka-connect-jms/src/test/scala/io/lenses/streamreactor/connect/jms/sink/converters/ProtoStoredAsConverterTest.scala
@@ -31,7 +31,6 @@ import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 
 import java.util.UUID
-import scala.jdk.CollectionConverters.MapHasAsJava
 
 class ProtoStoredAsConverterTest
     extends AnyWordSpec
@@ -164,7 +163,7 @@ class ProtoStoredAsConverterTest
     schema:      Schema,
     struct:      Struct,
   ) = {
-    val config   = JMSConfig(props.asJava)
+    val config   = JMSConfig(props)
     val settings = JMSSettings(config, true)
     val setting  = settings.settings.head
 

--- a/kafka-connect-jms/src/test/scala/io/lenses/streamreactor/connect/jms/source/JMSSourceConnectorTest.scala
+++ b/kafka-connect-jms/src/test/scala/io/lenses/streamreactor/connect/jms/source/JMSSourceConnectorTest.scala
@@ -46,9 +46,9 @@ class JMSSourceConnectorTest extends TestBase with BeforeAndAfterAll {
 
     val connector = new JMSSourceConnector()
     connector.start(props = props.asJava)
-    val configs = connector.taskConfigs(3)
-    val config1 = configs.asScala.head.asScala
-    val config2 = configs.asScala.last.asScala
+    val configs = connector.taskConfigs(3).asScala
+    val config1 = configs.head.asScala
+    val config2 = configs.last.asScala
     config1(JMSConfigConstants.KCQL) shouldBe kcqlQ
     config2(JMSConfigConstants.KCQL) shouldBe kcqlT
     connector.stop()

--- a/kafka-connect-mongodb/src/it/scala/io/lenses/streamreactor/connect/mongodb/sink/MongoWriterTest.scala
+++ b/kafka-connect-mongodb/src/it/scala/io/lenses/streamreactor/connect/mongodb/sink/MongoWriterTest.scala
@@ -47,7 +47,6 @@ import org.scalatest.wordspec.AnyWordSpecLike
 import java.util.UUID
 import scala.collection.immutable.ListMap
 import scala.collection.immutable.ListSet
-import scala.jdk.CollectionConverters.MapHasAsJava
 import scala.jdk.CollectionConverters.SeqHasAsJava
 
 class MongoWriterTest extends MongoDBContainer with AnyWordSpecLike with Matchers with BeforeAndAfterAll {
@@ -414,7 +413,7 @@ class MongoWriterTest extends MongoDBContainer with AnyWordSpecLike with Matcher
         SslConfigs.SSL_TRUSTSTORE_PASSWORD_CONFIG -> "truststore-password",
         SslConfigs.SSL_KEYSTORE_LOCATION_CONFIG   -> keystoreFilePath,
         SslConfigs.SSL_KEYSTORE_PASSWORD_CONFIG   -> "keystore-password",
-      ).asJava
+      )
 
       val config   = MongoConfig(map)
       val settings = MongoSettings(config)
@@ -448,7 +447,7 @@ class MongoWriterTest extends MongoDBContainer with AnyWordSpecLike with Matcher
         MongoConfigConstants.DATABASE_CONFIG   -> "database1",
         MongoConfigConstants.CONNECTION_CONFIG -> "mongodb://localhost:27017/?ssl=true",
         MongoConfigConstants.KCQL_CONFIG       -> s"INSERT INTO $collectionName SELECT vehicle, vehicle.fullVIN, header.applicationId FROM topicA",
-      ).asJava
+      )
 
       val config      = MongoConfig(map)
       val settings    = MongoSettings(config)
@@ -476,7 +475,7 @@ class MongoWriterTest extends MongoDBContainer with AnyWordSpecLike with Matcher
         MongoConfigConstants.DATABASE_CONFIG   -> "database1",
         MongoConfigConstants.CONNECTION_CONFIG -> "mongodb://localhost:27017/?ssl=true",
         MongoConfigConstants.KCQL_CONFIG       -> s"UPSERT INTO $collectionName SELECT vehicle.fullVIN, header.applicationId FROM topicA pk vehicle.fullVIN",
-      ).asJava
+      )
 
       val config      = MongoConfig(map)
       val settings    = MongoSettings(config)
@@ -504,7 +503,7 @@ class MongoWriterTest extends MongoDBContainer with AnyWordSpecLike with Matcher
         MongoConfigConstants.DATABASE_CONFIG   -> "database1",
         MongoConfigConstants.CONNECTION_CONFIG -> "mongodb://localhost:27017/?ssl=true",
         MongoConfigConstants.KCQL_CONFIG       -> s"UPSERT INTO $collectionName SELECT sensorID, location.lon as lon, location.lat as lat FROM topicA pk location.lon",
-      ).asJava
+      )
 
       val config      = MongoConfig(map)
       val settings    = MongoSettings(config)

--- a/kafka-connect-mongodb/src/main/scala/io/lenses/streamreactor/connect/mongodb/config/MongoConfig.scala
+++ b/kafka-connect-mongodb/src/main/scala/io/lenses/streamreactor/connect/mongodb/config/MongoConfig.scala
@@ -22,8 +22,6 @@ import io.lenses.streamreactor.common.config.base.traits.KcqlSettings
 import io.lenses.streamreactor.common.config.base.traits.NumberRetriesSettings
 import io.lenses.streamreactor.common.config.base.traits.UserSettings
 
-import java.util
-
 import org.apache.kafka.common.config.ConfigDef
 import org.apache.kafka.common.config.ConfigDef.Importance
 import org.apache.kafka.common.config.ConfigDef.Type
@@ -152,7 +150,7 @@ object MongoConfig {
     .withClientSslSupport()
 }
 
-case class MongoConfig(props: util.Map[String, String])
+case class MongoConfig(props: Map[String, String])
     extends BaseConfig(MongoConfigConstants.CONNECTOR_PREFIX, MongoConfig.config, props)
     with KcqlSettings
     with DatabaseSettings

--- a/kafka-connect-mongodb/src/main/scala/io/lenses/streamreactor/connect/mongodb/sink/MongoSinkConnector.scala
+++ b/kafka-connect-mongodb/src/main/scala/io/lenses/streamreactor/connect/mongodb/sink/MongoSinkConnector.scala
@@ -66,7 +66,7 @@ class MongoSinkConnector extends SinkConnector with StrictLogging {
     */
   override def start(props: util.Map[String, String]): Unit = {
     Helpers.checkInputTopics(MongoConfigConstants.KCQL_CONFIG, props.asScala.toMap)
-    Try(MongoConfig(props)) match {
+    Try(MongoConfig(props.asScala.toMap)) match {
       case Failure(f) =>
         throw new ConnectException(s"Couldn't start Mongo sink due to configuration error: ${f.getMessage}", f)
       case _ =>

--- a/kafka-connect-mongodb/src/main/scala/io/lenses/streamreactor/connect/mongodb/sink/MongoSinkTask.scala
+++ b/kafka-connect-mongodb/src/main/scala/io/lenses/streamreactor/connect/mongodb/sink/MongoSinkTask.scala
@@ -29,6 +29,7 @@ import org.apache.kafka.connect.sink.SinkTask
 
 import java.util
 import scala.jdk.CollectionConverters.IterableHasAsScala
+import scala.jdk.CollectionConverters.MapHasAsScala
 import scala.util.Failure
 import scala.util.Success
 import scala.util.Try
@@ -57,7 +58,7 @@ class MongoSinkTask extends SinkTask with StrictLogging {
 
     printAsciiHeader(manifest, "/mongo-ascii.txt")
 
-    val taskConfig = Try(MongoConfig(conf)) match {
+    val taskConfig = Try(MongoConfig(conf.asScala.toMap)) match {
       case Failure(f) => throw new ConnectException("Couldn't start Mongo Sink due to configuration error.", f)
       case Success(s) => s
     }

--- a/kafka-connect-mongodb/src/test/scala/io/lenses/streamreactor/connect/mongodb/config/MongoSettingsTest.scala
+++ b/kafka-connect-mongodb/src/test/scala/io/lenses/streamreactor/connect/mongodb/config/MongoSettingsTest.scala
@@ -20,8 +20,6 @@ import org.apache.kafka.common.config.ConfigException
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 
-import scala.jdk.CollectionConverters.MapHasAsJava
-
 class MongoSettingsTest extends AnyWordSpec with Matchers {
   "MongoSinkSettings" should {
     "default the host if the hosts settings not provided" in {
@@ -29,7 +27,7 @@ class MongoSettingsTest extends AnyWordSpec with Matchers {
         MongoConfigConstants.DATABASE_CONFIG   -> "database1",
         MongoConfigConstants.CONNECTION_CONFIG -> "mongodb://localhost:27017",
         MongoConfigConstants.KCQL_CONFIG       -> "INSERT INTO collection1 SELECT cola as cold, colc FROM topic1",
-      ).asJava
+      )
 
       val config   = MongoConfig(map)
       val settings = MongoSettings(config)
@@ -46,7 +44,7 @@ class MongoSettingsTest extends AnyWordSpec with Matchers {
         MongoConfigConstants.DATABASE_CONFIG   -> "database1",
         MongoConfigConstants.CONNECTION_CONFIG -> "mongodb://localhost:27017",
         MongoConfigConstants.KCQL_CONFIG       -> "INSERT INTO collection1 SELECT * FROM topic1;INSERT INTO coll2 SELECT a as F1, b as F2 FROM topic2",
-      ).asJava
+      )
 
       val config   = MongoConfig(map)
       val settings = MongoSettings(config)
@@ -63,7 +61,7 @@ class MongoSettingsTest extends AnyWordSpec with Matchers {
         MongoConfigConstants.DATABASE_CONFIG   -> "database1",
         MongoConfigConstants.CONNECTION_CONFIG -> "mongodb://localhost:27017",
         MongoConfigConstants.KCQL_CONFIG       -> "INSERT INTO collection1 SELECT * FROM topic1 IGNORE a,b,c",
-      ).asJava
+      )
 
       val config   = MongoConfig(map)
       val settings = MongoSettings(config)
@@ -81,7 +79,7 @@ class MongoSettingsTest extends AnyWordSpec with Matchers {
         MongoConfigConstants.DATABASE_CONFIG   -> "database1",
         MongoConfigConstants.CONNECTION_CONFIG -> "mongodb://localhost:27017",
         MongoConfigConstants.KCQL_CONFIG       -> "INSERT INTO collection1 SELECT * FROM topic1 PK a,b",
-      ).asJava
+      )
 
       val config   = MongoConfig(map)
       val settings = MongoSettings(config)
@@ -99,7 +97,7 @@ class MongoSettingsTest extends AnyWordSpec with Matchers {
         MongoConfigConstants.DATABASE_CONFIG   -> "database1",
         MongoConfigConstants.CONNECTION_CONFIG -> "mongodb://localhost:27017",
         MongoConfigConstants.KCQL_CONFIG       -> "INSERT INTO  SELECT * FROM topic1",
-      ).asJava
+      )
 
       val config = MongoConfig(map)
       intercept[IllegalArgumentException] {
@@ -111,7 +109,7 @@ class MongoSettingsTest extends AnyWordSpec with Matchers {
       val map = Map(
         MongoConfigConstants.DATABASE_CONFIG -> "database1",
         MongoConfigConstants.KCQL_CONFIG     -> "INSERT INTO collection1 SELECT * FROM topic1",
-      ).asJava
+      )
 
       intercept[ConfigException] {
         val config = MongoConfig(map)
@@ -124,7 +122,7 @@ class MongoSettingsTest extends AnyWordSpec with Matchers {
         MongoConfigConstants.DATABASE_CONFIG   -> "",
         MongoConfigConstants.CONNECTION_CONFIG -> "mongodb://localhost:27017",
         MongoConfigConstants.KCQL_CONFIG       -> "INSERT INTO collection1 SELECT * FROM topic1",
-      ).asJava
+      )
 
       val config = MongoConfig(map)
       intercept[IllegalArgumentException] {
@@ -140,7 +138,7 @@ class MongoSettingsTest extends AnyWordSpec with Matchers {
         MongoConfigConstants.DATABASE_CONFIG   -> "db",
         MongoConfigConstants.CONNECTION_CONFIG -> "mongodb://localhost:27017",
         MongoConfigConstants.KCQL_CONFIG       -> "INSERT INTO collection1 SELECT * FROM topic1",
-      ).asJava
+      )
       val settings = MongoSettings(MongoConfig(map))
       settings.jsonDateTimeFields shouldBe Set.empty[List[String]]
     }
@@ -151,7 +149,7 @@ class MongoSettingsTest extends AnyWordSpec with Matchers {
         MongoConfigConstants.CONNECTION_CONFIG           -> "mongodb://localhost:27017",
         MongoConfigConstants.KCQL_CONFIG                 -> "INSERT INTO collection1 SELECT * FROM topic1",
         MongoConfigConstants.JSON_DATETIME_FIELDS_CONFIG -> "",
-      ).asJava
+      )
       val settings = MongoSettings(MongoConfig(map))
       settings.jsonDateTimeFields shouldBe Set.empty[Seq[String]]
     }
@@ -162,7 +160,7 @@ class MongoSettingsTest extends AnyWordSpec with Matchers {
         MongoConfigConstants.CONNECTION_CONFIG           -> "mongodb://localhost:27017",
         MongoConfigConstants.KCQL_CONFIG                 -> "INSERT INTO collection1 SELECT * FROM topic1",
         MongoConfigConstants.JSON_DATETIME_FIELDS_CONFIG -> "a, b, c.m, d, e.n.y, f",
-      ).asJava
+      )
       val settings = MongoSettings(MongoConfig(map))
       settings.jsonDateTimeFields shouldBe Set(
         List("a"),

--- a/kafka-connect-mongodb/src/test/scala/io/lenses/streamreactor/connect/mongodb/converters/SinkRecordConverterTest.scala
+++ b/kafka-connect-mongodb/src/test/scala/io/lenses/streamreactor/connect/mongodb/converters/SinkRecordConverterTest.scala
@@ -102,7 +102,7 @@ class SinkRecordConverterTest extends AnyWordSpec with Matchers {
   "fromJson()" should {
 
     "not modify any values for date fields when jsonDateTimeFields is NOT specified" in {
-      implicit val settings = MongoSettings(MongoConfig(baseConfig.asJava))
+      implicit val settings = MongoSettings(MongoConfig(baseConfig))
       val doc: Document                           = SinkRecordConverter.fromJson(parse(jsonStr))
       val map: Set[JavaMap.Entry[String, AnyRef]] = doc.entrySet().asScala.toSet
 
@@ -133,7 +133,7 @@ class SinkRecordConverterTest extends AnyWordSpec with Matchers {
           Map(
             MongoConfigConstants.JSON_DATETIME_FIELDS_CONFIG ->
               expectedDates.keySet.mkString(","),
-          )).asJava),
+          ))),
       )
       val doc: Document                           = SinkRecordConverter.fromJson(parse(jsonStr))
       val map: Set[JavaMap.Entry[String, AnyRef]] = doc.entrySet().asScala.toSet
@@ -159,11 +159,11 @@ class SinkRecordConverterTest extends AnyWordSpec with Matchers {
       println(s"jsonInt = $jsonInt")
 
       implicit val settings = MongoSettings(
-        MongoConfig((baseConfig ++
+        MongoConfig(baseConfig ++
           Map(
             MongoConfigConstants.JSON_DATETIME_FIELDS_CONFIG ->
               expectedDates.keySet.mkString(","),
-          )).asJava),
+          )),
       )
       val doc: Document                           = SinkRecordConverter.fromJson(parse(jsonInt))
       val map: Set[JavaMap.Entry[String, AnyRef]] = doc.entrySet().asScala.toSet
@@ -200,7 +200,7 @@ class SinkRecordConverterTest extends AnyWordSpec with Matchers {
         Map(
           MongoConfigConstants.JSON_DATETIME_FIELDS_CONFIG ->
             "a, b, c, d, e, f",
-        )).asJava))
+        ))))
 
       val doc: Document = filterNonParsableDates(SinkRecordConverter.fromJson(parse(jsonStr)))
 
@@ -243,7 +243,7 @@ class SinkRecordConverterTest extends AnyWordSpec with Matchers {
         Map(
           MongoConfigConstants.JSON_DATETIME_FIELDS_CONFIG ->
             "c.ts, e.n.x.ts",
-        )).asJava))
+        ))))
       val doc: Document                           = SinkRecordConverter.fromJson(parse(json))
       val map: Set[JavaMap.Entry[String, AnyRef]] = doc.entrySet().asScala.toSet
 
@@ -307,7 +307,7 @@ class SinkRecordConverterTest extends AnyWordSpec with Matchers {
         Map(
           MongoConfigConstants.JSON_DATETIME_FIELDS_CONFIG ->
             "A, B.N",
-        )).asJava))
+        ))))
 
       val doc = SinkRecordConverter.fromMap(map)
 
@@ -329,7 +329,7 @@ class SinkRecordConverterTest extends AnyWordSpec with Matchers {
           Map(
             MongoConfigConstants.JSON_DATETIME_FIELDS_CONFIG ->
               "subDoc.N, timestamp, subList.Y",
-          )).asJava),
+          ))),
       )
 
       //map is {A=0, subList=[Document{{X=100, Y=101}}, Document{{Y=102}}],

--- a/kafka-connect-mqtt/src/it/scala/io/lenses/streamreactor/connect/mqtt/sink/TestMqttWriter.scala
+++ b/kafka-connect-mqtt/src/it/scala/io/lenses/streamreactor/connect/mqtt/sink/TestMqttWriter.scala
@@ -45,8 +45,6 @@ import java.nio.file.Paths
 import java.util.UUID
 import scala.collection.mutable
 import scala.io.Source
-import scala.jdk.CollectionConverters.MapHasAsJava
-import scala.jdk.CollectionConverters.MapHasAsScala
 import scala.util.Failure
 import scala.util.Success
 import scala.util.Try
@@ -207,7 +205,7 @@ class TestMqttWriter extends AnyWordSpec with MqttCallback with ForEachTestConta
       MqttConfigConstants.USER_CONFIG                -> mqttUser,
     )
 
-    val config   = MqttSinkConfig(props.asJava)
+    val config   = MqttSinkConfig(props)
     val settings = MqttSinkSettings(config)
 
     val convertersMap = settings.sinksToConverters.map {
@@ -267,7 +265,7 @@ class TestMqttWriter extends AnyWordSpec with MqttCallback with ForEachTestConta
       MqttConfigConstants.KEEP_ALIVE_INTERVAL_CONFIG   -> "1000",
       MqttConfigConstants.PASSWORD_CONFIG              -> mqttPassword,
       MqttConfigConstants.USER_CONFIG                  -> mqttUser,
-    ).asJava
+    )
 
     val config   = MqttSinkConfig(props)
     val settings = MqttSinkSettings(config)
@@ -283,7 +281,7 @@ class TestMqttWriter extends AnyWordSpec with MqttCallback with ForEachTestConta
             )
         }
 
-        converter.initialize(props.asScala.toMap)
+        converter.initialize(props)
         topic -> converter
     }
 

--- a/kafka-connect-mqtt/src/it/scala/io/lenses/streamreactor/connect/mqtt/source/MqttManagerTest.scala
+++ b/kafka-connect-mqtt/src/it/scala/io/lenses/streamreactor/connect/mqtt/source/MqttManagerTest.scala
@@ -46,7 +46,6 @@ import java.nio.file.Paths
 import java.util
 import java.util.UUID
 import scala.jdk.CollectionConverters.ListHasAsScala
-import scala.jdk.CollectionConverters.MapHasAsJava
 
 class MqttManagerTest extends AnyWordSpec with ForAllTestContainer with Matchers with StrictLogging {
 
@@ -452,10 +451,8 @@ class MqttManagerTest extends AnyWordSpec with ForAllTestContainer with Matchers
         MqttConfigConstants.HOSTS_CONFIG                   -> getMqttConnectionUrl,
         MqttConfigConstants.QS_CONFIG                      -> qs.toString,
       )
-      val mqttManager = new MqttManager(MqttClientConnectionFn.apply,
-                                        sourcesToConvMap,
-                                        MqttSourceSettings(MqttSourceConfig(props.asJava)),
-      )
+      val mqttManager =
+        new MqttManager(MqttClientConnectionFn.apply, sourcesToConvMap, MqttSourceSettings(MqttSourceConfig(props)))
       Thread.sleep(2000)
 
       val message = "message"

--- a/kafka-connect-mqtt/src/main/scala/io/lenses/streamreactor/connect/mqtt/config/MqttConfig.scala
+++ b/kafka-connect-mqtt/src/main/scala/io/lenses/streamreactor/connect/mqtt/config/MqttConfig.scala
@@ -20,8 +20,6 @@ import org.apache.kafka.common.config.ConfigDef
 import org.apache.kafka.common.config.ConfigDef.Importance
 import org.apache.kafka.common.config.ConfigDef.Type
 
-import java.util
-
 /**
   * Created by andrew@datamountaineer.com on 27/08/2017.
   * stream-reactor
@@ -244,7 +242,7 @@ object MqttSourceConfig {
     )
 }
 
-case class MqttSourceConfig(props: util.Map[String, String])
+case class MqttSourceConfig(props: Map[String, String])
     extends BaseConfig(MqttConfigConstants.CONNECTOR_PREFIX, MqttSourceConfig.config, props)
     with MqttConfigBase
 
@@ -296,7 +294,7 @@ object MqttSinkConfig {
     )
 }
 
-case class MqttSinkConfig(props: util.Map[String, String])
+case class MqttSinkConfig(props: Map[String, String])
     extends BaseConfig(MqttConfigConstants.CONNECTOR_PREFIX, MqttSinkConfig.config, props)
     with MqttConfigBase
 

--- a/kafka-connect-mqtt/src/main/scala/io/lenses/streamreactor/connect/mqtt/sink/MqttSinkTask.scala
+++ b/kafka-connect-mqtt/src/main/scala/io/lenses/streamreactor/connect/mqtt/sink/MqttSinkTask.scala
@@ -53,7 +53,7 @@ class MqttSinkTask extends SinkTask with StrictLogging {
     val conf = if (context.configs().isEmpty) props else context.configs()
 
     MqttSinkConfig.config.parse(conf)
-    val sinkConfig = new MqttSinkConfig(conf)
+    val sinkConfig = new MqttSinkConfig(conf.asScala.toMap)
     enableProgress = sinkConfig.getBoolean(MqttConfigConstants.PROGRESS_COUNTER_ENABLED)
     val settings = MqttSinkSettings(sinkConfig)
 

--- a/kafka-connect-mqtt/src/main/scala/io/lenses/streamreactor/connect/mqtt/source/MqttSourceConnector.scala
+++ b/kafka-connect-mqtt/src/main/scala/io/lenses/streamreactor/connect/mqtt/source/MqttSourceConnector.scala
@@ -47,7 +47,7 @@ class MqttSourceConnector extends SourceConnector with StrictLogging {
     */
   override def taskConfigs(maxTasks: Int): util.List[util.Map[String, String]] = {
 
-    val settings = MqttSourceSettings(MqttSourceConfig(configProps))
+    val settings = MqttSourceSettings(MqttSourceConfig(configProps.asScala.toMap))
     val kcql     = settings.kcql
     if (maxTasks == 1 || kcql.length == 1) {
       Collections.singletonList(configProps)

--- a/kafka-connect-mqtt/src/main/scala/io/lenses/streamreactor/connect/mqtt/source/MqttSourceTask.scala
+++ b/kafka-connect-mqtt/src/main/scala/io/lenses/streamreactor/connect/mqtt/source/MqttSourceTask.scala
@@ -45,7 +45,7 @@ class MqttSourceTask extends SourceTask with StrictLogging {
   override def start(props: util.Map[String, String]): Unit = {
     printAsciiHeader(manifest, "/mqtt-source-ascii.txt")
 
-    val conf = if (context.configs().isEmpty) props else context.configs()
+    val conf = (if (context.configs().isEmpty) props else context.configs()).asScala.toMap
 
     val settings = MqttSourceSettings(MqttSourceConfig(conf))
 
@@ -77,7 +77,7 @@ class MqttSourceTask extends SourceTask with StrictLogging {
               s"Invalid ${MqttConfigConstants.KCQL_CONFIG} is invalid. $clazz should have an empty ctor!",
             )
         }
-        converter.initialize(conf.asScala.toMap)
+        converter.initialize(conf)
         topic -> converter
     }
 

--- a/kafka-connect-mqtt/src/test/scala/io/lenses/streamreactor/connect/mqtt/config/MqttSourceSettingsTest.scala
+++ b/kafka-connect-mqtt/src/test/scala/io/lenses/streamreactor/connect/mqtt/config/MqttSourceSettingsTest.scala
@@ -21,8 +21,6 @@ import org.apache.kafka.common.config.ConfigException
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 
-import scala.jdk.CollectionConverters.MapHasAsJava
-
 class MqttSourceSettingsTest extends AnyWordSpec with Matchers {
   "MqttSourceSetting" should {
 
@@ -41,7 +39,7 @@ class MqttSourceSettingsTest extends AnyWordSpec with Matchers {
             MqttConfigConstants.KEEP_ALIVE_INTERVAL_CONFIG     -> "1000",
             MqttConfigConstants.PASSWORD_CONFIG                -> "somepassw",
             MqttConfigConstants.USER_CONFIG                    -> "user",
-          ).asJava,
+          ),
         )
       }
       settings.mqttQualityOfService shouldBe 1
@@ -72,7 +70,7 @@ class MqttSourceSettingsTest extends AnyWordSpec with Matchers {
             MqttConfigConstants.KEEP_ALIVE_INTERVAL_CONFIG     -> "1000",
             MqttConfigConstants.PASSWORD_CONFIG                -> "somepassw",
             MqttConfigConstants.USER_CONFIG                    -> "user",
-          ).asJava,
+          ),
         )
       }
 
@@ -93,7 +91,7 @@ class MqttSourceSettingsTest extends AnyWordSpec with Matchers {
             MqttConfigConstants.KEEP_ALIVE_INTERVAL_CONFIG     -> "1000",
             MqttConfigConstants.PASSWORD_CONFIG                -> "somepassw",
             MqttConfigConstants.USER_CONFIG                    -> "user",
-          ).asJava,
+          ),
         )
       }
     }
@@ -114,7 +112,7 @@ class MqttSourceSettingsTest extends AnyWordSpec with Matchers {
               MqttConfigConstants.KEEP_ALIVE_INTERVAL_CONFIG     -> "1000",
               MqttConfigConstants.PASSWORD_CONFIG                -> "somepassw",
               MqttConfigConstants.USER_CONFIG                    -> "user",
-            ).asJava,
+            ),
           ),
         )
       }
@@ -136,7 +134,7 @@ class MqttSourceSettingsTest extends AnyWordSpec with Matchers {
               MqttConfigConstants.KEEP_ALIVE_INTERVAL_CONFIG     -> "1000",
               MqttConfigConstants.PASSWORD_CONFIG                -> "somepassw",
               MqttConfigConstants.USER_CONFIG                    -> "user",
-            ).asJava,
+            ),
           ),
         )
       }
@@ -157,7 +155,7 @@ class MqttSourceSettingsTest extends AnyWordSpec with Matchers {
               MqttConfigConstants.KEEP_ALIVE_INTERVAL_CONFIG     -> "1000",
               MqttConfigConstants.PASSWORD_CONFIG                -> "somepassw",
               MqttConfigConstants.USER_CONFIG                    -> "user",
-            ).asJava,
+            ),
           ),
         )
       }
@@ -177,7 +175,7 @@ class MqttSourceSettingsTest extends AnyWordSpec with Matchers {
             MqttConfigConstants.KEEP_ALIVE_INTERVAL_CONFIG     -> "1000",
             MqttConfigConstants.PASSWORD_CONFIG                -> "somepassw",
             MqttConfigConstants.USER_CONFIG                    -> "user",
-          ).asJava,
+          ),
         )
       }
     }
@@ -196,7 +194,7 @@ class MqttSourceSettingsTest extends AnyWordSpec with Matchers {
             MqttConfigConstants.KEEP_ALIVE_INTERVAL_CONFIG     -> "1000",
             MqttConfigConstants.PASSWORD_CONFIG                -> "somepassw",
             MqttConfigConstants.USER_CONFIG                    -> "user",
-          ).asJava,
+          ),
         )
       }
     }
@@ -215,7 +213,7 @@ class MqttSourceSettingsTest extends AnyWordSpec with Matchers {
             MqttConfigConstants.KEEP_ALIVE_INTERVAL_CONFIG     -> "1000",
             MqttConfigConstants.PASSWORD_CONFIG                -> "somepassw",
             MqttConfigConstants.USER_CONFIG                    -> "user",
-          ).asJava,
+          ),
         )
       }
     }

--- a/kafka-connect-mqtt/src/test/scala/io/lenses/streamreactor/connect/mqtt/source/MqttSourceConnectorTest.scala
+++ b/kafka-connect-mqtt/src/test/scala/io/lenses/streamreactor/connect/mqtt/source/MqttSourceConnectorTest.scala
@@ -24,6 +24,7 @@ import org.scalatest.wordspec.AnyWordSpec
 
 import scala.jdk.CollectionConverters.ListHasAsScala
 import scala.jdk.CollectionConverters.MapHasAsJava
+import scala.jdk.CollectionConverters.MapHasAsScala
 
 class MqttSourceConnectorTest extends AnyWordSpec with Matchers {
   val baseProps: Map[String, String] = Map(
@@ -113,5 +114,5 @@ class MqttSourceConnectorTest extends AnyWordSpec with Matchers {
   }
 
   def extractKcqls(configs: util.List[util.Map[String, String]]): Array[Array[String]] =
-    configs.asScala.map(t => MqttSourceSettings(MqttSourceConfig(t)).kcql).toArray
+    configs.asScala.map(t => MqttSourceSettings(MqttSourceConfig(t.asScala.toMap)).kcql).toArray
 }

--- a/kafka-connect-redis/src/it/scala/io/lenses/streamreactor/connect/redis/sink/writer/RedisCacheTest.scala
+++ b/kafka-connect-redis/src/it/scala/io/lenses/streamreactor/connect/redis/sink/writer/RedisCacheTest.scala
@@ -33,7 +33,6 @@ import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 import redis.clients.jedis.Jedis
 
-import scala.jdk.CollectionConverters.MapHasAsJava
 import scala.jdk.CollectionConverters.MapHasAsScala
 
 class RedisCacheTest
@@ -64,7 +63,7 @@ class RedisCacheTest
     }
     "write Kafka records to Redis using CACHE mode with JSON no schema" in new BasePropsContext {
       val QUERY_ALL = s"SELECT * FROM $TOPIC PK firstName, child.firstName"
-      val props     = (baseProps + (RedisConfigConstants.KCQL_CONFIG -> QUERY_ALL)).asJava
+      val props     = baseProps + (RedisConfigConstants.KCQL_CONFIG -> QUERY_ALL)
       val config    = RedisConfig(props)
       val settings  = RedisSinkSettings(config)
       val writer    = new RedisCache(settings, JedisClientBuilder.createClient(settings))
@@ -96,7 +95,7 @@ class RedisCacheTest
 
     "write Kafka records to Redis using CACHE mode" in new BasePropsContext {
       val QUERY_ALL = s"SELECT * FROM $TOPIC PK firstName, child.firstName"
-      val props     = (baseProps + (RedisConfigConstants.KCQL_CONFIG -> QUERY_ALL)).asJava
+      val props     = baseProps + (RedisConfigConstants.KCQL_CONFIG -> QUERY_ALL)
       val config    = RedisConfig(props)
       val settings  = RedisSinkSettings(config)
       val writer    = new RedisCache(settings, JedisClientBuilder.createClient(settings))
@@ -150,7 +149,7 @@ class RedisCacheTest
 
     "write Kafka records to Redis using CACHE mode and PK field is not in the selected fields" in new BasePropsContext {
       val QUERY_ALL = s"SELECT age FROM $TOPIC PK firstName"
-      val props     = (baseProps + (RedisConfigConstants.KCQL_CONFIG -> QUERY_ALL)).asJava
+      val props     = baseProps + (RedisConfigConstants.KCQL_CONFIG -> QUERY_ALL)
       val config    = RedisConfig(props)
       val settings  = RedisSinkSettings(config)
       val writer    = new RedisCache(settings, JedisClientBuilder.createClient(settings))
@@ -184,7 +183,7 @@ class RedisCacheTest
     "write Kafka records to Redis using CACHE mode with explicit KEY (using INSERT)" in new BasePropsContext {
       val TOPIC = "topic2"
       val KCQL  = s"INSERT INTO KEY_PREFIX_ SELECT * FROM $TOPIC PK firstName"
-      val props = (baseProps + (RedisConfigConstants.KCQL_CONFIG -> KCQL)).asJava
+      val props = baseProps + (RedisConfigConstants.KCQL_CONFIG -> KCQL)
 
       val config   = RedisConfig(props)
       val settings = RedisSinkSettings(config)
@@ -255,7 +254,7 @@ class RedisCacheTest
 
     "write Kafka records to Redis using CACHE mode and PK has default delimiter" in new BasePropsContext {
 
-      val props    = base_Props.asJava
+      val props    = base_Props
       val config   = RedisConfig(props)
       val settings = RedisSinkSettings(config)
       val writer   = new RedisCache(settings, JedisClientBuilder.createClient(settings))
@@ -273,7 +272,7 @@ class RedisCacheTest
     "write Kafka records to Redis using CACHE mode and PK has custom delimiter" in new BasePropsContext {
 
       val delimiter = "-"
-      val props     = (base_Props + (RedisConfigConstants.REDIS_PK_DELIMITER -> delimiter)).asJava
+      val props     = base_Props + (RedisConfigConstants.REDIS_PK_DELIMITER -> delimiter)
       val config    = RedisConfig(props)
       val settings  = RedisSinkSettings(config)
       val writer    = new RedisCache(settings, JedisClientBuilder.createClient(settings))
@@ -289,7 +288,7 @@ class RedisCacheTest
     "write Kafka records to Redis using CACHE mode and PK has custom delimiter but not set" in new BasePropsContext {
 
       val delimiter = "$"
-      val props     = base_Props.asJava
+      val props     = base_Props
       val config    = RedisConfig(props)
       val settings  = RedisSinkSettings(config)
       val writer    = new RedisCache(settings, JedisClientBuilder.createClient(settings))

--- a/kafka-connect-redis/src/it/scala/io/lenses/streamreactor/connect/redis/sink/writer/RedisGeoAddTest.scala
+++ b/kafka-connect-redis/src/it/scala/io/lenses/streamreactor/connect/redis/sink/writer/RedisGeoAddTest.scala
@@ -18,7 +18,6 @@ import redis.clients.jedis.Jedis
 import redis.clients.jedis.args.GeoUnit
 
 import scala.jdk.CollectionConverters.ListHasAsScala
-import scala.jdk.CollectionConverters.MapHasAsJava
 
 class RedisGeoAddTest extends AnyWordSpec with Matchers with MockitoSugar with ForAllTestContainer {
 
@@ -38,7 +37,7 @@ class RedisGeoAddTest extends AnyWordSpec with Matchers with MockitoSugar with F
         RedisConfigConstants.REDIS_HOST  -> "localhost",
         RedisConfigConstants.REDIS_PORT  -> container.mappedPort(6379).toString,
         RedisConfigConstants.KCQL_CONFIG -> KCQL,
-      ).asJava
+      )
 
       val config         = RedisConfig(props)
       val connectionInfo = new RedisConnectionInfo("localhost", container.mappedPort(6379), None)
@@ -81,7 +80,7 @@ class RedisGeoAddTest extends AnyWordSpec with Matchers with MockitoSugar with F
         RedisConfigConstants.REDIS_HOST  -> "localhost",
         RedisConfigConstants.REDIS_PORT  -> container.mappedPort(6379).toString,
         RedisConfigConstants.KCQL_CONFIG -> KCQL,
-      ).asJava
+      )
 
       val config         = RedisConfig(props)
       val connectionInfo = new RedisConnectionInfo("localhost", container.mappedPort(6379), None)
@@ -126,7 +125,7 @@ class RedisGeoAddTest extends AnyWordSpec with Matchers with MockitoSugar with F
         RedisConfigConstants.REDIS_HOST  -> "localhost",
         RedisConfigConstants.REDIS_PORT  -> container.mappedPort(6379).toString,
         RedisConfigConstants.KCQL_CONFIG -> KCQL,
-      ).asJava
+      )
 
       val config         = RedisConfig(props)
       val connectionInfo = new RedisConnectionInfo("localhost", container.mappedPort(6379), None)

--- a/kafka-connect-redis/src/it/scala/io/lenses/streamreactor/connect/redis/sink/writer/RedisInsertSortedSetTest.scala
+++ b/kafka-connect-redis/src/it/scala/io/lenses/streamreactor/connect/redis/sink/writer/RedisInsertSortedSetTest.scala
@@ -33,7 +33,6 @@ import org.scalatest.wordspec.AnyWordSpec
 import redis.clients.jedis.Jedis
 
 import scala.jdk.CollectionConverters.ListHasAsScala
-import scala.jdk.CollectionConverters.MapHasAsJava
 
 class RedisInsertSortedSetTest extends AnyWordSpec with Matchers with MockitoSugar with ForAllTestContainer {
 
@@ -53,7 +52,7 @@ class RedisInsertSortedSetTest extends AnyWordSpec with Matchers with MockitoSug
         RedisConfigConstants.REDIS_HOST  -> "localhost",
         RedisConfigConstants.REDIS_PORT  -> container.mappedPort(6379).toString,
         RedisConfigConstants.KCQL_CONFIG -> KCQL,
-      ).asJava
+      )
 
       val config         = RedisConfig(props)
       val connectionInfo = new RedisConnectionInfo("localhost", container.mappedPort(6379), None)

--- a/kafka-connect-redis/src/it/scala/io/lenses/streamreactor/connect/redis/sink/writer/RedisMultipleSortedSetsTest.scala
+++ b/kafka-connect-redis/src/it/scala/io/lenses/streamreactor/connect/redis/sink/writer/RedisMultipleSortedSetsTest.scala
@@ -56,7 +56,7 @@ class RedisMultipleSortedSetsTest extends AnyWordSpec with Matchers with Mockito
         RedisConfigConstants.REDIS_HOST  -> "localhost",
         RedisConfigConstants.REDIS_PORT  -> container.mappedPort(6379).toString,
         RedisConfigConstants.KCQL_CONFIG -> KCQL,
-      ).asJava
+      )
 
       val config = RedisConfig(props)
 

--- a/kafka-connect-redis/src/it/scala/io/lenses/streamreactor/connect/redis/sink/writer/RedisPubSubTest.scala
+++ b/kafka-connect-redis/src/it/scala/io/lenses/streamreactor/connect/redis/sink/writer/RedisPubSubTest.scala
@@ -36,7 +36,6 @@ import redis.clients.jedis.Jedis
 import redis.clients.jedis.JedisPubSub
 
 import scala.collection.mutable.ListBuffer
-import scala.jdk.CollectionConverters.MapHasAsJava
 
 class RedisPubSubTest extends AnyWordSpec with Matchers with MockitoSugar with LazyLogging with ForAllTestContainer {
 
@@ -56,7 +55,7 @@ class RedisPubSubTest extends AnyWordSpec with Matchers with MockitoSugar with L
         RedisConfigConstants.REDIS_HOST  -> "localhost",
         RedisConfigConstants.REDIS_PORT  -> container.mappedPort(6379).toString,
         RedisConfigConstants.KCQL_CONFIG -> KCQL,
-      ).asJava
+      )
 
       val config         = RedisConfig(props)
       val connectionInfo = new RedisConnectionInfo("localhost", container.mappedPort(6379), None)

--- a/kafka-connect-redis/src/main/scala/io/lenses/streamreactor/connect/redis/sink/RedisSinkTask.scala
+++ b/kafka-connect-redis/src/main/scala/io/lenses/streamreactor/connect/redis/sink/RedisSinkTask.scala
@@ -33,6 +33,7 @@ import org.apache.kafka.connect.sink.SinkTask
 import java.util
 import scala.jdk.CollectionConverters.IterableHasAsScala
 import scala.jdk.CollectionConverters.ListHasAsScala
+import scala.jdk.CollectionConverters.MapHasAsScala
 
 /**
   * <h1>RedisSinkTask</h1>
@@ -56,7 +57,7 @@ class RedisSinkTask extends SinkTask with StrictLogging {
     val conf = if (context.configs().isEmpty) props else context.configs()
 
     RedisConfig.config.parse(conf)
-    val sinkConfig = new RedisConfig(conf)
+    val sinkConfig = new RedisConfig(conf.asScala.toMap)
     val settings   = RedisSinkSettings(sinkConfig)
     enableProgress = sinkConfig.getBoolean(RedisConfigConstants.PROGRESS_COUNTER_ENABLED)
 

--- a/kafka-connect-redis/src/main/scala/io/lenses/streamreactor/connect/redis/sink/config/RedisConfig.scala
+++ b/kafka-connect-redis/src/main/scala/io/lenses/streamreactor/connect/redis/sink/config/RedisConfig.scala
@@ -20,8 +20,6 @@ import org.apache.kafka.common.config.ConfigDef
 import org.apache.kafka.common.config.ConfigDef.Importance
 import org.apache.kafka.common.config.ConfigDef.Type
 
-import java.util
-
 object RedisConfig {
 
   val config: ConfigDef = new ConfigDef()
@@ -136,7 +134,7 @@ object RedisConfig {
   *
   * Holds config, extends AbstractConfig.
   */
-case class RedisConfig(props: util.Map[String, String])
+case class RedisConfig(props: Map[String, String])
     extends BaseConfig(RedisConfigConstants.CONNECTOR_PREFIX, RedisConfig.config, props)
     with KcqlSettings
     with ErrorPolicySettings

--- a/kafka-connect-redis/src/test/scala/io/lenses/streamreactor/connect/redis/sink/RedisSinkTaskTest.scala
+++ b/kafka-connect-redis/src/test/scala/io/lenses/streamreactor/connect/redis/sink/RedisSinkTaskTest.scala
@@ -22,8 +22,6 @@ import io.lenses.streamreactor.connect.redis.sink.support.RedisMockSupport
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 
-import scala.jdk.CollectionConverters.MapHasAsJava
-
 class RedisSinkTaskTest extends AnyWordSpec with Matchers with RedisMockSupport {
 
   "work with Cache" -> {
@@ -33,7 +31,7 @@ class RedisSinkTaskTest extends AnyWordSpec with Matchers with RedisMockSupport 
       RedisConfigConstants.REDIS_HOST  -> "localhost",
       RedisConfigConstants.REDIS_PORT  -> "0000",
       RedisConfigConstants.KCQL_CONFIG -> KCQL,
-    ).asJava
+    )
 
     val config   = RedisConfig(props)
     val settings = RedisSinkSettings(config)
@@ -52,7 +50,7 @@ class RedisSinkTaskTest extends AnyWordSpec with Matchers with RedisMockSupport 
       RedisConfigConstants.REDIS_HOST  -> "localhost",
       RedisConfigConstants.REDIS_PORT  -> "0000",
       RedisConfigConstants.KCQL_CONFIG -> KCQL,
-    ).asJava
+    )
 
     val config   = RedisConfig(props)
     val settings = RedisSinkSettings(config)
@@ -71,7 +69,7 @@ class RedisSinkTaskTest extends AnyWordSpec with Matchers with RedisMockSupport 
       RedisConfigConstants.REDIS_HOST  -> "localhost",
       RedisConfigConstants.REDIS_PORT  -> "0000",
       RedisConfigConstants.KCQL_CONFIG -> KCQL,
-    ).asJava
+    )
 
     val config   = RedisConfig(props)
     val settings = RedisSinkSettings(config)
@@ -97,7 +95,7 @@ class RedisSinkTaskTest extends AnyWordSpec with Matchers with RedisMockSupport 
       RedisConfigConstants.REDIS_HOST  -> "localhost",
       RedisConfigConstants.REDIS_PORT  -> "0000",
       RedisConfigConstants.KCQL_CONFIG -> KCQL,
-    ).asJava
+    )
 
     val config   = RedisConfig(props)
     val settings = RedisSinkSettings(config)
@@ -131,7 +129,7 @@ class RedisSinkTaskTest extends AnyWordSpec with Matchers with RedisMockSupport 
       RedisConfigConstants.REDIS_HOST  -> "localhost",
       RedisConfigConstants.REDIS_PORT  -> "0000",
       RedisConfigConstants.KCQL_CONFIG -> KCQL,
-    ).asJava
+    )
 
     val config   = RedisConfig(props)
     val settings = RedisSinkSettings(config)

--- a/kafka-connect-redis/src/test/scala/io/lenses/streamreactor/connect/redis/sink/support/RedisMockSupport.scala
+++ b/kafka-connect-redis/src/test/scala/io/lenses/streamreactor/connect/redis/sink/support/RedisMockSupport.scala
@@ -19,8 +19,6 @@ import io.lenses.streamreactor.connect.redis.sink.config.RedisConfig
 import io.lenses.streamreactor.connect.redis.sink.config.RedisConfigConstants
 import org.mockito.MockitoSugar
 
-import scala.jdk.CollectionConverters.MapHasAsJava
-
 trait RedisMockSupport extends MockitoSugar {
 
   def getRedisSinkConfig(password: Boolean, KCQL: Option[String], pkDelimiter: Option[String] = None): RedisConfig = {
@@ -42,7 +40,7 @@ trait RedisMockSupport extends MockitoSugar {
       baseProps += RedisConfigConstants.REDIS_PK_DELIMITER -> delimiter
     }
 
-    RedisConfig(baseProps.asJava)
+    RedisConfig(baseProps.toMap)
   }
 
 }

--- a/kafka-connect-redis/src/test/scala/io/lenses/streamreactor/connect/redis/sink/writer/RedisStreamTest.scala
+++ b/kafka-connect-redis/src/test/scala/io/lenses/streamreactor/connect/redis/sink/writer/RedisStreamTest.scala
@@ -48,7 +48,6 @@ import redis.clients.jedis.StreamEntryID
 import redis.clients.jedis.params.XAddParams
 
 import java.util
-import scala.jdk.CollectionConverters.MapHasAsJava
 
 class RedisStreamTest
     extends AnyWordSpec
@@ -68,7 +67,7 @@ class RedisStreamTest
         RedisConfigConstants.REDIS_PORT     -> "6379",
         RedisConfigConstants.KCQL_CONFIG    -> KCQL,
         RedisConfigConstants.REDIS_PASSWORD -> "",
-      ).asJava
+      )
 
       val config   = RedisConfig(props)
       val settings = RedisSinkSettings(config)


### PR DESCRIPTION
Avoid passing round java maps.  Only on ingress and egress from the scala code

This has caused a maintainability issue with the main and test code and is making refactors difficult due to the number of conversions required.

The SinkTask and SourceTask are bound to the Java API, and when we manage connect ConfigDef we are also bound to the Java API.  However these are at very distinct points in the code.  Currently we have conversions from/to java maps happening in a haphazard way throughout the codebase and this is causing maintainability issues and preventing sensible refactoring.  Enough is enough and this PR attempts to fix this so we can move forward.