### PR TITLE
[OPS-2283] CICD: Add AV checks before release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,7 +25,6 @@ jobs:
           if [[ ${GITHUB_REF##*/} =~ ^[0-9]\.[0-9]\.[0-9]$ ]];
           then
               draft_release=false
-          
           elif [[ ${GITHUB_REF##*/} =~ ^[0-9]\.[0-9]\.[0-9]+(-(alpha|beta|rc)(\.[0-9]+)?)?(\+[A-Za-z0-9.]+)?$ ]];
           then
               draft_release=true
@@ -44,11 +43,70 @@ jobs:
       version: ${{ needs.validate-tag.outputs.tag }}
     secrets: inherit
 
+  antivirus-scan-initialization:
+    timeout-minutes: 15
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Install and Update Antivirus Software
+        run: |
+          # Install ClamAV
+          sudo apt-get update
+          sudo apt-get install -y clamav
+          sudo systemctl stop clamav-freshclam
+          sudo freshclam || exit 0
+      - name: Run Antivirus Scan for Source Code
+        run: |
+          clamscan --recursive --alert-broken --alert-encrypted \
+            --alert-encrypted-archive --alert-exceeds-max --detect-pua .
+      - name: Cache Antivirus Database
+        uses: actions/cache/save@v3
+        with:
+          path: /var/lib/clamav
+          key: clamav-database-${{ github.run_id }}
+
+  antivirus-scan:
+    needs:
+      - build
+      - antivirus-scan-initialization
+    timeout-minutes: 30
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        module: ${{fromJSON(needs.initiate.outputs.dep_check_matrix)}}
+    steps:
+      - uses: actions/checkout@v3
+      - name: Restore assembly
+        uses: actions/cache/restore@v3
+        with:
+          path: ~/**/target/libs/*.jar
+          key: assembly-${{ matrix.module }}-${{ github.run_id }}
+          fail-on-cache-miss: true
+      - name: Install Antivirus Software
+        run: |
+          # Install ClamAV and prepare database directory to be restored
+          sudo apt-get update && sudo apt-get install -y clamav
+          sudo systemctl stop clamav-freshclam
+          sudo chmod 777 /var/lib/clamav
+      - name: Restore Antivirus Database
+        uses: actions/cache/restore@v3
+        with:
+          path: /var/lib/clamav
+          key: clamav-database-${{ github.run_id }}
+      - name: Run Antivirus Scan
+        run: |
+          clamscan --recursive --alert-broken --alert-encrypted \
+            --alert-encrypted-archive --alert-exceeds-max \
+            --include-pua=Unix --include-pua=Java \
+            --max-scansize=1000m --max-filesize=500m --max-files=100000 \
+            kafka-connect-${{ matrix.module }}
+
   create-release:
     runs-on: ubuntu-latest
     needs:
       - validate-tag
       - build
+      - antivirus-scan
     strategy:
       # Avoid parallel uploads
       max-parallel: 1


### PR DESCRIPTION
This commit adds antivirus checks via ClamAV on release builds.

The scan runs in two jobs, the first one refreshes the AV database and caches
it, then checks the repo itself for malicious files. Then the second job, runs
in a matrix and scans the build files including their dependencies.
We are being cautious and enable most of ClamAV's features.

Signed-off-by: Stefan Bocutiu <stefan.bocutiu@gmail.com>
Signed-off-by: Marios Andreopoulos <opensource@andmarios.com>