### PR TITLE
Fix discrepancy between code and docs for recurse levels/millis/mode

### DIFF
--- a/kafka-connect-aws-s3/src/it/scala/io/lenses/streamreactor/connect/aws/s3/source/S3SourceAvroEnvelopeTest.scala
+++ b/kafka-connect-aws-s3/src/it/scala/io/lenses/streamreactor/connect/aws/s3/source/S3SourceAvroEnvelopeTest.scala
@@ -124,9 +124,9 @@ class S3SourceAvroEnvelopeTest
     val task = new S3SourceTask()
 
     val props = (defaultProps ++ Map(
-      "connect.s3.kcql"                            -> s"insert into $TopicName select * from $BucketName:$MyPrefix/avro STOREAS `AVRO` LIMIT 1000 PROPERTIES ('store.envelope'=true)",
-      "connect.s3.partition.search.recurse.levels" -> "0",
-      "connect.partition.search.continuous"        -> "false",
+      "connect.s3.kcql"                                   -> s"insert into $TopicName select * from $BucketName:$MyPrefix/avro STOREAS `AVRO` LIMIT 1000 PROPERTIES ('store.envelope'=true)",
+      "connect.s3.source.partition.search.recurse.levels" -> "0",
+      "connect.s3.source.partition.search.continuous"     -> "false",
     )).asJava
 
     task.start(props)

--- a/kafka-connect-aws-s3/src/it/scala/io/lenses/streamreactor/connect/aws/s3/source/S3SourceAvroWithValueAsArrayEnvelopeTest.scala
+++ b/kafka-connect-aws-s3/src/it/scala/io/lenses/streamreactor/connect/aws/s3/source/S3SourceAvroWithValueAsArrayEnvelopeTest.scala
@@ -105,9 +105,9 @@ class S3SourceAvroWithValueAsArrayEnvelopeTest
     val task = new S3SourceTask()
 
     val props = (defaultProps ++ Map(
-      "connect.s3.kcql"                            -> s"insert into $TopicName select * from $BucketName:$MyPrefix/avro STOREAS `AVRO` LIMIT 1000 PROPERTIES ('store.envelope'=true)",
-      "connect.s3.partition.search.recurse.levels" -> "0",
-      "connect.partition.search.continuous"        -> "false",
+      "connect.s3.kcql"                                   -> s"insert into $TopicName select * from $BucketName:$MyPrefix/avro STOREAS `AVRO` LIMIT 1000 PROPERTIES ('store.envelope'=true)",
+      "connect.s3.source.partition.search.recurse.levels" -> "0",
+      "connect.s3.source.partition.search.continuous"     -> "false",
     )).asJava
 
     task.start(props)

--- a/kafka-connect-aws-s3/src/it/scala/io/lenses/streamreactor/connect/aws/s3/source/S3SourceAvroWithValueAsOptionalArrayEnvelopeTest.scala
+++ b/kafka-connect-aws-s3/src/it/scala/io/lenses/streamreactor/connect/aws/s3/source/S3SourceAvroWithValueAsOptionalArrayEnvelopeTest.scala
@@ -104,9 +104,9 @@ class S3SourceAvroWithValueAsOptionalArrayEnvelopeTest
     val task = new S3SourceTask()
 
     val props = (defaultProps ++ Map(
-      "connect.s3.kcql"                            -> s"insert into $TopicName select * from $BucketName:$MyPrefix/avro STOREAS `AVRO` LIMIT 1000 PROPERTIES ('store.envelope'=true)",
-      "connect.s3.partition.search.recurse.levels" -> "0",
-      "connect.partition.search.continuous"        -> "false",
+      "connect.s3.kcql"                                   -> s"insert into $TopicName select * from $BucketName:$MyPrefix/avro STOREAS `AVRO` LIMIT 1000 PROPERTIES ('store.envelope'=true)",
+      "connect.s3.source.partition.search.recurse.levels" -> "0",
+      "connect.s3.source.partition.search.continuous"     -> "false",
     )).asJava
 
     task.start(props)
