### PR TITLE
KCQLSettings Housekeeping

### DIFF
--- a/kafka-connect-cassandra/src/main/scala/io/lenses/streamreactor/connect/cassandra/config/CassandraSettings.scala
+++ b/kafka-connect-cassandra/src/main/scala/io/lenses/streamreactor/connect/cassandra/config/CassandraSettings.scala
@@ -211,6 +211,7 @@ object CassandraSettings extends StrictLogging {
       defaultValueStrategy,
     )
   }
+
 }
 
 object DefaultValueServeStrategy extends Enumeration {

--- a/kafka-connect-common/src/main/scala/io/lenses/streamreactor/common/config/base/traits/KcqlSettings.scala
+++ b/kafka-connect-common/src/main/scala/io/lenses/streamreactor/common/config/base/traits/KcqlSettings.scala
@@ -15,14 +15,9 @@
  */
 package io.lenses.streamreactor.common.config.base.traits
 
-import io.lenses.kcql.Field
-import io.lenses.kcql.FormatType
 import io.lenses.kcql.Kcql
 import io.lenses.kcql.WriteModeEnum
 import io.lenses.streamreactor.common.config.base.const.TraitConfigConst.KCQL_PROP_SUFFIX
-import io.lenses.streamreactor.common.rowkeys.StringGenericRowKeyBuilder
-import io.lenses.streamreactor.common.rowkeys.StringKeyBuilder
-import io.lenses.streamreactor.common.rowkeys.StringStructFieldsStringKeyBuilder
 import org.apache.kafka.common.config.ConfigException
 
 import scala.collection.immutable.ListSet
@@ -49,15 +44,6 @@ trait KcqlSettings extends BaseSettings {
       .map(rm => (rm.getSource, rm.getFields.asScala.map(fa => (fa.toString, fa.getAlias)).toMap))
       .toMap
 
-  def getFields(kcql: Set[Kcql] = getKCQL): Map[String, Seq[Field]] =
-    kcql.toList.map(rm => (rm.getSource, rm.getFields.asScala.toSeq)).toMap
-
-  def getIgnoreFields(kcql: Set[Kcql] = getKCQL): Map[String, Seq[Field]] =
-    kcql.toList.map(rm => (rm.getSource, rm.getIgnoredFields.asScala.toSeq)).toMap
-
-  def getFieldsAliases(kcql: Set[Kcql] = getKCQL): List[Map[String, String]] =
-    kcql.toList.map(rm => rm.getFields.asScala.map(fa => (fa.getName, fa.getAlias)).toMap)
-
   def getIgnoreFieldsMap(
     kcql: Set[Kcql] = getKCQL,
   ): Map[String, Set[String]] =
@@ -72,29 +58,10 @@ trait KcqlSettings extends BaseSettings {
       (r.getSource, set)
     }.toMap
 
-  def getFormat(formatType: FormatType => FormatType, kcql: Set[Kcql] = getKCQL): Map[String, FormatType] =
-    kcql.toList.map(r => (r.getSource, formatType(r.getFormatType))).toMap
-
-  def getTTL(kcql: Set[Kcql] = getKCQL): Map[String, Long] =
-    kcql.toList.map(r => (r.getSource, r.getTTL)).toMap
-
-//  def getIncrementalMode(kcql: Set[Kcql] = getKCQL): Map[String, String] = {
-//    kcql.toList.map(r => (r.getSource, r.getIncrementalMode)).toMap
-//  }
-
   def getBatchSize(kcql: Set[Kcql] = getKCQL, defaultBatchSize: Int): Map[String, Int] =
     kcql.toList
       .map(r => (r.getSource, Option(r.getBatchSize).getOrElse(defaultBatchSize)))
       .toMap
-
-  def getWriteMode(kcql: Set[Kcql] = getKCQL): Map[String, WriteModeEnum] =
-    kcql.toList.map(r => (r.getSource, r.getWriteMode)).toMap
-
-  def getAutoCreate(kcql: Set[Kcql] = getKCQL): Map[String, Boolean] =
-    kcql.toList.map(r => (r.getSource, r.isAutoCreate)).toMap
-
-  def getAutoEvolve(kcql: Set[Kcql] = getKCQL): Map[String, Boolean] =
-    kcql.toList.map(r => (r.getSource, r.isAutoEvolve)).toMap
 
   /** Get all the upsert keys
     *
@@ -129,21 +96,5 @@ trait KcqlSettings extends BaseSettings {
         (r.getSource, keys)
       }
       .toMap
-
-  def getRowKeyBuilders(kcql: Set[Kcql] = getKCQL): List[StringKeyBuilder] =
-    kcql.toList.map { k =>
-      val keys = k.getPrimaryKeys.asScala.map(k => k.getName).toSeq
-      // No PK => 'topic|par|offset' builder else generic-builder
-      if (keys.nonEmpty) StringStructFieldsStringKeyBuilder(keys)
-      else new StringGenericRowKeyBuilder()
-    }
-
-  def getPrimaryKeyCols(kcql: Set[Kcql] = getKCQL): Map[String, Set[String]] =
-    kcql.toList
-      .map(k => (k.getSource, ListSet(k.getPrimaryKeys.asScala.map(p => p.getName).reverse.toSeq: _*).toSet))
-      .toMap
-
-  def getIncrementalMode(routes: Set[Kcql]): Map[String, String] =
-    routes.toList.map(r => (r.getSource, r.getIncrementalMode)).toMap
 
 }

--- a/kafka-connect-mongodb/src/main/scala/io/lenses/streamreactor/connect/mongodb/config/MongoSettings.scala
+++ b/kafka-connect-mongodb/src/main/scala/io/lenses/streamreactor/connect/mongodb/config/MongoSettings.scala
@@ -112,7 +112,7 @@ object MongoSettings extends StrictLogging {
     *      Seq("top-level-parent", "child1", "child2", "fieldname"),
     *    )
     */
-  def getJsonDateTimeFields(config: MongoConfig): Set[Seq[String]] = {
+  private def getJsonDateTimeFields(config: MongoConfig): Set[Seq[String]] = {
     val set: Set[Seq[String]] =
       config.getList(MongoConfigConstants.JSON_DATETIME_FIELDS_CONFIG).asScala.map { fullName =>
         fullName.trim.split('.').toSeq

--- a/kafka-connect-redis/src/main/scala/io/lenses/streamreactor/connect/redis/sink/config/RedisSinkSettings.scala
+++ b/kafka-connect-redis/src/main/scala/io/lenses/streamreactor/connect/redis/sink/config/RedisSinkSettings.scala
@@ -18,7 +18,7 @@ package io.lenses.streamreactor.connect.redis.sink.config
 import io.lenses.kcql.Kcql
 import io.lenses.streamreactor.common.errors.ErrorPolicy
 import io.lenses.streamreactor.common.errors.ThrowErrorPolicy
-import io.lenses.streamreactor.common.rowkeys.StringKeyBuilder
+import io.lenses.streamreactor.connect.redis.sink.rowkeys.StringKeyBuilder
 import org.apache.kafka.common.config.ConfigException
 import org.apache.kafka.common.config.SslConfigs
 

--- a/kafka-connect-redis/src/main/scala/io/lenses/streamreactor/connect/redis/sink/rowkeys/RowKeyBuilderString.scala
+++ b/kafka-connect-redis/src/main/scala/io/lenses/streamreactor/connect/redis/sink/rowkeys/RowKeyBuilderString.scala
@@ -13,13 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.lenses.streamreactor.common.rowkeys
+package io.lenses.streamreactor.connect.redis.sink.rowkeys
 
-import org.apache.kafka.connect.data.Schema
-import org.apache.kafka.connect.data.Struct
 import org.apache.kafka.connect.sink.SinkRecord
-
-import scala.jdk.CollectionConverters.ListHasAsScala
 
 /**
   * Builds the new record key for the given connect SinkRecord.
@@ -53,56 +49,5 @@ class StringSinkRecordKeyBuilder extends StringKeyBuilder {
         record.key().toString
       case other => throw new IllegalArgumentException(s"$other is not supported by the ${getClass.getName}")
     }
-  }
-}
-
-/**
-  * Builds a new key from the payload fields specified
-  *
-  * @param keys The key to build
-  * @param keyDelimiter Row key delimiter
-  */
-case class StringStructFieldsStringKeyBuilder(keys: Seq[String], keyDelimiter: String = ".") extends StringKeyBuilder {
-  private val availableSchemaTypes = Set(
-    Schema.Type.BOOLEAN,
-    Schema.Type.BYTES,
-    Schema.Type.FLOAT32,
-    Schema.Type.FLOAT64,
-    Schema.Type.INT8,
-    Schema.Type.INT16,
-    Schema.Type.INT32,
-    Schema.Type.INT64,
-    Schema.Type.STRING,
-  )
-
-  require(keys.nonEmpty, "Invalid keys provided")
-
-  /**
-    * Builds a row key for a records
-    *
-    * @param record a SinkRecord to build the key for
-    * @return A row key string
-    */
-  override def build(record: SinkRecord): String = {
-    val struct = record.value().asInstanceOf[Struct]
-    val schema = struct.schema
-
-    val availableFields = schema.fields().asScala.map(_.name).toSet
-    val missingKeys     = keys.filterNot(availableFields.contains)
-    require(
-      missingKeys.isEmpty,
-      s"[${missingKeys.mkString(",")}] keys are not present in the SinkRecord payload: [${availableFields.mkString(",")}]",
-    )
-
-    keys.flatMap { key =>
-      val field = schema.field(key)
-      val value = struct.get(field)
-
-      require(value != null,
-              s"[$key] field value is null. Non null value is required for the fields creating the Hbase row key",
-      )
-      if (availableSchemaTypes.contains(field.schema().`type`())) Some(value.toString)
-      else None
-    }.mkString(keyDelimiter)
   }
 }

--- a/kafka-connect-redis/src/main/scala/io/lenses/streamreactor/connect/redis/sink/rowkeys/StringStructFieldsStringKeyBuilder.scala
+++ b/kafka-connect-redis/src/main/scala/io/lenses/streamreactor/connect/redis/sink/rowkeys/StringStructFieldsStringKeyBuilder.scala
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2017-2024 Lenses.io Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.lenses.streamreactor.connect.redis.sink.rowkeys
+
+import org.apache.kafka.connect.data.Schema
+import org.apache.kafka.connect.data.Struct
+import org.apache.kafka.connect.sink.SinkRecord
+
+import scala.jdk.CollectionConverters.ListHasAsScala
+
+/**
+  * Builds a new key from the payload fields specified
+  *
+  * @param keys The key to build
+  * @param keyDelimiter Row key delimiter
+  */
+case class StringStructFieldsStringKeyBuilder(keys: Seq[String], keyDelimiter: String = ".") extends StringKeyBuilder {
+  private val availableSchemaTypes = Set(
+    Schema.Type.BOOLEAN,
+    Schema.Type.BYTES,
+    Schema.Type.FLOAT32,
+    Schema.Type.FLOAT64,
+    Schema.Type.INT8,
+    Schema.Type.INT16,
+    Schema.Type.INT32,
+    Schema.Type.INT64,
+    Schema.Type.STRING,
+  )
+
+  require(keys.nonEmpty, "Invalid keys provided")
+
+  /**
+    * Builds a row key for a records
+    *
+    * @param record a SinkRecord to build the key for
+    * @return A row key string
+    */
+  override def build(record: SinkRecord): String = {
+    val struct = record.value().asInstanceOf[Struct]
+    val schema = struct.schema
+
+    val availableFields = schema.fields().asScala.map(_.name).toSet
+    val missingKeys     = keys.filterNot(availableFields.contains)
+    require(
+      missingKeys.isEmpty,
+      s"[${missingKeys.mkString(",")}] keys are not present in the SinkRecord payload: [${availableFields.mkString(",")}]",
+    )
+
+    keys.flatMap { key =>
+      val field = schema.field(key)
+      val value = struct.get(field)
+
+      require(value != null,
+              s"[$key] field value is null. Non null value is required for the fields creating the Hbase row key",
+      )
+      if (availableSchemaTypes.contains(field.schema().`type`())) Some(value.toString)
+      else None
+    }.mkString(keyDelimiter)
+  }
+}

--- a/kafka-connect-redis/src/main/scala/io/lenses/streamreactor/connect/redis/sink/writer/RedisInsertSortedSet.scala
+++ b/kafka-connect-redis/src/main/scala/io/lenses/streamreactor/connect/redis/sink/writer/RedisInsertSortedSet.scala
@@ -19,12 +19,12 @@ import com.typesafe.scalalogging.StrictLogging
 import io.lenses.kcql.Kcql
 import io.lenses.streamreactor.common.config.base.settings.Projections
 import io.lenses.streamreactor.common.errors.ErrorHandler
-import io.lenses.streamreactor.common.rowkeys.StringStructFieldsStringKeyBuilder
 import io.lenses.streamreactor.common.schemas.SinkRecordConverterHelper.SinkRecordExtension
 import io.lenses.streamreactor.common.sink.DbWriter
 import io.lenses.streamreactor.connect.json.SimpleJsonConverter
 import io.lenses.streamreactor.connect.redis.sink.config.RedisKCQLSetting
 import io.lenses.streamreactor.connect.redis.sink.config.RedisSinkSettings
+import io.lenses.streamreactor.connect.redis.sink.rowkeys.StringStructFieldsStringKeyBuilder
 import org.apache.kafka.connect.sink.SinkRecord
 import redis.clients.jedis.Jedis
 

--- a/kafka-connect-redis/src/main/scala/io/lenses/streamreactor/connect/redis/sink/writer/RedisPubSub.scala
+++ b/kafka-connect-redis/src/main/scala/io/lenses/streamreactor/connect/redis/sink/writer/RedisPubSub.scala
@@ -19,12 +19,12 @@ import com.typesafe.scalalogging.StrictLogging
 import io.lenses.kcql.Kcql
 import io.lenses.streamreactor.common.config.base.settings.Projections
 import io.lenses.streamreactor.common.errors.ErrorHandler
-import io.lenses.streamreactor.common.rowkeys.StringStructFieldsStringKeyBuilder
 import io.lenses.streamreactor.common.schemas.SinkRecordConverterHelper.SinkRecordExtension
 import io.lenses.streamreactor.common.sink.DbWriter
 import io.lenses.streamreactor.connect.json.SimpleJsonConverter
 import io.lenses.streamreactor.connect.redis.sink.config.RedisKCQLSetting
 import io.lenses.streamreactor.connect.redis.sink.config.RedisSinkSettings
+import io.lenses.streamreactor.connect.redis.sink.rowkeys.StringStructFieldsStringKeyBuilder
 import org.apache.kafka.connect.sink.SinkRecord
 import redis.clients.jedis.Jedis
 

--- a/kafka-connect-redis/src/test/scala/io/lenses/streamreactor/connect/redis/sink/config/ConfigMultipleSortedSetsTest.scala
+++ b/kafka-connect-redis/src/test/scala/io/lenses/streamreactor/connect/redis/sink/config/ConfigMultipleSortedSetsTest.scala
@@ -15,7 +15,7 @@
  */
 package io.lenses.streamreactor.connect.redis.sink.config
 
-import io.lenses.streamreactor.common.rowkeys.StringStructFieldsStringKeyBuilder
+import io.lenses.streamreactor.connect.redis.sink.rowkeys.StringStructFieldsStringKeyBuilder
 import io.lenses.streamreactor.connect.redis.sink.support.RedisMockSupport
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec

--- a/kafka-connect-redis/src/test/scala/io/lenses/streamreactor/connect/redis/sink/config/RedisSinkSettingsTest.scala
+++ b/kafka-connect-redis/src/test/scala/io/lenses/streamreactor/connect/redis/sink/config/RedisSinkSettingsTest.scala
@@ -15,8 +15,8 @@
  */
 package io.lenses.streamreactor.connect.redis.sink.config
 
-import io.lenses.streamreactor.common.rowkeys.StringGenericRowKeyBuilder
-import io.lenses.streamreactor.common.rowkeys.StringStructFieldsStringKeyBuilder
+import io.lenses.streamreactor.connect.redis.sink.rowkeys.StringGenericRowKeyBuilder
+import io.lenses.streamreactor.connect.redis.sink.rowkeys.StringStructFieldsStringKeyBuilder
 import io.lenses.streamreactor.connect.redis.sink.support.RedisMockSupport
 import org.apache.kafka.common.config.ConfigException
 import org.scalatest.matchers.should.Matchers

--- a/kafka-connect-redis/src/test/scala/io/lenses/streamreactor/connect/redis/sink/rowkeys/StringGenericRowKeyBuilderTest.scala
+++ b/kafka-connect-redis/src/test/scala/io/lenses/streamreactor/connect/redis/sink/rowkeys/StringGenericRowKeyBuilderTest.scala
@@ -13,9 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.lenses.streamreactor.common.sink
+package io.lenses.streamreactor.connect.redis.sink.rowkeys
 
-import io.lenses.streamreactor.common.rowkeys.StringGenericRowKeyBuilder
+import io.lenses.streamreactor.connect.redis.sink.rowkeys.StringGenericRowKeyBuilder
 import org.apache.kafka.connect.data.Schema
 import org.apache.kafka.connect.sink.SinkRecord
 import org.scalatest.matchers.should.Matchers

--- a/kafka-connect-redis/src/test/scala/io/lenses/streamreactor/connect/redis/sink/rowkeys/StringSinkRecordKeyBuilderTest.scala
+++ b/kafka-connect-redis/src/test/scala/io/lenses/streamreactor/connect/redis/sink/rowkeys/StringSinkRecordKeyBuilderTest.scala
@@ -13,9 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.lenses.streamreactor.common.sink
+package io.lenses.streamreactor.connect.redis.sink.rowkeys
 
-import io.lenses.streamreactor.common.rowkeys.StringSinkRecordKeyBuilder
+import io.lenses.streamreactor.connect.redis.sink.rowkeys.StringSinkRecordKeyBuilder
 import org.apache.kafka.connect.data.Schema
 import org.apache.kafka.connect.sink.SinkRecord
 import org.scalatest.matchers.should.Matchers

--- a/kafka-connect-redis/src/test/scala/io/lenses/streamreactor/connect/redis/sink/rowkeys/StringStructFieldsStringKeyBuilderTest.scala
+++ b/kafka-connect-redis/src/test/scala/io/lenses/streamreactor/connect/redis/sink/rowkeys/StringStructFieldsStringKeyBuilderTest.scala
@@ -13,9 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.lenses.streamreactor.common.sink
+package io.lenses.streamreactor.connect.redis.sink.rowkeys
 
-import io.lenses.streamreactor.common.rowkeys.StringStructFieldsStringKeyBuilder
+import io.lenses.streamreactor.connect.redis.sink.rowkeys.StringStructFieldsStringKeyBuilder
 import org.apache.kafka.connect.data.Schema
 import org.apache.kafka.connect.data.SchemaBuilder
 import org.apache.kafka.connect.data.Struct


### PR DESCRIPTION
Remove some complexity from KcqlSettings where the functionality is only used for one connector (related classes only used once, and the related unit tests are also moved).