### PR TITLE
Partition Search

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -86,3 +86,4 @@ classes/*
 /kafka-connect-hive/it/.project
 /kafka-connect-hive/it/.settings/
 /kafka-connect-hive/it/bin/
+java-connectors/kafka-connect-query-language/gen/*

--- a/kafka-connect-aws-s3/src/it/scala/io/lenses/streamreactor/connect/aws/s3/source/S3SourceTaskTest.scala
+++ b/kafka-connect-aws-s3/src/it/scala/io/lenses/streamreactor/connect/aws/s3/source/S3SourceTaskTest.scala
@@ -56,6 +56,7 @@ class S3SourceTaskTest
   private var bucketSetupOpt:          Option[BucketSetup]    = None
   def bucketSetup:                     BucketSetup            = bucketSetupOpt.getOrElse(throw new IllegalStateException("Not initialised"))
   override def cleanUp():              Unit                   = ()
+  private val filesLimit = 1000
 
   def DefaultProps: Map[String, String] = defaultProps ++
     Seq(
@@ -80,7 +81,12 @@ class S3SourceTaskTest
   "task" should "retrieve subdirectories correctly" in {
     val root = CloudLocation(BucketName, s"${bucketSetup.PrefixName}/avro/myTopic/".some)
     val dirs =
-      new AwsS3DirectoryLister(ConnectorTaskId("name", 1, 1), client).findDirectories(root, 0, Set.empty, Set.empty)
+      new AwsS3DirectoryLister(ConnectorTaskId("name", 1, 1), client).findDirectories(root,
+                                                                                      filesLimit,
+                                                                                      0,
+                                                                                      Set.empty,
+                                                                                      Set.empty,
+      )
     dirs.unsafeRunSync() should be(Set("streamReactorBackups/avro/myTopic/0/"))
   }
 

--- a/kafka-connect-aws-s3/src/it/scala/io/lenses/streamreactor/connect/aws/s3/storage/ListDirectoryTest.scala
+++ b/kafka-connect-aws-s3/src/it/scala/io/lenses/streamreactor/connect/aws/s3/storage/ListDirectoryTest.scala
@@ -1,6 +1,5 @@
 package io.lenses.streamreactor.connect.aws.s3.storage
 
-import cats.effect.unsafe.implicits.global
 import cats.implicits.catsSyntaxEitherId
 import cats.implicits.catsSyntaxOptionId
 import com.typesafe.scalalogging.LazyLogging
@@ -10,10 +9,16 @@ import io.lenses.streamreactor.connect.cloud.common.config.ConnectorTaskId
 import io.lenses.streamreactor.connect.cloud.common.model.UploadableString
 import io.lenses.streamreactor.connect.cloud.common.model.location.CloudLocation
 import io.lenses.streamreactor.connect.cloud.common.model.location.CloudLocationValidator
+import io.lenses.streamreactor.connect.cloud.common.utils.AsyncIOAssertions
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 
-class ListDirectoryTest extends AnyFlatSpec with Matchers with S3ProxyContainerTest with LazyLogging {
+class ListDirectoryTest
+    extends AnyFlatSpec
+    with Matchers
+    with S3ProxyContainerTest
+    with AsyncIOAssertions
+    with LazyLogging {
 
   implicit val cloudLocationValidator: CloudLocationValidator = S3LocationValidator
 
@@ -39,16 +44,18 @@ class ListDirectoryTest extends AnyFlatSpec with Matchers with S3ProxyContainerT
 
     val topicRoot = CloudLocation(BucketName, "topic-1/".some)
 
-    val dirs = new AwsS3DirectoryLister(connectorTaskId, client).findDirectories(
+    new AwsS3DirectoryLister(connectorTaskId, client).findDirectories(
       topicRoot,
       0,
       Set.empty,
       Set.empty,
-    ).unsafeRunSync()
-
-    val allValues        = (1 to 10).map(x => s"topic-1/$x/")
-    val partitionResults = allValues.toSet
-    dirs should be(partitionResults)
+    ).asserting {
+      dirs =>
+        val allValues        = (1 to 10).map(x => s"topic-1/$x/")
+        val partitionResults = allValues.toSet
+        dirs should be(partitionResults)
+        ()
+    }
 
   }
 
@@ -58,11 +65,12 @@ class ListDirectoryTest extends AnyFlatSpec with Matchers with S3ProxyContainerT
 
     val bucketRoot = CloudLocation(BucketName)
 
-    val dirs =
-      new AwsS3DirectoryLister(taskId, client).findDirectories(bucketRoot, 2, Set.empty, Set.empty).unsafeRunSync()
-
-    val partitionResults = Set.empty
-    dirs should be(partitionResults)
+    new AwsS3DirectoryLister(taskId, client).findDirectories(bucketRoot, 2, Set.empty, Set.empty).asserting {
+      dirs =>
+        val partitionResults = Set.empty
+        dirs should be(partitionResults)
+        ()
+    }
 
   }
 
@@ -72,26 +80,30 @@ class ListDirectoryTest extends AnyFlatSpec with Matchers with S3ProxyContainerT
 
     val bucketRoot = CloudLocation(BucketName)
 
-    val dirs =
-      new AwsS3DirectoryLister(taskId, client).findDirectories(bucketRoot, 3, Set.empty, Set.empty).unsafeRunSync()
-
-    val partitionResults = Set.empty
-    dirs should be(partitionResults)
+    new AwsS3DirectoryLister(taskId, client).findDirectories(bucketRoot, 3, Set.empty, Set.empty).asserting {
+      dirs =>
+        val partitionResults = Set.empty
+        dirs should be(partitionResults)
+        ()
+    }
 
   }
+
   "s3StorageInterface" should "list directories within a path 1 levels deep from bucket root" in {
 
     val taskId = ConnectorTaskId("sinkName", 1, 0)
 
     val bucketRoot = CloudLocation(BucketName)
 
-    val dirs =
-      new AwsS3DirectoryLister(taskId, client).findDirectories(bucketRoot, 1, Set.empty, Set.empty).unsafeRunSync()
+    new AwsS3DirectoryLister(taskId, client).findDirectories(bucketRoot, 1, Set.empty, Set.empty).asserting {
+      dirs =>
+        val allValues = (1 to 10).flatMap(x => List(s"topic-1/$x/", s"topic-2/$x/"))
 
-    val allValues = (1 to 10).flatMap(x => List(s"topic-1/$x/", s"topic-2/$x/"))
-
-    val partitionResults = allValues.toSet
-    dirs should be(partitionResults)
+        val partitionResults = allValues.toSet
+        dirs should be(partitionResults)
+        ()
+    }
 
   }
+
 }

--- a/kafka-connect-aws-s3/src/it/scala/io/lenses/streamreactor/connect/aws/s3/storage/ListDirectoryTest.scala
+++ b/kafka-connect-aws-s3/src/it/scala/io/lenses/streamreactor/connect/aws/s3/storage/ListDirectoryTest.scala
@@ -20,6 +20,8 @@ class ListDirectoryTest
     with AsyncIOAssertions
     with LazyLogging {
 
+  private val filesLimit = 1000
+
   implicit val cloudLocationValidator: CloudLocationValidator = S3LocationValidator
 
   override def cleanUp(): Unit = ()
@@ -46,6 +48,7 @@ class ListDirectoryTest
 
     new AwsS3DirectoryLister(connectorTaskId, client).findDirectories(
       topicRoot,
+      filesLimit,
       0,
       Set.empty,
       Set.empty,
@@ -65,7 +68,12 @@ class ListDirectoryTest
 
     val bucketRoot = CloudLocation(BucketName)
 
-    new AwsS3DirectoryLister(taskId, client).findDirectories(bucketRoot, 2, Set.empty, Set.empty).asserting {
+    new AwsS3DirectoryLister(taskId, client).findDirectories(bucketRoot,
+                                                             filesLimit,
+                                                             2,
+                                                             Set.empty,
+                                                             Set.empty,
+    ).asserting {
       dirs =>
         val partitionResults = Set.empty
         dirs should be(partitionResults)
@@ -80,7 +88,12 @@ class ListDirectoryTest
 
     val bucketRoot = CloudLocation(BucketName)
 
-    new AwsS3DirectoryLister(taskId, client).findDirectories(bucketRoot, 3, Set.empty, Set.empty).asserting {
+    new AwsS3DirectoryLister(taskId, client).findDirectories(bucketRoot,
+                                                             filesLimit,
+                                                             3,
+                                                             Set.empty,
+                                                             Set.empty,
+    ).asserting {
       dirs =>
         val partitionResults = Set.empty
         dirs should be(partitionResults)
@@ -95,7 +108,12 @@ class ListDirectoryTest
 
     val bucketRoot = CloudLocation(BucketName)
 
-    new AwsS3DirectoryLister(taskId, client).findDirectories(bucketRoot, 1, Set.empty, Set.empty).asserting {
+    new AwsS3DirectoryLister(taskId, client).findDirectories(bucketRoot,
+                                                             filesLimit,
+                                                             1,
+                                                             Set.empty,
+                                                             Set.empty,
+    ).asserting {
       dirs =>
         val allValues = (1 to 10).flatMap(x => List(s"topic-1/$x/", s"topic-2/$x/"))
 

--- a/kafka-connect-aws-s3/src/it/scala/io/lenses/streamreactor/connect/aws/s3/storage/ListDirectoryTest.scala
+++ b/kafka-connect-aws-s3/src/it/scala/io/lenses/streamreactor/connect/aws/s3/storage/ListDirectoryTest.scala
@@ -10,12 +10,8 @@ import io.lenses.streamreactor.connect.cloud.common.config.ConnectorTaskId
 import io.lenses.streamreactor.connect.cloud.common.model.UploadableString
 import io.lenses.streamreactor.connect.cloud.common.model.location.CloudLocation
 import io.lenses.streamreactor.connect.cloud.common.model.location.CloudLocationValidator
-import io.lenses.streamreactor.connect.cloud.common.storage.DirectoryFindCompletionConfig
-import io.lenses.streamreactor.connect.cloud.common.storage.DirectoryFindResults
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
-
-import scala.jdk.CollectionConverters.IteratorHasAsScala
 
 class ListDirectoryTest extends AnyFlatSpec with Matchers with S3ProxyContainerTest with LazyLogging {
 
@@ -43,17 +39,15 @@ class ListDirectoryTest extends AnyFlatSpec with Matchers with S3ProxyContainerT
 
     val topicRoot = CloudLocation(BucketName, "topic-1/".some)
 
-    val dirs = AwsS3DirectoryLister.findDirectories(
+    val dirs = new AwsS3DirectoryLister(connectorTaskId, client).findDirectories(
       topicRoot,
-      DirectoryFindCompletionConfig(0),
+      0,
       Set.empty,
       Set.empty,
-      client.listObjectsV2Paginator(_).iterator().asScala,
-      connectorTaskId,
     ).unsafeRunSync()
 
     val allValues        = (1 to 10).map(x => s"topic-1/$x/")
-    val partitionResults = DirectoryFindResults(allValues.toSet)
+    val partitionResults = allValues.toSet
     dirs should be(partitionResults)
 
   }
@@ -64,16 +58,10 @@ class ListDirectoryTest extends AnyFlatSpec with Matchers with S3ProxyContainerT
 
     val bucketRoot = CloudLocation(BucketName)
 
-    val dirs = AwsS3DirectoryLister.findDirectories(
-      bucketRoot,
-      DirectoryFindCompletionConfig(2),
-      Set.empty,
-      Set.empty,
-      client.listObjectsV2Paginator(_).iterator().asScala,
-      taskId,
-    ).unsafeRunSync()
+    val dirs =
+      new AwsS3DirectoryLister(taskId, client).findDirectories(bucketRoot, 2, Set.empty, Set.empty).unsafeRunSync()
 
-    val partitionResults = DirectoryFindResults(Set.empty)
+    val partitionResults = Set.empty
     dirs should be(partitionResults)
 
   }
@@ -84,16 +72,10 @@ class ListDirectoryTest extends AnyFlatSpec with Matchers with S3ProxyContainerT
 
     val bucketRoot = CloudLocation(BucketName)
 
-    val dirs = AwsS3DirectoryLister.findDirectories(
-      bucketRoot,
-      DirectoryFindCompletionConfig(3),
-      Set.empty,
-      Set.empty,
-      client.listObjectsV2Paginator(_).iterator().asScala,
-      taskId,
-    ).unsafeRunSync()
+    val dirs =
+      new AwsS3DirectoryLister(taskId, client).findDirectories(bucketRoot, 3, Set.empty, Set.empty).unsafeRunSync()
 
-    val partitionResults = DirectoryFindResults(Set.empty)
+    val partitionResults = Set.empty
     dirs should be(partitionResults)
 
   }
@@ -103,18 +85,12 @@ class ListDirectoryTest extends AnyFlatSpec with Matchers with S3ProxyContainerT
 
     val bucketRoot = CloudLocation(BucketName)
 
-    val dirs = AwsS3DirectoryLister.findDirectories(
-      bucketRoot,
-      DirectoryFindCompletionConfig(1),
-      Set.empty,
-      Set.empty,
-      client.listObjectsV2Paginator(_).iterator().asScala,
-      taskId,
-    ).unsafeRunSync()
+    val dirs =
+      new AwsS3DirectoryLister(taskId, client).findDirectories(bucketRoot, 1, Set.empty, Set.empty).unsafeRunSync()
 
     val allValues = (1 to 10).flatMap(x => List(s"topic-1/$x/", s"topic-2/$x/"))
 
-    val partitionResults = DirectoryFindResults(allValues.toSet)
+    val partitionResults = allValues.toSet
     dirs should be(partitionResults)
 
   }

--- a/kafka-connect-aws-s3/src/it/scala/io/lenses/streamreactor/connect/cloud/common/utils/AsyncIOAssertions.scala
+++ b/kafka-connect-aws-s3/src/it/scala/io/lenses/streamreactor/connect/cloud/common/utils/AsyncIOAssertions.scala
@@ -1,0 +1,17 @@
+package io.lenses.streamreactor.connect.cloud.common.utils
+
+import cats.effect.IO
+
+/**
+  * This is a workaround for being unable to use AsyncIOSpec in some tests due to their superclasses using some other non-IO spec.
+  */
+trait AsyncIOAssertions {
+
+  implicit class IOAssertionOps[T](io: IO[T]) {
+    def asserting(predicate: T => Unit): IO[T] = io.map { value =>
+      predicate(value)
+      value
+    }
+  }
+
+}