@@ -232,9 +232,9 @@ class S3SourceAvroWithValueAsOptionalArrayMixValuesEnvelopeTest
     val task = new S3SourceTask()
 
     val props = (defaultProps ++ Map(
-      "connect.s3.kcql"                            -> s"insert into $TopicName select * from $BucketName:$MyPrefix/avro STOREAS `AVRO` LIMIT 1000 PROPERTIES ('store.envelope'=true)",
-      "connect.s3.partition.search.recurse.levels" -> "0",
-      "connect.partition.search.continuous"        -> "false",
+      "connect.s3.kcql"                                   -> s"insert into $TopicName select * from $BucketName:$MyPrefix/avro STOREAS `AVRO` LIMIT 1000 PROPERTIES ('store.envelope'=true)",
+      "connect.s3.source.partition.search.recurse.levels" -> "0",
+      "connect.s3.source.partition.search.continuous"     -> "false",
     )).asJava
 
     task.start(props)

--- a/kafka-connect-aws-s3/src/it/scala/io/lenses/streamreactor/connect/aws/s3/source/S3SourceJsonEnvelopeTest.scala
+++ b/kafka-connect-aws-s3/src/it/scala/io/lenses/streamreactor/connect/aws/s3/source/S3SourceJsonEnvelopeTest.scala
@@ -56,9 +56,9 @@ class S3SourceJsonEnvelopeTest
     val task = new S3SourceTask()
 
     val props = (defaultProps ++ Map(
-      "connect.s3.kcql"                            -> s"insert into $TopicName select * from $BucketName:$MyPrefix/json STOREAS `JSON` LIMIT 1000 PROPERTIES ('store.envelope'=true)",
-      "connect.s3.partition.search.recurse.levels" -> "0",
-      "connect.partition.search.continuous"        -> "false",
+      "connect.s3.kcql"                                   -> s"insert into $TopicName select * from $BucketName:$MyPrefix/json STOREAS `JSON` LIMIT 1000 PROPERTIES ('store.envelope'=true)",
+      "connect.s3.source.partition.search.recurse.levels" -> "0",
+      "connect.s3.source.partition.search.continuous"     -> "false",
     )).asJava
 
     task.start(props)

--- a/kafka-connect-aws-s3/src/it/scala/io/lenses/streamreactor/connect/aws/s3/source/S3SourceParquetEnvelopeTest.scala
+++ b/kafka-connect-aws-s3/src/it/scala/io/lenses/streamreactor/connect/aws/s3/source/S3SourceParquetEnvelopeTest.scala
@@ -135,9 +135,9 @@ class S3SourceParquetEnvelopeTest
 
     val props = (defaultProps ++
       Map(
-        "connect.s3.kcql"                            -> s"insert into $TopicName select * from $BucketName:$MyPrefix/parquet STOREAS `Parquet` LIMIT 1000 PROPERTIES ('store.envelope'=true)",
-        "connect.s3.partition.search.recurse.levels" -> "0",
-        "connect.s3.partition.search.continuous"     -> "false",
+        "connect.s3.kcql"                                   -> s"insert into $TopicName select * from $BucketName:$MyPrefix/parquet STOREAS `Parquet` LIMIT 1000 PROPERTIES ('store.envelope'=true)",
+        "connect.s3.source.partition.search.recurse.levels" -> "0",
+        "connect.s3.source.partition.search.continuous"     -> "false",
       ))
       .asJava
 

--- a/kafka-connect-aws-s3/src/it/scala/io/lenses/streamreactor/connect/aws/s3/source/S3SourceTaskXmlReaderTest.scala
+++ b/kafka-connect-aws-s3/src/it/scala/io/lenses/streamreactor/connect/aws/s3/source/S3SourceTaskXmlReaderTest.scala
@@ -47,8 +47,8 @@ class S3SourceTaskXmlReaderTest
     val task = new S3SourceTask()
 
     val props = (defaultProps ++ Map(
-      "connect.s3.kcql"                            -> s"insert into $TopicName select * from $BucketName:$PrefixName/xml STOREAS `TEXT` LIMIT 1000 PROPERTIES ( 'read.text.mode'='StartEndTag' , 'read.text.start.tag'='<Employee>' , 'read.text.end.tag'='</Employee>' )",
-      "connect.s3.partition.search.recurse.levels" -> "0",
+      "connect.s3.kcql"                                   -> s"insert into $TopicName select * from $BucketName:$PrefixName/xml STOREAS `TEXT` LIMIT 1000 PROPERTIES ( 'read.text.mode'='StartEndTag' , 'read.text.start.tag'='<Employee>' , 'read.text.end.tag'='</Employee>' )",
+      "connect.s3.source.partition.search.recurse.levels" -> "0",
     )).asJava
 
     task.start(props)

