### PR TITLE
LC-187 Avoid adapting the partition fields value

### DIFF
--- a/kafka-connect-cloud-common/src/main/scala/io/lenses/streamreactor/connect/cloud/common/sink/naming/CloudKeyNamer.scala
+++ b/kafka-connect-cloud-common/src/main/scala/io/lenses/streamreactor/connect/cloud/common/sink/naming/CloudKeyNamer.scala
@@ -199,10 +199,7 @@ class CloudKeyNamer(
 
   private def getFieldStringValue(struct: SinkData, partitionName: Option[PartitionNamePath]) =
     adaptErrorResponse(SinkDataExtractor.extractPathFromSinkData(struct)(partitionName)).fold(Option.empty[String])(
-      fieldVal =>
-        Option(fieldVal
-          .replace("/", "-")
-          .replace("\\", "-")),
+      fieldVal => Option(fieldVal),
     )
 
   private def getPartitionValueFromSinkData(sinkData: SinkData, partitionName: PartitionNamePath): String =

--- a/kafka-connect-cloud-common/src/main/scala/io/lenses/streamreactor/connect/cloud/common/sink/naming/CloudKeyNamer.scala
+++ b/kafka-connect-cloud-common/src/main/scala/io/lenses/streamreactor/connect/cloud/common/sink/naming/CloudKeyNamer.scala
@@ -197,10 +197,8 @@ class CloudKeyNamer(
         }
     }
 
-  private def getFieldStringValue(struct: SinkData, partitionName: Option[PartitionNamePath]) =
-    adaptErrorResponse(SinkDataExtractor.extractPathFromSinkData(struct)(partitionName)).fold(Option.empty[String])(
-      fieldVal => Option(fieldVal),
-    )
+  private def getFieldStringValue(struct: SinkData, partitionName: Option[PartitionNamePath]): Option[String] =
+    adaptErrorResponse(SinkDataExtractor.extractPathFromSinkData(struct)(partitionName))
 
   private def getPartitionValueFromSinkData(sinkData: SinkData, partitionName: PartitionNamePath): String =
     getFieldStringValue(sinkData, Option(partitionName)).getOrElse("[missing]")

--- a/kafka-connect-cloud-common/src/test/scala/io/lenses/streamreactor/connect/cloud/common/sink/naming/CloudKeyNamerTest.scala
+++ b/kafka-connect-cloud-common/src/test/scala/io/lenses/streamreactor/connect/cloud/common/sink/naming/CloudKeyNamerTest.scala
@@ -87,13 +87,9 @@ class CloudKeyNamerTest extends AnyFunSuite with Matchers with OptionValues with
       topicPartition.toTopicPartition,
     )
 
-    either match {
-      case Left(_) => fail("Should not have failed")
-      case Right(value) =>
-        value shouldBe Map(HeaderPartitionField(PartitionNamePath("h")) -> "val1/val2")
-    }
-
+    either.value shouldBe Map(HeaderPartitionField(PartitionNamePath("h")) -> "val1/val2")
   }
+
   test("stagingFile should generate the correct staging file path with no prefix") {
     val stagingDirectory = Files.createTempDirectory("myTempDir").toFile
 

--- a/kafka-connect-cloud-common/src/test/scala/io/lenses/streamreactor/connect/cloud/common/sink/naming/CloudKeyNamerTest.scala
+++ b/kafka-connect-cloud-common/src/test/scala/io/lenses/streamreactor/connect/cloud/common/sink/naming/CloudKeyNamerTest.scala
@@ -18,18 +18,19 @@ package io.lenses.streamreactor.connect.cloud.common.sink.naming
 import cats.implicits.none
 import io.lenses.streamreactor.connect.cloud.common.config.FormatSelection
 import io.lenses.streamreactor.connect.cloud.common.config.JsonFormatSelection
+import io.lenses.streamreactor.connect.cloud.common.formats.writer.MessageDetail
+import io.lenses.streamreactor.connect.cloud.common.formats.writer.NullSinkData
+import io.lenses.streamreactor.connect.cloud.common.formats.writer.StringSinkData
 import io.lenses.streamreactor.connect.cloud.common.model.Topic
 import io.lenses.streamreactor.connect.cloud.common.model.location.CloudLocation
 import io.lenses.streamreactor.connect.cloud.common.model.location.CloudLocationValidator
+import io.lenses.streamreactor.connect.cloud.common.sink.SinkError
 import io.lenses.streamreactor.connect.cloud.common.sink.config.PartitionDisplay.Values
 import io.lenses.streamreactor.connect.cloud.common.sink.config.PartitionSelection.defaultPartitionSelection
+import io.lenses.streamreactor.connect.cloud.common.sink.config._
 import io.lenses.streamreactor.connect.cloud.common.sink.config.padding.LeftPadPaddingStrategy
 import io.lenses.streamreactor.connect.cloud.common.sink.config.padding.PaddingService
 import io.lenses.streamreactor.connect.cloud.common.sink.config.padding.PaddingStrategy
-import io.lenses.streamreactor.connect.cloud.common.sink.config.PartitionField
-import io.lenses.streamreactor.connect.cloud.common.sink.config.PartitionPartitionField
-import io.lenses.streamreactor.connect.cloud.common.sink.config.PartitionSelection
-import io.lenses.streamreactor.connect.cloud.common.sink.config.TopicPartitionField
 import io.lenses.streamreactor.connect.cloud.common.utils.SampleData
 import org.mockito.ArgumentMatchers.anyString
 import org.mockito.MockitoSugar
@@ -69,6 +70,30 @@ class CloudKeyNamerTest extends AnyFunSuite with Matchers with OptionValues with
 
   private val s3KeyNamer = CloudKeyNamer(formatSelection, partitionSelection, fileNamer, paddingService)
 
+  test("the partition values do not replace / or \\ characters") {
+    val partitionSelection =
+      PartitionSelection(isCustom = false, List(HeaderPartitionField(PartitionNamePath("h"))), Values)
+    val keyNamer = CloudKeyNamer(formatSelection, partitionSelection, fileNamer, paddingService)
+    val either: Either[SinkError, Map[PartitionField, String]] = keyNamer.processPartitionValues(
+      MessageDetail(
+        NullSinkData(None),
+        NullSinkData(None),
+        Map("h" -> StringSinkData("val1/val2")),
+        None,
+        topicPartition.topic,
+        topicPartition.partition,
+        topicPartition.offset,
+      ),
+      topicPartition.toTopicPartition,
+    )
+
+    either match {
+      case Left(_) => fail("Should not have failed")
+      case Right(value) =>
+        value shouldBe Map(HeaderPartitionField(PartitionNamePath("h")) -> "val1/val2")
+    }
+
+  }
   test("stagingFile should generate the correct staging file path with no prefix") {
     val stagingDirectory = Files.createTempDirectory("myTempDir").toFile
 


### PR DESCRIPTION
At the moment an SMT can control the format of the key. For example it can set it to: yyyy-MM-dd/HH. But the connector replaces the `/` and thus breaks the key.

The change removes the code to replace the value and adds a test for it.