--- a/kafka-connect-aws-s3/src/main/scala/io/lenses/streamreactor/connect/aws/s3/storage/AwsS3DirectoryLister.scala
+++ b/kafka-connect-aws-s3/src/main/scala/io/lenses/streamreactor/connect/aws/s3/storage/AwsS3DirectoryLister.scala
@@ -44,12 +44,12 @@ class AwsS3DirectoryLister(connectorTaskId: ConnectorTaskId, s3Client: S3Client)
     wildcardExcludes: Set[String],
   ): IO[Set[String]] =
     for {
-      iterator   <- listObjects(bucketAndPrefix)
+      iterator   <- listObjects(filesLimit, bucketAndPrefix)
       prefixInfo <- extractPrefixesFromResponse(iterator, exclude, wildcardExcludes, recurseLevels)
       flattened  <- flattenPrefixes(bucketAndPrefix, filesLimit, prefixInfo, recurseLevels, exclude, wildcardExcludes)
     } yield flattened
 
-  private def listObjects(bucketAndPrefix: CloudLocation): IO[Iterator[ListObjectsV2Response]] = {
+  private def listObjects(filesLimit: Int, bucketAndPrefix: CloudLocation): IO[Iterator[ListObjectsV2Response]] = {
 
     def createListObjectsRequest(
       bucketAndPrefix: CloudLocation,
@@ -57,7 +57,7 @@ class AwsS3DirectoryLister(connectorTaskId: ConnectorTaskId, s3Client: S3Client)
 
       val builder = ListObjectsV2Request
         .builder()
-        .maxKeys(1000)
+        .maxKeys(filesLimit)
         .bucket(bucketAndPrefix.bucket)
         .delimiter("/")
       bucketAndPrefix.prefix.foreach(builder.prefix)

--- a/kafka-connect-aws-s3/src/main/scala/io/lenses/streamreactor/connect/aws/s3/storage/AwsS3DirectoryLister.scala
+++ b/kafka-connect-aws-s3/src/main/scala/io/lenses/streamreactor/connect/aws/s3/storage/AwsS3DirectoryLister.scala
@@ -20,43 +20,51 @@ import cats.implicits._
 import com.typesafe.scalalogging.LazyLogging
 import io.lenses.streamreactor.connect.cloud.common.config.ConnectorTaskId
 import io.lenses.streamreactor.connect.cloud.common.model.location.CloudLocation
-import io.lenses.streamreactor.connect.cloud.common.storage.DirectoryFindCompletionConfig
-import io.lenses.streamreactor.connect.cloud.common.storage.DirectoryFindResults
+import io.lenses.streamreactor.connect.cloud.common.storage.DirectoryLister
+import software.amazon.awssdk.services.s3.S3Client
 import software.amazon.awssdk.services.s3.model._
 
 import scala.jdk.CollectionConverters.IteratorHasAsScala
 
-object AwsS3DirectoryLister extends LazyLogging {
+class AwsS3DirectoryLister(connectorTaskId: ConnectorTaskId, s3Client: S3Client)
+    extends LazyLogging
+    with DirectoryLister {
+
+  private val listObjectsF: ListObjectsV2Request => IO[Iterator[ListObjectsV2Response]] = e =>
+    IO(s3Client.listObjectsV2Paginator(e).iterator().asScala)
 
   /**
     * @param wildcardExcludes allows ignoring paths containing certain strings.  Mainly it is used to prevent us from reading anything inside the .indexes key prefix, as these should be ignored by the source.
     */
-  def findDirectories(
+  override def findDirectories(
     bucketAndPrefix:  CloudLocation,
-    completionConfig: DirectoryFindCompletionConfig,
+    recurseLevels:    Int,
     exclude:          Set[String],
     wildcardExcludes: Set[String],
-    listObjectsF:     ListObjectsV2Request => Iterator[ListObjectsV2Response],
-    connectorTaskId:  ConnectorTaskId,
-  ): IO[DirectoryFindResults] =
+  ): IO[Set[String]] =
     for {
-      iterator <- IO(listObjectsF(createListObjectsRequest(bucketAndPrefix)))
-      prefixInfo <- extractPrefixesFromResponse(iterator,
-                                                exclude,
-                                                wildcardExcludes,
-                                                connectorTaskId,
-                                                completionConfig.levelsToRecurse,
-      )
-      flattened <- flattenPrefixes(
-        bucketAndPrefix,
-        prefixInfo.partitions,
-        completionConfig,
-        exclude,
-        wildcardExcludes,
-        listObjectsF,
-        connectorTaskId,
-      )
-    } yield DirectoryFindResults(flattened)
+      iterator   <- listObjects(bucketAndPrefix)
+      prefixInfo <- extractPrefixesFromResponse(iterator, exclude, wildcardExcludes, recurseLevels)
+      flattened  <- flattenPrefixes(bucketAndPrefix, prefixInfo, recurseLevels, exclude, wildcardExcludes)
+    } yield flattened
+
+  private def listObjects(bucketAndPrefix: CloudLocation): IO[Iterator[ListObjectsV2Response]] = {
+
+    def createListObjectsRequest(
+      bucketAndPrefix: CloudLocation,
+    ): ListObjectsV2Request = {
+
+      val builder = ListObjectsV2Request
+        .builder()
+        .maxKeys(1000)
+        .bucket(bucketAndPrefix.bucket)
+        .delimiter("/")
+      bucketAndPrefix.prefix.foreach(builder.prefix)
+      builder.build()
+    }
+
+    listObjectsF(createListObjectsRequest(bucketAndPrefix))
+  }
 
   /**
     * @param wildcardExcludes allows ignoring paths containing certain strings.  Mainly it is used to prevent us from reading anything inside the .indexes key prefix, as these should be ignored by the source.
@@ -64,50 +72,27 @@ object AwsS3DirectoryLister extends LazyLogging {
   private def flattenPrefixes(
     bucketAndPrefix:  CloudLocation,
     prefixes:         Set[String],
-    completionConfig: DirectoryFindCompletionConfig,
+    recurseLevels:    Int,
     exclude:          Set[String],
     wildcardExcludes: Set[String],
-    listObjectsF:     ListObjectsV2Request => Iterator[ListObjectsV2Response],
-    connectorTaskId:  ConnectorTaskId,
   ): IO[Set[String]] =
-    if (completionConfig.levelsToRecurse <= 0) IO.delay(prefixes)
+    if (recurseLevels <= 0) IO.delay(prefixes)
     else {
       prefixes.map(bucketAndPrefix.fromRoot).toList
-        .traverse(
-          findDirectories(
-            _,
-            completionConfig.copy(levelsToRecurse = completionConfig.levelsToRecurse - 1),
-            exclude,
-            wildcardExcludes,
-            listObjectsF,
-            connectorTaskId,
-          ).map(_.partitions),
+        .traverse((bucketAndPrefix: CloudLocation) =>
+          findDirectories(bucketAndPrefix, recurseLevels - 1, exclude, wildcardExcludes),
         )
         .map { result =>
           result.foldLeft(Set.empty[String])(_ ++ _)
         }
     }
 
-  private def createListObjectsRequest(
-    bucketAndPrefix: CloudLocation,
-  ): ListObjectsV2Request = {
-
-    val builder = ListObjectsV2Request
-      .builder()
-      .maxKeys(1000)
-      .bucket(bucketAndPrefix.bucket)
-      .delimiter("/")
-    bucketAndPrefix.prefix.foreach(builder.prefix)
-    builder.build()
-  }
-
   private def extractPrefixesFromResponse(
     iterator:         Iterator[ListObjectsV2Response],
     exclude:          Set[String],
     wildcardExcludes: Set[String],
-    connectorTaskId:  ConnectorTaskId,
     levelsToRecurse:  Int,
-  ): IO[DirectoryFindResults] =
+  ): IO[Set[String]] =
     IO {
       val paths = iterator.foldLeft(Set.empty[String]) {
         case (acc, listResp) =>
@@ -128,6 +113,6 @@ object AwsS3DirectoryLister extends LazyLogging {
               }
           acc ++ commonPrefixesFiltered
       }
-      DirectoryFindResults(paths)
+      paths
     }
 }

--- a/kafka-connect-aws-s3/src/test/scala/io/lenses/streamreactor/connect/aws/s3/source/reader/S3PartitionDiscoveryTest.scala
+++ b/kafka-connect-aws-s3/src/test/scala/io/lenses/streamreactor/connect/aws/s3/source/reader/S3PartitionDiscoveryTest.scala
@@ -18,6 +18,7 @@ package io.lenses.streamreactor.connect.aws.s3.source.reader
 import cats.effect.IO
 import cats.effect.kernel.Ref
 import cats.effect.unsafe.implicits.global
+import cats.implicits.catsSyntaxEitherId
 import cats.implicits.catsSyntaxOptionId
 import io.lenses.streamreactor.connect.aws.s3.model.location.S3LocationValidator
 import io.lenses.streamreactor.connect.aws.s3.storage.AwsS3DirectoryLister
@@ -44,6 +45,9 @@ import scala.concurrent.duration.DurationInt
 class S3PartitionDiscoveryTest extends AnyFlatSpecLike with Matchers with MockitoSugar {
   private implicit val cloudLocationValidator: CloudLocationValidator = S3LocationValidator
   private val connectorTaskId:                 ConnectorTaskId        = ConnectorTaskId("sinkName", 1, 1)
+
+  private val fFilesLimit: CloudLocation => Either[Throwable, Int] = _ => 1000.asRight
+
   "PartitionDiscovery" should "discover all partitions" in {
     val fileQueueProcessor: SourceFileQueue = mock[SourceFileQueue]
     val limit = 10
@@ -65,6 +69,7 @@ class S3PartitionDiscoveryTest extends AnyFlatSpecLike with Matchers with Mockit
         connectorTaskId,
         options,
         new CloudPartitionSearcher(
+          fFilesLimit,
           directoryLister,
           List(
             CloudLocation("bucket", None),
@@ -132,6 +137,7 @@ class S3PartitionDiscoveryTest extends AnyFlatSpecLike with Matchers with Mockit
         connectorTaskId,
         options,
         new CloudPartitionSearcher(
+          fFilesLimit,
           directoryLister,
           List(
             CloudLocation("bucket", None),
@@ -191,6 +197,7 @@ class S3PartitionDiscoveryTest extends AnyFlatSpecLike with Matchers with Mockit
         connectorTaskId,
         options,
         new CloudPartitionSearcher(
+          fFilesLimit,
           directoryLister,
           List(
             CloudLocation("bucket", "prefix1/".some),
@@ -253,6 +260,7 @@ class S3PartitionDiscoveryTest extends AnyFlatSpecLike with Matchers with Mockit
             taskId,
             options,
             new CloudPartitionSearcher(
+              fFilesLimit,
               directoryLister,
               List(
                 CloudLocation("bucket", "prefix1/".some),

--- a/kafka-connect-aws-s3/src/test/scala/io/lenses/streamreactor/connect/aws/s3/storage/AwsS3DirectoryListerTest.scala
+++ b/kafka-connect-aws-s3/src/test/scala/io/lenses/streamreactor/connect/aws/s3/storage/AwsS3DirectoryListerTest.scala
@@ -31,6 +31,7 @@ class AwsS3DirectoryListerTest extends AsyncFlatSpecLike with AsyncIOSpec with M
   private implicit val cloudLocationValidator: CloudLocationValidator = S3LocationValidator
 
   private val connectorTaskId: ConnectorTaskId = ConnectorTaskId("sinkName", 1, 1)
+  private val filesLimit = 1000
 
   private def check(
     location:         CloudLocation,
@@ -43,6 +44,7 @@ class AwsS3DirectoryListerTest extends AsyncFlatSpecLike with AsyncIOSpec with M
   ): IO[Assertion] =
     new AwsS3DirectoryLister(connectorTaskId, client).findDirectories(
       location,
+      filesLimit,
       recursiveLevel,
       exclude,
       wildcardExcludes,
@@ -88,6 +90,7 @@ class AwsS3DirectoryListerTest extends AsyncFlatSpecLike with AsyncIOSpec with M
 
     new AwsS3DirectoryLister(connectorTaskId, client).findDirectories(
       CloudLocation("bucket", none),
+      filesLimit,
       1,
       Set.empty,
       Set.empty,

--- a/kafka-connect-cloud-common/src/main/scala/io/lenses/streamreactor/connect/cloud/common/source/CloudSourceTask.scala
+++ b/kafka-connect-cloud-common/src/main/scala/io/lenses/streamreactor/connect/cloud/common/source/CloudSourceTask.scala
@@ -29,12 +29,14 @@ import io.lenses.streamreactor.connect.cloud.common.config.ConnectorTaskId
 import io.lenses.streamreactor.connect.cloud.common.config.ConnectorTaskIdCreator
 import io.lenses.streamreactor.connect.cloud.common.model.location.CloudLocation
 import io.lenses.streamreactor.connect.cloud.common.model.location.CloudLocationValidator
+import io.lenses.streamreactor.connect.cloud.common.source.distribution.CloudPartitionSearcher
+import io.lenses.streamreactor.connect.cloud.common.source.distribution.PartitionSearcher
 import io.lenses.streamreactor.connect.cloud.common.source.reader.PartitionDiscovery
 import io.lenses.streamreactor.connect.cloud.common.source.reader.ReaderManager
 import io.lenses.streamreactor.connect.cloud.common.source.reader.ReaderManagerState
 import io.lenses.streamreactor.connect.cloud.common.source.state.CloudSourceTaskState
-import io.lenses.streamreactor.connect.cloud.common.source.state.PartitionSearcher
 import io.lenses.streamreactor.connect.cloud.common.source.state.ReaderManagerBuilder
+import io.lenses.streamreactor.connect.cloud.common.storage.DirectoryLister
 import io.lenses.streamreactor.connect.cloud.common.storage.FileMetadata
 import io.lenses.streamreactor.connect.cloud.common.storage.StorageInterface
 import io.lenses.streamreactor.connect.cloud.common.utils.MapUtils
@@ -131,7 +133,9 @@ abstract class CloudSourceTask[MD <: FileMetadata, C <: CloudSourceConfig[MD], C
       config          <- IO.fromEither(convertPropsToConfig(connectorTaskId, props))
       s3Client        <- IO.fromEither(createClient(config))
       storageInterface: StorageInterface[MD] <- IO.delay(createStorageInterface(connectorTaskId, config, s3Client))
-      partitionSearcher  <- IO.delay(createPartitionSearcher(connectorTaskId, config, s3Client))
+
+      directoryLister    <- IO.delay(createDirectoryLister(connectorTaskId, s3Client))
+      partitionSearcher  <- IO.delay(createPartitionSearcher(directoryLister, connectorTaskId, config))
       readerManagerState <- Ref[IO].of(ReaderManagerState(Seq.empty, Seq.empty))
       cancelledRef       <- Ref[IO].of(false)
     } yield {
@@ -159,5 +163,17 @@ abstract class CloudSourceTask[MD <: FileMetadata, C <: CloudSourceConfig[MD], C
 
   def convertPropsToConfig(connectorTaskId: ConnectorTaskId, props: Map[String, String]): Either[Throwable, C]
 
-  def createPartitionSearcher(connectorTaskId: ConnectorTaskId, config: C, client: CT): PartitionSearcher
+  def createDirectoryLister(connectorTaskId: ConnectorTaskId, s3Client: CT): DirectoryLister
+
+  def createPartitionSearcher(
+    directoryLister: DirectoryLister,
+    connectorTaskId: ConnectorTaskId,
+    config:          C,
+  ): PartitionSearcher =
+    new CloudPartitionSearcher(
+      directoryLister,
+      config.bucketOptions.map(_.sourceBucketAndPrefix),
+      config.partitionSearcher,
+      connectorTaskId,
+    )
 }

--- a/kafka-connect-cloud-common/src/main/scala/io/lenses/streamreactor/connect/cloud/common/source/distribution/CloudPartitionSearcher.scala
+++ b/kafka-connect-cloud-common/src/main/scala/io/lenses/streamreactor/connect/cloud/common/source/distribution/CloudPartitionSearcher.scala
@@ -32,6 +32,7 @@ import io.lenses.streamreactor.connect.cloud.common.storage.DirectoryLister
   * @param connectorTaskId The identifier for the connector task.
   */
 class CloudPartitionSearcher(
+  fFilesLimit:     CloudLocation => Either[Throwable, Int],
   directoryLister: DirectoryLister,
   roots:           Seq[CloudLocation],
   settings:        PartitionSearcherOptions,
@@ -67,7 +68,9 @@ class CloudPartitionSearcher(
     originalPartitions: Set[String],
   ): IO[PartitionSearcherResponse] =
     for {
+      filesLimit <- IO.fromEither(fFilesLimit(root))
       foundPartitions <- directoryLister.findDirectories(root,
+                                                         filesLimit,
                                                          settings.recurseLevels,
                                                          originalPartitions,
                                                          settings.wildcardExcludes,

--- a/kafka-connect-cloud-common/src/main/scala/io/lenses/streamreactor/connect/cloud/common/source/distribution/CloudPartitionSearcher.scala
+++ b/kafka-connect-cloud-common/src/main/scala/io/lenses/streamreactor/connect/cloud/common/source/distribution/CloudPartitionSearcher.scala
@@ -13,20 +13,15 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.lenses.streamreactor.connect.aws.s3.source.distribution
+package io.lenses.streamreactor.connect.cloud.common.source.distribution
 
 import cats.effect.IO
 import cats.implicits._
 import com.typesafe.scalalogging.LazyLogging
-import io.lenses.streamreactor.connect.aws.s3.storage.AwsS3DirectoryLister
 import io.lenses.streamreactor.connect.cloud.common.config.ConnectorTaskId
 import io.lenses.streamreactor.connect.cloud.common.model.location.CloudLocation
 import io.lenses.streamreactor.connect.cloud.common.source.config.PartitionSearcherOptions
-import io.lenses.streamreactor.connect.cloud.common.source.distribution.PartitionSearcherResponse
-import io.lenses.streamreactor.connect.cloud.common.source.state.PartitionSearcher
-import io.lenses.streamreactor.connect.cloud.common.storage.DirectoryFindCompletionConfig
-import software.amazon.awssdk.services.s3.model.ListObjectsV2Request
-import software.amazon.awssdk.services.s3.model.ListObjectsV2Response
+import io.lenses.streamreactor.connect.cloud.common.storage.DirectoryLister
 
 /**
   * Class implementing a partition searcher for S3 cloud storage.
@@ -35,13 +30,12 @@ import software.amazon.awssdk.services.s3.model.ListObjectsV2Response
   * @param roots           The list of root locations in which to search for partitions.
   * @param settings        The configuration options for partition searching.
   * @param connectorTaskId The identifier for the connector task.
-  * @param listS3ObjF      A function to list objects in S3 buckets.
   */
-class S3PartitionSearcher(
+class CloudPartitionSearcher(
+  directoryLister: DirectoryLister,
   roots:           Seq[CloudLocation],
   settings:        PartitionSearcherOptions,
   connectorTaskId: ConnectorTaskId,
-  listS3ObjF:      ListObjectsV2Request => Iterator[ListObjectsV2Response],
 ) extends PartitionSearcher
     with LazyLogging {
 
@@ -71,22 +65,18 @@ class S3PartitionSearcher(
     root:               CloudLocation,
     settings:           PartitionSearcherOptions,
     originalPartitions: Set[String],
-  ): IO[PartitionSearcherResponse] = {
-    val config = DirectoryFindCompletionConfig.fromSearchOptions(settings)
+  ): IO[PartitionSearcherResponse] =
     for {
-      foundPartitions <- AwsS3DirectoryLister.findDirectories(
-        root,
-        config,
-        originalPartitions,
-        settings.wildcardExcludes,
-        listS3ObjF,
-        connectorTaskId,
+      foundPartitions <- directoryLister.findDirectories(root,
+                                                         settings.recurseLevels,
+                                                         originalPartitions,
+                                                         settings.wildcardExcludes,
       )
       _ <- IO {
-        if (foundPartitions.partitions.nonEmpty)
+        if (foundPartitions.nonEmpty)
           logger.info("[{}] Found new partitions {} for: {}",
                       connectorTaskId.show,
-                      foundPartitions.partitions.mkString(","),
+                      foundPartitions.mkString(","),
                       root.show,
           )
         else
@@ -95,10 +85,9 @@ class S3PartitionSearcher(
 
     } yield PartitionSearcherResponse(
       root,
-      originalPartitions ++ foundPartitions.partitions,
+      originalPartitions ++ foundPartitions,
       foundPartitions,
       Option.empty,
     )
-  }
 
 }

--- a/kafka-connect-cloud-common/src/main/scala/io/lenses/streamreactor/connect/cloud/common/source/distribution/PartitionSearcher.scala
+++ b/kafka-connect-cloud-common/src/main/scala/io/lenses/streamreactor/connect/cloud/common/source/distribution/PartitionSearcher.scala
@@ -13,10 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.lenses.streamreactor.connect.cloud.common.source.state
+package io.lenses.streamreactor.connect.cloud.common.source.distribution
 
 import cats.effect.IO
-import io.lenses.streamreactor.connect.cloud.common.source.distribution.PartitionSearcherResponse
 
 /**
   * Trait defining a partition searcher.

--- a/kafka-connect-cloud-common/src/main/scala/io/lenses/streamreactor/connect/cloud/common/source/distribution/PartitionSearcherResponse.scala
+++ b/kafka-connect-cloud-common/src/main/scala/io/lenses/streamreactor/connect/cloud/common/source/distribution/PartitionSearcherResponse.scala
@@ -16,11 +16,10 @@
 package io.lenses.streamreactor.connect.cloud.common.source.distribution
 
 import io.lenses.streamreactor.connect.cloud.common.model.location.CloudLocation
-import io.lenses.streamreactor.connect.cloud.common.storage.DirectoryFindResults
 
 case class PartitionSearcherResponse(
   root:          CloudLocation,
   allPartitions: Set[String],
-  results:       DirectoryFindResults,
+  results:       Set[String],
   error:         Option[Exception],
 )

--- a/kafka-connect-cloud-common/src/main/scala/io/lenses/streamreactor/connect/cloud/common/source/reader/PartitionDiscovery.scala
+++ b/kafka-connect-cloud-common/src/main/scala/io/lenses/streamreactor/connect/cloud/common/source/reader/PartitionDiscovery.scala
@@ -42,7 +42,7 @@ object PartitionDiscovery extends LazyLogging {
       _        <- IO(logger.info(s"[${connectorTaskId.show}] Starting the partition discovery task."))
       oldState <- readerManagerState.get
       newParts <- partitionSearcher(oldState.partitionResponses)
-      tuples    = newParts.flatMap(part => part.results.partitions.map(part.root -> _))
+      tuples    = newParts.flatMap(part => part.results.map(part.root -> _))
       newReaderManagers <- tuples
         .map {
           case (location, path) =>

--- a/kafka-connect-cloud-common/src/main/scala/io/lenses/streamreactor/connect/cloud/common/storage/DirectoryLister.scala
+++ b/kafka-connect-cloud-common/src/main/scala/io/lenses/streamreactor/connect/cloud/common/storage/DirectoryLister.scala
@@ -15,20 +15,18 @@
  */
 package io.lenses.streamreactor.connect.cloud.common.storage
 
-import io.lenses.streamreactor.connect.cloud.common.source.config.PartitionSearcherOptions
+import cats.effect.IO
+import io.lenses.streamreactor.connect.cloud.common.model.location.CloudLocation
 
-object DirectoryFindCompletionConfig {
-  def fromSearchOptions(
-    searchOptions: PartitionSearcherOptions,
-  ): DirectoryFindCompletionConfig = DirectoryFindCompletionConfig(
-    searchOptions.recurseLevels,
-  )
+trait DirectoryLister {
+
+  /**
+    * @param wildcardExcludes allows ignoring paths containing certain strings.  Mainly it is used to prevent us from reading anything inside the .indexes key prefix, as these should be ignored by the source.
+    */
+  def findDirectories(
+    bucketAndPrefix:  CloudLocation,
+    recurseLevels:    Int,
+    exclude:          Set[String],
+    wildcardExcludes: Set[String],
+  ): IO[Set[String]]
 }
-
-case class DirectoryFindCompletionConfig(
-  levelsToRecurse: Int,
-)
-
-case class DirectoryFindResults(
-  partitions: Set[String],
-)

--- a/kafka-connect-cloud-common/src/main/scala/io/lenses/streamreactor/connect/cloud/common/storage/DirectoryLister.scala
+++ b/kafka-connect-cloud-common/src/main/scala/io/lenses/streamreactor/connect/cloud/common/storage/DirectoryLister.scala
@@ -25,6 +25,7 @@ trait DirectoryLister {
     */
   def findDirectories(
     bucketAndPrefix:  CloudLocation,
+    filesLimit:       Int,
     recurseLevels:    Int,
     exclude:          Set[String],
     wildcardExcludes: Set[String],

--- a/kafka-connect-cloud-common/src/test/scala/io/lenses/streamreactor/connect/cloud/common/source/reader/PartitionDiscoveryTest.scala
+++ b/kafka-connect-cloud-common/src/test/scala/io/lenses/streamreactor/connect/cloud/common/source/reader/PartitionDiscoveryTest.scala
@@ -25,7 +25,6 @@ import io.lenses.streamreactor.connect.cloud.common.source.config.PartitionSearc
 import io.lenses.streamreactor.connect.cloud.common.source.config.PartitionSearcherOptions.ExcludeIndexes
 import io.lenses.streamreactor.connect.cloud.common.source.distribution.PartitionSearcherResponse
 import io.lenses.streamreactor.connect.cloud.common.source.files.SourceFileQueue
-import io.lenses.streamreactor.connect.cloud.common.storage.DirectoryFindResults
 import io.lenses.streamreactor.connect.cloud.common.utils.SampleData
 import org.mockito.MockitoSugar
 import org.scalatest.flatspec.AnyFlatSpecLike
@@ -62,7 +61,7 @@ class PartitionDiscoveryTest extends AnyFlatSpecLike with Matchers with MockitoS
           List(
             PartitionSearcherResponse(CloudLocation("bucket", None),
                                       Set("prefix1/", "prefix2/"),
-                                      DirectoryFindResults(Set("prefix1/", "prefix2/")),
+                                      Set("prefix1/", "prefix2/"),
                                       None,
             ),
           )
@@ -100,7 +99,7 @@ class PartitionDiscoveryTest extends AnyFlatSpecLike with Matchers with MockitoS
         PartitionSearcherResponse(
           CloudLocation("bucket", None),
           Set("prefix1/", "prefix2/"),
-          DirectoryFindResults(Set("prefix1/", "prefix2/")),
+          Set("prefix1/", "prefix2/"),
           None,
         ),
       ),

--- a/kafka-connect-gcp-storage/src/main/scala/io/lenses/streamreactor/connect/gcp/storage/source/GCPStorageSourceConnector.scala
+++ b/kafka-connect-gcp-storage/src/main/scala/io/lenses/streamreactor/connect/gcp/storage/source/GCPStorageSourceConnector.scala
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2017-2024 Lenses.io Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.lenses.streamreactor.connect.gcp.storage.source
+
+import com.typesafe.scalalogging.LazyLogging
+import io.lenses.streamreactor.common.utils.JarManifest
+import io.lenses.streamreactor.connect.cloud.common.config.TaskDistributor
+import io.lenses.streamreactor.connect.gcp.storage.config.GCPConfigSettings.CONNECTOR_PREFIX
+import io.lenses.streamreactor.connect.gcp.storage.source.config.GCPStorageSourceConfigDef
+import org.apache.kafka.common.config.ConfigDef
+import org.apache.kafka.connect.connector.Task
+import org.apache.kafka.connect.source.ExactlyOnceSupport
+import org.apache.kafka.connect.source.SourceConnector
+
+import java.util
+
+class GCPStorageSourceConnector extends SourceConnector with LazyLogging {
+
+  private val manifest = JarManifest(getClass.getProtectionDomain.getCodeSource.getLocation)
+  private val props: util.Map[String, String] = new util.HashMap[String, String]()
+
+  override def version(): String = manifest.version()
+
+  override def taskClass(): Class[_ <: Task] = classOf[GCPStorageSourceTask]
+
+  override def config(): ConfigDef = GCPStorageSourceConfigDef.config
+
+  override def start(props: util.Map[String, String]): Unit = {
+    logger.info(s"Creating GCP Storage source connector")
+    this.props.putAll(props)
+  }
+
+  override def stop(): Unit = ()
+
+  override def taskConfigs(maxTasks: Int): util.List[util.Map[String, String]] = {
+    logger.info(s"Creating $maxTasks tasks config")
+    new TaskDistributor(CONNECTOR_PREFIX).distributeTasks(props, maxTasks)
+  }
+
+  override def exactlyOnceSupport(connectorConfig: util.Map[String, String]): ExactlyOnceSupport =
+    ExactlyOnceSupport.SUPPORTED
+}

--- a/kafka-connect-gcp-storage/src/main/scala/io/lenses/streamreactor/connect/gcp/storage/source/GCPStorageSourceTask.scala
+++ b/kafka-connect-gcp-storage/src/main/scala/io/lenses/streamreactor/connect/gcp/storage/source/GCPStorageSourceTask.scala
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2017-2024 Lenses.io Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.lenses.streamreactor.connect.gcp.storage.source
+
+import com.google.cloud.storage.Storage
+import com.typesafe.scalalogging.LazyLogging
+import io.lenses.streamreactor.connect.cloud.common.config.ConnectorTaskId
+import io.lenses.streamreactor.connect.cloud.common.model.location.CloudLocationValidator
+import io.lenses.streamreactor.connect.cloud.common.source.CloudSourceTask
+import io.lenses.streamreactor.connect.cloud.common.storage.DirectoryLister
+import io.lenses.streamreactor.connect.gcp.storage.auth.GCPStorageClientCreator
+import io.lenses.streamreactor.connect.gcp.storage.config.GCPConfigSettings.CONNECTOR_PREFIX
+import io.lenses.streamreactor.connect.gcp.storage.model.location.GCPStorageLocationValidator
+import io.lenses.streamreactor.connect.gcp.storage.source.config.GCPStorageSourceConfig
+import io.lenses.streamreactor.connect.gcp.storage.storage.GCPStorageDirectoryLister
+import io.lenses.streamreactor.connect.gcp.storage.storage.GCPStorageFileMetadata
+import io.lenses.streamreactor.connect.gcp.storage.storage.GCPStorageStorageInterface
+
+class GCPStorageSourceTask
+    extends CloudSourceTask[
+      GCPStorageFileMetadata,
+      GCPStorageSourceConfig,
+      Storage,
+    ]
+    with LazyLogging {
+
+  val validator: CloudLocationValidator = GCPStorageLocationValidator
+
+  override def createStorageInterface(
+    connectorTaskId: ConnectorTaskId,
+    config:          GCPStorageSourceConfig,
+    storage:         Storage,
+  ): GCPStorageStorageInterface =
+    new GCPStorageStorageInterface(connectorTaskId, storage = storage, avoidReumableUpload = false)
+
+  override def createClient(config: GCPStorageSourceConfig): Either[Throwable, Storage] =
+    GCPStorageClientCreator.make(config.connectionConfig)
+
+  override def convertPropsToConfig(
+    connectorTaskId: ConnectorTaskId,
+    props:           Map[String, String],
+  ): Either[Throwable, GCPStorageSourceConfig] = GCPStorageSourceConfig.fromProps(connectorTaskId, props)(validator)
+
+  override def connectorPrefix: String = CONNECTOR_PREFIX
+
+  override def createDirectoryLister(connectorTaskId: ConnectorTaskId, s3Client: Storage): DirectoryLister =
+    new GCPStorageDirectoryLister(connectorTaskId, s3Client)
+}

--- a/kafka-connect-gcp-storage/src/main/scala/io/lenses/streamreactor/connect/gcp/storage/storage/GCPStorageDirectoryLister.scala
+++ b/kafka-connect-gcp-storage/src/main/scala/io/lenses/streamreactor/connect/gcp/storage/storage/GCPStorageDirectoryLister.scala
@@ -34,6 +34,7 @@ class GCPStorageDirectoryLister(connectorTaskId: ConnectorTaskId, storage: Stora
     */
   override def findDirectories(
     bucketAndPrefix:  CloudLocation,
+    filesLimit:       Int,
     recurseLevels:    Int,
     exclude:          Set[String],
     wildcardExcludes: Set[String],
@@ -43,7 +44,7 @@ class GCPStorageDirectoryLister(connectorTaskId: ConnectorTaskId, storage: Stora
 
       val blobListOptions = BlobListOption.dedupe(
         BlobListOption.delimiter("/"),
-        BlobListOption.pageSize(1000),
+        BlobListOption.pageSize(filesLimit.toLong),
         BlobListOption.prefix(prefix),
         BlobListOption.currentDirectory(),
       )

--- a/kafka-connect-gcp-storage/src/main/scala/io/lenses/streamreactor/connect/gcp/storage/storage/GCPStorageDirectoryLister.scala
+++ b/kafka-connect-gcp-storage/src/main/scala/io/lenses/streamreactor/connect/gcp/storage/storage/GCPStorageDirectoryLister.scala
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2017-2024 Lenses.io Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.lenses.streamreactor.connect.gcp.storage.storage
+
+import cats.effect.IO
+import com.google.cloud.storage.Storage
+import com.google.cloud.storage.Storage.BlobListOption
+import com.typesafe.scalalogging.LazyLogging
+import io.lenses.streamreactor.connect.cloud.common.config.ConnectorTaskId
+import io.lenses.streamreactor.connect.cloud.common.model.location.CloudLocation
+import io.lenses.streamreactor.connect.cloud.common.storage.DirectoryLister
+
+import scala.jdk.CollectionConverters.IterableHasAsScala
+
+class GCPStorageDirectoryLister(connectorTaskId: ConnectorTaskId, storage: Storage)
+    extends LazyLogging
+    with DirectoryLister {
+
+  /**
+    * @param wildcardExcludes allows ignoring paths containing certain strings.  Mainly it is used to prevent us from reading anything inside the .indexes key prefix, as these should be ignored by the source.
+    */
+  override def findDirectories(
+    bucketAndPrefix:  CloudLocation,
+    recurseLevels:    Int,
+    exclude:          Set[String],
+    wildcardExcludes: Set[String],
+  ): IO[Set[String]] = {
+
+    def listSubdirs(prefix: String, recurseLevels: Int): Iterable[String] = {
+
+      val blobListOptions = BlobListOption.dedupe(
+        BlobListOption.delimiter("/"),
+        BlobListOption.pageSize(1000),
+        BlobListOption.prefix(prefix),
+        BlobListOption.currentDirectory(),
+      )
+
+      val foundResults = storage
+        .get(bucketAndPrefix.bucket)
+        .list(blobListOptions: _*)
+        .iterateAll()
+        .asScala
+        .filter(_.isDirectory)
+        .map(_.getName)
+        .toList
+        .filter { prefix =>
+          connectorTaskId.ownsDir(prefix) && !exclude.contains(prefix) && !wildcardExcludes.exists(we =>
+            prefix.contains(we),
+          )
+        }
+
+      foundResults.flatMap {
+        case d: String if recurseLevels > 1 =>
+          listSubdirs(d, recurseLevels - 1)
+        case _ =>
+          foundResults
+      }
+
+    }
+
+    for {
+      iterator <- IO(listSubdirs(bucketAndPrefix.prefix.getOrElse(""), recurseLevels))
+    } yield iterator.toSet ++ bucketAndPrefix.prefix
+
+  }
+
+}

--- a/kafka-connect-gcp-storage/src/test/scala/io/lenses/streamreactor/connect/gcp/storage/storage/GCPStorageDirectoryListerTest.scala
+++ b/kafka-connect-gcp-storage/src/test/scala/io/lenses/streamreactor/connect/gcp/storage/storage/GCPStorageDirectoryListerTest.scala
@@ -1,0 +1,246 @@
+/*
+ * Copyright 2017-2024 Lenses.io Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.lenses.streamreactor.connect.gcp.storage.storage
+
+import cats.effect.testing.scalatest.AsyncIOSpec
+import cats.implicits.catsSyntaxOptionId
+import cats.implicits.none
+import com.google.api.gax.paging.Page
+import com.google.cloud.storage.Blob
+import com.google.cloud.storage.BlobId
+import com.google.cloud.storage.Bucket
+import com.google.cloud.storage.Storage
+import com.google.cloud.storage.Storage.BlobListOption
+import com.google.cloud.storage.Storage.BucketGetOption
+import io.lenses.streamreactor.connect.cloud.common.config.ConnectorTaskId
+import io.lenses.streamreactor.connect.cloud.common.model.location.CloudLocation
+import io.lenses.streamreactor.connect.cloud.common.model.location.CloudLocationValidator
+import io.lenses.streamreactor.connect.gcp.storage.model.location.GCPStorageLocationValidator
+import org.mockito.ArgumentMatchersSugar
+import org.mockito.MockitoSugar
+import org.scalatest.flatspec.AsyncFlatSpecLike
+import org.scalatest.matchers.should.Matchers
+
+import scala.collection.immutable.Seq
+import scala.jdk.CollectionConverters.IterableHasAsJava
+
+class GCPStorageDirectoryListerTest
+    extends AsyncFlatSpecLike
+    with AsyncIOSpec
+    with Matchers
+    with MockitoSugar
+    with ArgumentMatchersSugar {
+  private implicit val cloudLocationValidator: CloudLocationValidator = GCPStorageLocationValidator
+
+  private val connectorTaskId: ConnectorTaskId = ConnectorTaskId("sinkName", 1, 1)
+
+  private val bucketName = "bucket"
+
+  "lister" should "list all directories" in {
+
+    val mockClient: Storage = setUpMockClient(Seq(
+      "prefix1/",
+      "prefix2/",
+      "prefix3/",
+      "prefix4/",
+    ))
+
+    check(
+      mockClient,
+      connectorTaskId,
+      CloudLocation("bucket", none),
+      0,
+      Set.empty,
+      Set.empty,
+      Set("prefix1/", "prefix2/", "prefix3/", "prefix4/"),
+    )
+  }
+
+  "lister" should "list directories recursively" in {
+
+    val mockClient: Storage = setUpMockClient(
+      Seq(
+        "prefix1/",
+        "prefix2/",
+        "prefix3/",
+        "prefix4/",
+      ),
+      Seq("prefix1/sub1/"),
+      Seq("prefix2/sub2/"),
+      Seq("prefix3/sub3/"),
+      Seq("prefix4/sub4/"),
+    )
+
+    check(
+      mockClient,
+      connectorTaskId,
+      CloudLocation("bucket", none),
+      2,
+      Set.empty,
+      Set.empty,
+      Set("prefix1/sub1/", "prefix2/sub2/", "prefix3/sub3/", "prefix4/sub4/"),
+    )
+  }
+
+  "lister" should "exclude directories" in {
+
+    val mockClient: Storage = setUpMockClient(
+      Seq(
+        "prefix1/",
+        "prefix2/",
+        "prefix3/",
+        "prefix4/",
+      ),
+    )
+
+    check(
+      mockClient,
+      location         = CloudLocation("bucket", none),
+      recursiveLevel   = 0,
+      exclude          = Set("prefix1/", "prefix4/"),
+      wildcardExcludes = Set.empty,
+      expected         = Set("prefix2/", "prefix3/"),
+    )
+  }
+
+  "lister" should "consider the connector task owning the partition" in {
+    val taskId1 = ConnectorTaskId("sinkName", 2, 1)
+    val taskId2 = ConnectorTaskId("sinkName", 2, 0)
+
+    val mockClient: Storage = setUpMockClient(Seq(
+      "prefix1/",
+      "prefix2/",
+      "prefix3/",
+      "prefix4/",
+    ))
+
+    check(mockClient, taskId1, CloudLocation("bucket", none), 0, Set.empty, Set.empty, Set("prefix2/", "prefix4/"))
+
+    check(mockClient, taskId2, CloudLocation("bucket", none), 0, Set.empty, Set.empty, Set("prefix1/", "prefix3/"))
+
+    check(mockClient, taskId1, CloudLocation("bucket", none), 0, Set("prefix2/", "prefix4/"), Set.empty, Set.empty)
+
+    check(mockClient, taskId2, CloudLocation("bucket", none), 0, Set("prefix1/", "prefix3/"), Set.empty, Set.empty)
+
+    check(mockClient, taskId1, CloudLocation("bucket", none), 0, Set("prefix2/"), Set.empty, Set("prefix4/"))
+
+    check(mockClient, taskId2, CloudLocation("bucket", none), 0, Set("prefix1/"), Set.empty, Set("prefix3/"))
+  }
+
+  "lister" should "exclude indexes directory when configured as wildcard exclude" in {
+
+    val mockClient: Storage = setUpMockClient(
+      Seq(
+        ".indexes/sinkName/myTopic/00005/00000000000000000050",
+        ".indexes/sinkName/myTopic/00005/00000000000000000070",
+        ".indexes/sinkName/myTopic/00005/00000000000000000100",
+        "prefix1/",
+        "prefix1/",
+        "prefix2/",
+        "prefix2/",
+      ),
+    )
+
+    check(
+      mockClient,
+      location         = CloudLocation("bucket", "prefix1/".some),
+      exclude          = Set.empty,
+      wildcardExcludes = Set(".indexes"),
+      recursiveLevel   = 0,
+      expected         = Set("prefix1/"),
+    )
+    check(
+      mockClient,
+      location         = CloudLocation("bucket", "prefix2/".some),
+      exclude          = Set.empty,
+      wildcardExcludes = Set(".indexes"),
+      recursiveLevel   = 0,
+      expected         = Set("prefix2/"),
+    )
+    check(
+      mockClient,
+      location         = CloudLocation("bucket", "prefix3/".some),
+      exclude          = Set.empty,
+      wildcardExcludes = Set(".indexes"),
+      recursiveLevel   = 0,
+      expected         = Set.empty,
+    )
+    check(
+      mockClient,
+      location         = CloudLocation("bucket", None),
+      exclude          = Set.empty,
+      wildcardExcludes = Set(".indexes"),
+      recursiveLevel   = 0,
+      expected         = Set("prefix1/", "prefix2/"),
+    )
+  }
+
+  private def setUpMockClient(dirsToFind: Seq[String]*) = {
+    val mockBucket = mock[Bucket]
+
+    val mockBlobPages = dirsToFind.map {
+      dirs =>
+        val mockBlobPage: Page[Blob] = mockTheBlobPage(dirs)
+
+        mockBlobPage
+    }
+
+    when(mockBucket.list(any[BlobListOption])) thenReturn (mockBlobPages.head, mockBlobPages.tail: _*)
+
+    val mockClient = mock[Storage]
+    when(
+      mockClient.get(
+        any[String],
+        any[BucketGetOption],
+      ),
+    ).thenReturn(mockBucket)
+    mockClient
+  }
+
+  private def mockTheBlobPage(dirsToFind: Seq[String]) = {
+    val blobberable: Iterable[Blob] = dirsToFind.map { b =>
+      val blobId: BlobId = BlobId.of(bucketName, b)
+
+      val blob: Blob = mock[Blob]
+      when(blob.getName).thenReturn(b)
+      when(blob.getBlobId).thenReturn(blobId)
+      when(blob.isDirectory).thenReturn(true)
+      blob
+    }
+
+    val mockBlobPage = mock[Page[Blob]]
+    when(mockBlobPage.iterateAll())
+      .thenReturn(blobberable.asJava)
+    mockBlobPage
+  }
+
+  private def check(
+    client:           Storage,
+    connectorTaskId:  ConnectorTaskId = connectorTaskId,
+    location:         CloudLocation,
+    recursiveLevel:   Int,
+    exclude:          Set[String],
+    wildcardExcludes: Set[String],
+    expected:         Set[String],
+  ) =
+    new GCPStorageDirectoryLister(connectorTaskId, client).findDirectories(
+      location,
+      recursiveLevel,
+      exclude,
+      wildcardExcludes,
+    ).asserting(actual => actual should be(expected))
+
+}

--- a/kafka-connect-gcp-storage/src/test/scala/io/lenses/streamreactor/connect/gcp/storage/storage/GCPStorageDirectoryListerTest.scala
+++ b/kafka-connect-gcp-storage/src/test/scala/io/lenses/streamreactor/connect/gcp/storage/storage/GCPStorageDirectoryListerTest.scala
@@ -47,6 +47,7 @@ class GCPStorageDirectoryListerTest
 
   private val connectorTaskId: ConnectorTaskId = ConnectorTaskId("sinkName", 1, 1)
 
+  private val filesLimit = 4
   private val bucketName = "bucket"
 
   "lister" should "list all directories" in {
@@ -238,6 +239,7 @@ class GCPStorageDirectoryListerTest
   ) =
     new GCPStorageDirectoryLister(connectorTaskId, client).findDirectories(
       location,
+      filesLimit,
       recursiveLevel,
       exclude,
       wildcardExcludes,


### PR DESCRIPTION
This introduces most of the functionality for the GCP Storage Source.

* Removes `DirectoryFindCompletionConfig` and `DirectoryFindResults` case classes as these were simple wrappers for primitive values and adding indirection to the code.
* Some functionality is pushed up from `S3SourceTask` into `CloudSourceTask` to be shared by all cloud connectors, with some abstract template methods defined in `CloudSourceTask` to ensure the functionality is implemented by all connectors.
* `S3PartitionSearcher` is promoted to cloud-commons module and renamed to `CloudPartitionSearcher`.
* `DirectoryLister` becomes a trait (interface) sitting in cloud-commons to be implemented by each source subproject.  Implementations of this trait are `GCPStorageDirectoryLister` and `AWSS3DirectoryLister`.
* `GCPStorageSourceTask` and `GCPStorageSourceConnector` are introduced but not yet ready to use until some methods in the `GCPStorageStorageInterface` are implemented.
