### PR TITLE
Remove parsed values to simplify builders

### DIFF
--- a/kafka-connect-aws-s3/src/main/scala/io/lenses/streamreactor/connect/aws/s3/sink/config/S3ConsumerGroupsSinkConfig.scala
+++ b/kafka-connect-aws-s3/src/main/scala/io/lenses/streamreactor/connect/aws/s3/sink/config/S3ConsumerGroupsSinkConfig.scala
@@ -35,7 +35,7 @@ object S3ConsumerGroupsSinkConfig extends PropertiesHelper {
     s3ConfigDefBuilder: S3ConsumerGroupsSinkConfigDef,
   ): Either[Throwable, S3ConsumerGroupsSinkConfig] =
     S3ConsumerGroupsSinkConfig.from(
-      s3ConfigDefBuilder.getParsedValues,
+      s3ConfigDefBuilder.props,
     )
 
   def from(props: Map[String, _]): Either[Throwable, S3ConsumerGroupsSinkConfig] =

--- a/kafka-connect-aws-s3/src/main/scala/io/lenses/streamreactor/connect/aws/s3/sink/config/S3ConsumerGroupsSinkConfigDef.scala
+++ b/kafka-connect-aws-s3/src/main/scala/io/lenses/streamreactor/connect/aws/s3/sink/config/S3ConsumerGroupsSinkConfigDef.scala
@@ -22,8 +22,6 @@ import org.apache.kafka.common.config.ConfigDef
 import org.apache.kafka.common.config.ConfigDef.Importance
 import org.apache.kafka.common.config.ConfigDef.Type
 