--- a/kafka-connect-aws-s3/src/main/scala/io/lenses/streamreactor/connect/aws/s3/config/processors/kcql/DeprecationConfigDefProcessor.scala
+++ b/kafka-connect-aws-s3/src/main/scala/io/lenses/streamreactor/connect/aws/s3/config/processors/kcql/DeprecationConfigDefProcessor.scala
@@ -16,9 +16,11 @@
 package io.lenses.streamreactor.connect.aws.s3.config.processors.kcql
 
 import com.typesafe.scalalogging.LazyLogging
+import io.lenses.streamreactor.common.config.base.traits.WithConnectorPrefix
 import io.lenses.streamreactor.connect.aws.s3.config.S3ConfigSettings.AUTH_MODE
 import io.lenses.streamreactor.connect.aws.s3.config.S3ConfigSettings.AWS_ACCESS_KEY
 import io.lenses.streamreactor.connect.aws.s3.config.S3ConfigSettings.AWS_SECRET_KEY
+import io.lenses.streamreactor.connect.aws.s3.config.S3ConfigSettings.CONNECTOR_PREFIX
 import io.lenses.streamreactor.connect.aws.s3.config.S3ConfigSettings.CUSTOM_ENDPOINT
 import io.lenses.streamreactor.connect.aws.s3.config.S3ConfigSettings.ENABLE_VIRTUAL_HOST_BUCKETS
 import io.lenses.streamreactor.connect.aws.s3.config.processors.kcql.DeprecationConfigDefProcessor.DEP_AUTH_MODE
@@ -26,7 +28,11 @@ import io.lenses.streamreactor.connect.aws.s3.config.processors.kcql.Deprecation
 import io.lenses.streamreactor.connect.aws.s3.config.processors.kcql.DeprecationConfigDefProcessor.DEP_AWS_SECRET_KEY
 import io.lenses.streamreactor.connect.aws.s3.config.processors.kcql.DeprecationConfigDefProcessor.DEP_CUSTOM_ENDPOINT
 import io.lenses.streamreactor.connect.aws.s3.config.processors.kcql.DeprecationConfigDefProcessor.DEP_ENABLE_VIRTUAL_HOST_BUCKETS
+import io.lenses.streamreactor.connect.aws.s3.config.processors.kcql.DeprecationConfigDefProcessor.DEP_SOURCE_PARTITION_SEARCH_INTERVAL_MILLIS
+import io.lenses.streamreactor.connect.aws.s3.config.processors.kcql.DeprecationConfigDefProcessor.DEP_SOURCE_PARTITION_SEARCH_MODE
+import io.lenses.streamreactor.connect.aws.s3.config.processors.kcql.DeprecationConfigDefProcessor.DEP_SOURCE_PARTITION_SEARCH_RECURSE_LEVELS
 import io.lenses.streamreactor.connect.cloud.common.config.processors.ConfigDefProcessor
+import io.lenses.streamreactor.connect.cloud.common.source.config.CloudSourceSettingsKeys
 
 import scala.collection.MapView
 import scala.collection.immutable.ListMap
@@ -40,6 +46,11 @@ object DeprecationConfigDefProcessor {
   val DEP_CUSTOM_ENDPOINT:             String = "aws.custom.endpoint"
   val DEP_ENABLE_VIRTUAL_HOST_BUCKETS: String = "aws.vhost.bucket"
 
+  // Deprecated due to incorrect implementation - all the other properties have "source" in the property key
+  val DEP_SOURCE_PARTITION_SEARCH_RECURSE_LEVELS:  String = "connect.s3.partition.search.recurse.levels"
+  val DEP_SOURCE_PARTITION_SEARCH_INTERVAL_MILLIS: String = s"connect.s3.partition.search.interval"
+  val DEP_SOURCE_PARTITION_SEARCH_MODE:            String = s"connect.s3.partition.search.continuous"
+
 }
 
 /**
@@ -47,14 +58,21 @@ object DeprecationConfigDefProcessor {
   * connector configuration, this will fail during connector initialisation advising of the errors and how to update the
   * properties.  This will be removed in a future release.
   */