-import scala.jdk.CollectionConverters._
-
 object S3ConsumerGroupsSinkConfigDef {
 
   val config: ConfigDef = new ConfigDef()
@@ -116,7 +114,4 @@ object S3ConsumerGroupsSinkConfigDef {
 }
 
 case class S3ConsumerGroupsSinkConfigDef(props: Map[String, String])
-    extends BaseConfig(S3ConfigSettings.CONNECTOR_PREFIX, S3ConsumerGroupsSinkConfigDef.config, props) {
-  def getParsedValues: Map[String, _] = values().asScala.toMap
-
-}
+    extends BaseConfig(S3ConfigSettings.CONNECTOR_PREFIX, S3ConsumerGroupsSinkConfigDef.config, props) {}

--- a/kafka-connect-aws-s3/src/main/scala/io/lenses/streamreactor/connect/aws/s3/sink/config/S3SinkConfig.scala
+++ b/kafka-connect-aws-s3/src/main/scala/io/lenses/streamreactor/connect/aws/s3/sink/config/S3SinkConfig.scala
@@ -49,7 +49,7 @@ object S3SinkConfig {
         s3ConfigDefBuilder.getInt(SEEK_MAX_INDEX_FILES),
       )
     } yield S3SinkConfig(
-      S3Config(s3ConfigDefBuilder.getParsedValues),
+      S3Config(s3ConfigDefBuilder.props),
       sinkBucketOptions,
       offsetSeekerOptions,
       s3ConfigDefBuilder.getCompressionCodec(),

--- a/kafka-connect-aws-s3/src/main/scala/io/lenses/streamreactor/connect/aws/s3/sink/config/S3SinkConfigDefBuilder.scala
+++ b/kafka-connect-aws-s3/src/main/scala/io/lenses/streamreactor/connect/aws/s3/sink/config/S3SinkConfigDefBuilder.scala
@@ -20,8 +20,6 @@ import io.lenses.streamreactor.connect.aws.s3.config.DeleteModeSettings
 import io.lenses.streamreactor.connect.aws.s3.config.S3ConfigSettings
 import io.lenses.streamreactor.connect.cloud.common.sink.config.CloudSinkConfigDefBuilder
 
-import scala.jdk.CollectionConverters.MapHasAsScala
-
 case class S3SinkConfigDefBuilder(props: Map[String, String])
     extends BaseConfig(S3ConfigSettings.CONNECTOR_PREFIX, S3SinkConfigDef.config, props)
     with CloudSinkConfigDefBuilder
@@ -29,8 +27,4 @@ case class S3SinkConfigDefBuilder(props: Map[String, String])
     with NumberRetriesSettings
     with UserSettings
     with ConnectionSettings
-    with DeleteModeSettings {
-
-  def getParsedValues: Map[String, _] = values().asScala.toMap
-
-}
+    with DeleteModeSettings {}

--- a/kafka-connect-aws-s3/src/main/scala/io/lenses/streamreactor/connect/aws/s3/source/config/S3SourceConfig.scala
+++ b/kafka-connect-aws-s3/src/main/scala/io/lenses/streamreactor/connect/aws/s3/source/config/S3SourceConfig.scala
@@ -50,7 +50,7 @@ object S3SourceConfig {
     S3SourceConfig(S3SourceConfigDefBuilder(props))
 
   def apply(s3ConfigDefBuilder: S3SourceConfigDefBuilder): Either[Throwable, S3SourceConfig] = {
-    val parsedValues = s3ConfigDefBuilder.getParsedValues
+    val parsedValues = s3ConfigDefBuilder.props
     for {
       sbo <- SourceBucketOptions(
         s3ConfigDefBuilder,

--- a/kafka-connect-aws-s3/src/main/scala/io/lenses/streamreactor/connect/aws/s3/source/config/S3SourceConfigDefBuilder.scala
+++ b/kafka-connect-aws-s3/src/main/scala/io/lenses/streamreactor/connect/aws/s3/source/config/S3SourceConfigDefBuilder.scala
@@ -20,8 +20,6 @@ import io.lenses.streamreactor.connect.aws.s3.config.DeleteModeSettings
 import io.lenses.streamreactor.connect.aws.s3.config.S3ConfigSettings
 import io.lenses.streamreactor.connect.cloud.common.config.CompressionCodecSettings
 
-import scala.jdk.CollectionConverters.MapHasAsScala
-
 case class S3SourceConfigDefBuilder(props: Map[String, String])
     extends BaseConfig(S3ConfigSettings.CONNECTOR_PREFIX, S3SourceConfigDef.config, props)
     with KcqlSettings
@@ -31,8 +29,4 @@ case class S3SourceConfigDefBuilder(props: Map[String, String])
     with ConnectionSettings
     with CompressionCodecSettings
     with SourcePartitionSearcherSettings
-    with DeleteModeSettings {
-
-  def getParsedValues: Map[String, _] = values().asScala.toMap
-
-}
+    with DeleteModeSettings {}

--- a/kafka-connect-azure-datalake/src/main/scala/io/lenses/streamreactor/connect/datalake/sink/config/DatalakeSinkConfig.scala
+++ b/kafka-connect-azure-datalake/src/main/scala/io/lenses/streamreactor/connect/datalake/sink/config/DatalakeSinkConfig.scala
@@ -49,7 +49,7 @@ object DatalakeSinkConfig {
         s3ConfigDefBuilder.getInt(SEEK_MAX_INDEX_FILES),
       )
     } yield DatalakeSinkConfig(
-      AzureConfig(s3ConfigDefBuilder.getParsedValues, authMode),
+      AzureConfig(s3ConfigDefBuilder.props, authMode),
       sinkBucketOptions,
       offsetSeekerOptions,
       s3ConfigDefBuilder.getCompressionCodec(),

--- a/kafka-connect-azure-datalake/src/main/scala/io/lenses/streamreactor/connect/datalake/sink/config/DatalakeSinkConfigDefBuilder.scala
+++ b/kafka-connect-azure-datalake/src/main/scala/io/lenses/streamreactor/connect/datalake/sink/config/DatalakeSinkConfigDefBuilder.scala
@@ -20,8 +20,6 @@ import io.lenses.streamreactor.connect.cloud.common.sink.config.CloudSinkConfigD
 import io.lenses.streamreactor.connect.datalake.config.AuthModeSettings
 import io.lenses.streamreactor.connect.datalake.config.AzureConfigSettings
 
-import scala.jdk.CollectionConverters.MapHasAsScala
-
 case class DatalakeSinkConfigDefBuilder(props: Map[String, String])
     extends BaseConfig(AzureConfigSettings.CONNECTOR_PREFIX, DatalakeSinkConfigDef.config, props)
     with CloudSinkConfigDefBuilder
@@ -29,8 +27,4 @@ case class DatalakeSinkConfigDefBuilder(props: Map[String, String])
     with NumberRetriesSettings
     with UserSettings
     with ConnectionSettings
-    with AuthModeSettings {
-
-  def getParsedValues: Map[String, _] = values().asScala.toMap
-
-}
+    with AuthModeSettings {}

--- a/kafka-connect-cloud-common/src/test/scala/io/lenses/streamreactor/connect/cloud/common/sink/config/TestConfigDefBuilder.scala
+++ b/kafka-connect-cloud-common/src/test/scala/io/lenses/streamreactor/connect/cloud/common/sink/config/TestConfigDefBuilder.scala
@@ -20,16 +20,10 @@ import io.lenses.streamreactor.connect.cloud.common.sink.config.padding.PaddingS
 import io.lenses.streamreactor.connect.cloud.common.sink.config.padding.PaddingStrategySettings
 import org.apache.kafka.common.config.ConfigDef
 
-import scala.jdk.CollectionConverters.MapHasAsScala
-
 case class TestConfigDefBuilder(configDef: ConfigDef, props: Map[String, String])
     extends BaseConfig("connect.testing", configDef, props)
     with PaddingStrategySettings
-    with LocalStagingAreaSettings {
-
-  def getParsedValues: Map[String, _] = values().asScala.toMap
-
-}
+    with LocalStagingAreaSettings {}
 
 object TestConfig {
 

--- a/kafka-connect-gcp-storage/src/main/scala/io/lenses/streamreactor/connect/gcp/storage/sink/config/GCPStorageSinkConfig.scala
+++ b/kafka-connect-gcp-storage/src/main/scala/io/lenses/streamreactor/connect/gcp/storage/sink/config/GCPStorageSinkConfig.scala
@@ -49,7 +49,7 @@ object GCPStorageSinkConfig {
         gcpConfigDefBuilder.getInt(SEEK_MAX_INDEX_FILES),
       )
     } yield GCPStorageSinkConfig(
-      GCPConfig(gcpConfigDefBuilder.getParsedValues, authMode),
+      GCPConfig(gcpConfigDefBuilder.props, authMode),
       sinkBucketOptions,
       offsetSeekerOptions,
       gcpConfigDefBuilder.getCompressionCodec(),

--- a/kafka-connect-gcp-storage/src/main/scala/io/lenses/streamreactor/connect/gcp/storage/sink/config/GCPStorageSinkConfigDefBuilder.scala
+++ b/kafka-connect-gcp-storage/src/main/scala/io/lenses/streamreactor/connect/gcp/storage/sink/config/GCPStorageSinkConfigDefBuilder.scala
@@ -21,8 +21,6 @@ import io.lenses.streamreactor.connect.gcp.storage.config.AuthModeSettings
 import io.lenses.streamreactor.connect.gcp.storage.config.GCPConfigSettings
 import io.lenses.streamreactor.connect.gcp.storage.config.UploadSettings
 
-import scala.jdk.CollectionConverters.MapHasAsScala
-
 case class GCPStorageSinkConfigDefBuilder(props: Map[String, String])
     extends BaseConfig(GCPConfigSettings.CONNECTOR_PREFIX, GCPStorageSinkConfigDef.config, props)
     with CloudSinkConfigDefBuilder
@@ -31,8 +29,4 @@ case class GCPStorageSinkConfigDefBuilder(props: Map[String, String])
     with UserSettings
     with ConnectionSettings
     with AuthModeSettings
-    with UploadSettings {
-
-  def getParsedValues: Map[String, _] = values().asScala.toMap
-
-}
+    with UploadSettings {}


### PR DESCRIPTION
Related to #1029 , now that `props` is a scala Map we can use this instead of doing another java conversion converting from the value stored in the java superclass.