-class DeprecationConfigDefProcessor extends ConfigDefProcessor with LazyLogging {
+class DeprecationConfigDefProcessor
+    extends ConfigDefProcessor
+    with LazyLogging
+    with CloudSourceSettingsKeys
+    with WithConnectorPrefix {
 
   private val deprecatedProps: Map[String, String] = ListMap(
-    DEP_AUTH_MODE                   -> AUTH_MODE,
-    DEP_AWS_ACCESS_KEY              -> AWS_ACCESS_KEY,
-    DEP_AWS_SECRET_KEY              -> AWS_SECRET_KEY,
-    DEP_ENABLE_VIRTUAL_HOST_BUCKETS -> ENABLE_VIRTUAL_HOST_BUCKETS,
-    DEP_CUSTOM_ENDPOINT             -> CUSTOM_ENDPOINT,
+    DEP_AUTH_MODE                               -> AUTH_MODE,
+    DEP_AWS_ACCESS_KEY                          -> AWS_ACCESS_KEY,
+    DEP_AWS_SECRET_KEY                          -> AWS_SECRET_KEY,
+    DEP_ENABLE_VIRTUAL_HOST_BUCKETS             -> ENABLE_VIRTUAL_HOST_BUCKETS,
+    DEP_CUSTOM_ENDPOINT                         -> CUSTOM_ENDPOINT,
+    DEP_SOURCE_PARTITION_SEARCH_RECURSE_LEVELS  -> SOURCE_PARTITION_SEARCH_RECURSE_LEVELS,
+    DEP_SOURCE_PARTITION_SEARCH_INTERVAL_MILLIS -> SOURCE_PARTITION_SEARCH_INTERVAL_MILLIS,
+    DEP_SOURCE_PARTITION_SEARCH_MODE            -> SOURCE_PARTITION_SEARCH_MODE,
   )
 
   override def process(input: Map[String, Any]): Either[Exception, Map[String, Any]] = {
@@ -75,4 +93,6 @@ class DeprecationConfigDefProcessor extends ConfigDefProcessor with LazyLogging 
       s"The following properties have been deprecated: $keyPrintOut. Please change to using the keys prefixed by `connect.s3`. $detailedInstructions",
     )
   }
+
+  override def connectorPrefix: String = CONNECTOR_PREFIX
 }

--- a/kafka-connect-aws-s3/src/test/scala/io/lenses/streamreactor/connect/aws/s3/config/processors/DeprecationConfigDefProcessorTest.scala
+++ b/kafka-connect-aws-s3/src/test/scala/io/lenses/streamreactor/connect/aws/s3/config/processors/DeprecationConfigDefProcessorTest.scala
@@ -23,9 +23,10 @@ import org.scalatest.matchers.should.Matchers
 class DeprecationConfigDefProcessorTest extends AnyFunSuite with Matchers with EitherValues {
 
   private val okProperties = Map(
-    "connect.s3.aws.access.key" -> "myKey",
-    "aws.s3.someProperty"       -> "value1",
-    "aws.s3.anotherProp"        -> "value2",
+    "connect.s3.aws.access.key"                         -> "myKey",
+    "aws.s3.someProperty"                               -> "value1",
+    "aws.s3.anotherProp"                                -> "value2",
+    "connect.s3.source.partition.search.recurse.levels" -> "1",
   )
 
   test("process should return Right when no deprecated properties are found") {
@@ -38,8 +39,11 @@ class DeprecationConfigDefProcessorTest extends AnyFunSuite with Matchers with E
   test("process should return Left with error message when deprecated properties are found") {
     val processor = new DeprecationConfigDefProcessor()
     val inputConfig = okProperties ++ Map(
-      "aws.access.key"   -> "value1",
-      "aws.vhost.bucket" -> "value2",
+      "aws.access.key"                             -> "value1",
+      "aws.vhost.bucket"                           -> "value2",
+      "connect.s3.partition.search.recurse.levels" -> "value3",
+      "connect.s3.partition.search.interval"       -> "value4",
+      "connect.s3.partition.search.continuous"     -> "value5",
     )
 
     val result       = processor.process(inputConfig)
@@ -47,6 +51,15 @@ class DeprecationConfigDefProcessorTest extends AnyFunSuite with Matchers with E
     errorMessage should include("The following properties have been deprecated:")
     errorMessage should include("Change `aws.access.key` to `connect.s3.aws.access.key`")
     errorMessage should include("Change `aws.vhost.bucket` to `connect.s3.vhost.bucket`")
+    errorMessage should include(
+      "Change `connect.s3.partition.search.recurse.levels` to `connect.s3.source.partition.search.recurse.levels`",
+    )
+    errorMessage should include(
+      "Change `connect.s3.partition.search.interval` to `connect.s3.source.partition.search.interval`",
+    )
+    errorMessage should include(
+      "Change `connect.s3.partition.search.continuous` to `connect.s3.source.partition.search.continuous`",
+    )
   }
 
   test("process should return Right when empty input configuration is provided") {

--- a/kafka-connect-aws-s3/src/test/scala/io/lenses/streamreactor/connect/aws/s3/source/config/S3SourceConfigTest.scala
+++ b/kafka-connect-aws-s3/src/test/scala/io/lenses/streamreactor/connect/aws/s3/source/config/S3SourceConfigTest.scala
@@ -51,7 +51,7 @@ class S3SourceConfigTest extends AnyFunSuite with Matchers with TaskIndexKey wit
            |insert into $topicName1 select * from $BucketName:$prefixName1 STOREAS `AVRO` LIMIT 1000 PROPERTIES ( 'store.envelope' = 'true' );
            |insert into $topicName2 select * from $BucketName:$prefixName2 STOREAS `PARQUET` LIMIT 1000 PROPERTIES ( 'store.envelope' = 'false' );
            |insert into $topicName3 select * from $BucketName:$prefixName3 STOREAS `PARQUET` LIMIT 1000""".stripMargin,
-      "connect.s3.partition.search.recurse.levels" -> "0",
+      "connect.s3.source.partition.search.recurse.levels" -> "0",
     )
 
     S3SourceConfig(S3SourceConfigDefBuilder(props)) match {

--- a/kafka-connect-cloud-common/src/main/scala/io/lenses/streamreactor/connect/cloud/common/source/config/CloudSourceSettingsKeys.scala
+++ b/kafka-connect-cloud-common/src/main/scala/io/lenses/streamreactor/connect/cloud/common/source/config/CloudSourceSettingsKeys.scala
@@ -20,17 +20,17 @@ import org.apache.kafka.common.config.ConfigDef.Importance
 import org.apache.kafka.common.config.ConfigDef.Type
 
 trait CloudSourceSettingsKeys extends WithConnectorPrefix {
-  val SOURCE_PARTITION_SEARCH_RECURSE_LEVELS: String = s"$connectorPrefix.partition.search.recurse.levels"
+  val SOURCE_PARTITION_SEARCH_RECURSE_LEVELS: String = s"$connectorPrefix.source.partition.search.recurse.levels"
   private val SOURCE_PARTITION_SEARCH_RECURSE_LEVELS_DOC: String =
     "When searching for new partitions on the S3 filesystem, how many levels deep to recurse."
   private val SOURCE_PARTITION_SEARCH_RECURSE_LEVELS_DEFAULT: Int = 0
 
-  val SOURCE_PARTITION_SEARCH_INTERVAL_MILLIS: String = s"$connectorPrefix.partition.search.interval"
+  val SOURCE_PARTITION_SEARCH_INTERVAL_MILLIS: String = s"$connectorPrefix.source.partition.search.interval"
   private val SOURCE_PARTITION_SEARCH_INTERVAL_MILLIS_DOC: String =
     "The interval in milliseconds between searching for new partitions.  Defaults to 5 minutes."
   val SOURCE_PARTITION_SEARCH_INTERVAL_MILLIS_DEFAULT: Long = 300000L
 
-  val SOURCE_PARTITION_SEARCH_MODE: String = s"$connectorPrefix.partition.search.continuous"
+  val SOURCE_PARTITION_SEARCH_MODE: String = s"$connectorPrefix.source.partition.search.continuous"
   private val SOURCE_PARTITION_SEARCH_MODE_DOC: String =
     "If set to true, it will be continuously search for new partitions. Otherwise it is a one-off operation. Defaults to true."
 


### PR DESCRIPTION
The following properties are described in the docs:

```
connect.s3.source.partition.search.continuous    
connect.s3.source.partition.search.interval      
connect.s3.source.partition.search.recurse.levels
```

And these follow the convention of the other properties.  However in implementation the properties are:

```
connect.s3.partition.search.continuous    
connect.s3.partition.search.interval      
connect.s3.partition.search.recurse.levels
```


This PR corrects the code to reflect the properties in the docs.  The `DeprecationConfigDefProcessor` will also cause an descriptive error on startup if the old property continues to be used, enabling the user to update their configuration to the correct one.

The error in the logs will look like this:

```
Change `connect.s3.partition.search.continuous` to `connect.s3.source.partition.search.continuous`
```