### PR TITLE
java connectors GitHub workflows

### DIFF
--- a/.github/workflows/java-build.yml
+++ b/.github/workflows/java-build.yml
@@ -59,7 +59,7 @@ jobs:
       - name: Test with Gradle
         run: cd 'java-connectors' && ./gradlew ${{ matrix.module }}:test
 
-  build-and-upload-artifact:
+  build-and-cache:
     needs:
       - test
       - initiate
@@ -97,3 +97,39 @@ jobs:
         with:
           path: ./java-connectors/release/${{ matrix.module }}*.jar
           key: assembly-java-${{ github.run_id }}
+
+  jar-dependency-check:
+    needs:
+      - build-and-cache
+      - initiate
+    timeout-minutes: 30
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        module: ${{fromJSON(needs.initiate.outputs.matrix)}}
+    steps:
+      - name: Restore assembly
+        uses: actions/cache/restore@v4
+        with:
+          path: ./java-connectors/release/${{ matrix.module }}*.jar
+          key: assembly-java-${{ github.run_id }}
+          fail-on-cache-miss: true
+
+      - name: Get branch names.
+        id: branch_name
+        uses: tj-actions/branch-names@v8
+      - name: Dependency Check
+        uses: dependency-check/Dependency-Check_Action@1.1.0
+        with:
+          project: kafka-connect-${{matrix.module}}-deps
+          path: ./java-connectors/release/${{ matrix.module }}*.jar
+          format: 'HTML'
+          args: >-
+            --failOnCVSS 5
+            --suppression https://raw.githubusercontent.com/${{ github.event.pull_request.head.repo.owner.login }}/${{github.event.repository.name}}/${{ steps.branch_name.outputs.tag }}${{ steps.branch_name.outputs.current_branch }}/suppression.xml      - name: Upload Test results
+
+      - name: Upload Test results
+        uses: actions/upload-artifact@master
+        with:
+          name: ${{matrix.module}}-depcheck-results
+          path: ${{github.workspace}}/reports

--- a/.github/workflows/java-build.yml
+++ b/.github/workflows/java-build.yml
@@ -20,10 +20,10 @@ jobs:
       matrix: ${{ steps.java-mods.outputs.matrix }}
     steps:
       - uses: actions/checkout@v4
-      - name: Set up JDK 21
+      - name: Set up JDK 17
         uses: actions/setup-java@v4
         with:
-          java-version: '21'
+          java-version: '17'
           distribution: 'temurin'
           cache: 'gradle'
       - name: Generate modules lists
@@ -45,10 +45,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Set up JDK 21
+      - name: Set up JDK 17
         uses: actions/setup-java@v4
         with:
-          java-version: 21
+          java-version: 17
           distribution: 'temurin'
 
       - name: Setup Gradle
@@ -69,10 +69,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Set up JDK 21
+      - name: Set up JDK 17
         uses: actions/setup-java@v4
         with:
-          java-version: 21
+          java-version: 17
           distribution: 'temurin'
           cache: gradle
 

--- a/.github/workflows/java-build.yml
+++ b/.github/workflows/java-build.yml
@@ -1,7 +1,5 @@
 name: CI-java
 on:
-  # remove push
-  push:
   pull_request:
   workflow_call:
     inputs:
@@ -94,11 +92,8 @@ jobs:
           mkdir -p $JAVA_RELEASE_FOLDER
           cp $JAVA_BUILD_FOLDER/${{ matrix.module }}*.jar LICENSE $JAVA_RELEASE_FOLDER/
 
-#      - name: Debug pwd and ls
-#        run: pwd && ls -R java-connectors
-
       - name: Cache assembly
-        uses: actions/cache/save@v3
+        uses: actions/cache/save@v4
         with:
           path: ./java-connectors/release/${{ matrix.module }}*.jar
           key: assembly-java-${{ github.run_id }}

--- a/.github/workflows/java-build.yml
+++ b/.github/workflows/java-build.yml
@@ -127,3 +127,9 @@ jobs:
           args: >-
             --failOnCVSS 5
             --suppression https://raw.githubusercontent.com/${{ github.event.pull_request.head.repo.owner.login }}/${{github.event.repository.name}}/${{ steps.branch_name.outputs.tag }}${{ steps.branch_name.outputs.current_branch }}/suppression.xml
+
+      - name: Upload Test results
+        uses: actions/upload-artifact@master
+        with:
+          name: ${{matrix.module}}-depcheck-results
+          path: ${{github.workspace}}/reports/java

--- a/.github/workflows/java-build.yml
+++ b/.github/workflows/java-build.yml
@@ -118,9 +118,8 @@ jobs:
       - name: Get branch names.
         id: branch_name
         uses: tj-actions/branch-names@v8
-
-      - name: Dependency Check
-        uses: dependency-check/Dependency-Check_Action@1.1.0
+      - name: JAR Dependency Check
+        uses: dependency-check/Dependency-Check_Action@main
         with:
           project: kafka-connect-${{matrix.module}}-deps
           path: ./java-connectors/release/${{ matrix.module }}*.jar
@@ -128,9 +127,3 @@ jobs:
           args: >-
             --failOnCVSS 5
             --suppression https://raw.githubusercontent.com/${{ github.event.pull_request.head.repo.owner.login }}/${{github.event.repository.name}}/${{ steps.branch_name.outputs.tag }}${{ steps.branch_name.outputs.current_branch }}/suppression.xml
-
-      - name: Upload Test results
-        uses: actions/upload-artifact@master
-        with:
-          name: ${{matrix.module}}-depcheck-results
-          path: ${{github.workspace}}/reports

--- a/.github/workflows/java-build.yml
+++ b/.github/workflows/java-build.yml
@@ -118,6 +118,7 @@ jobs:
       - name: Get branch names.
         id: branch_name
         uses: tj-actions/branch-names@v8
+
       - name: Dependency Check
         uses: dependency-check/Dependency-Check_Action@1.1.0
         with:
@@ -126,7 +127,7 @@ jobs:
           format: 'HTML'
           args: >-
             --failOnCVSS 5
-            --suppression https://raw.githubusercontent.com/${{ github.event.pull_request.head.repo.owner.login }}/${{github.event.repository.name}}/${{ steps.branch_name.outputs.tag }}${{ steps.branch_name.outputs.current_branch }}/suppression.xml      - name: Upload Test results
+            --suppression https://raw.githubusercontent.com/${{ github.event.pull_request.head.repo.owner.login }}/${{github.event.repository.name}}/${{ steps.branch_name.outputs.tag }}${{ steps.branch_name.outputs.current_branch }}/suppression.xml
 
       - name: Upload Test results
         uses: actions/upload-artifact@master

--- a/.github/workflows/java-build.yml
+++ b/.github/workflows/java-build.yml
@@ -1,0 +1,104 @@
+name: CI-java
+on:
+  # remove push
+  push:
+  pull_request:
+  workflow_call:
+    inputs:
+      version:
+        required: true
+        type: string
+    outputs:
+      modules:
+        description: "Stream reactor collection of modules"
+        value: ${{ jobs.initiate.outputs.matrix }}
+
+jobs:
+
+  initiate:
+    timeout-minutes: 5
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.java-mods.outputs.matrix }}
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up JDK 21
+        uses: actions/setup-java@v4
+        with:
+          java-version: '21'
+          distribution: 'temurin'
+          cache: 'gradle'
+      - name: Generate modules lists
+        run: cd 'java-connectors' && ./gradlew releaseModuleList
+        env:
+          JVM_OPTS: -Xmx512m
+      - name: Read java modules lists
+        id: java-mods
+        run: |
+          echo "::set-output name=matrix::$(cat ./java-connectors/gradle-modules.txt)"
+
+  test:
+    needs:
+      - initiate
+    strategy:
+      matrix:
+        module: ${{fromJSON(needs.initiate.outputs.matrix)}}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@v4
+        with:
+          java-version: 21
+          distribution: 'temurin'
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v3
+        with:
+          gradle-version: 8.6
+
+      - name: Test with Gradle
+        run: cd 'java-connectors' && ./gradlew ${{ matrix.module }}:test
+
+  build-and-upload-artifact:
+    needs:
+      - test
+      - initiate
+    strategy:
+      matrix:
+        module: ${{fromJSON(needs.initiate.outputs.matrix)}}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up JDK 21
+        uses: actions/setup-java@v4
+        with:
+          java-version: 21
+          distribution: 'temurin'
+          cache: gradle
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v3
+        with:
+          gradle-version: 8.6
+
+      - name: Execute Gradle build
+        run: cd 'java-connectors' && ./gradlew ${{ matrix.module }}:shadowJar --scan
+
+      - name: Move to release folder
+        shell: bash
+        run: |
+          JAVA_RELEASE_FOLDER=java-connectors/release
+          JAVA_BUILD_FOLDER=java-connectors/${{ matrix.module }}/build/libs
+          mkdir -p $JAVA_RELEASE_FOLDER
+          cp $JAVA_BUILD_FOLDER/${{ matrix.module }}*.jar LICENSE $JAVA_RELEASE_FOLDER/
+
+#      - name: Debug pwd and ls
+#        run: pwd && ls -R java-connectors
+
+      - name: Cache assembly
+        uses: actions/cache/save@v3
+        with:
+          path: ./java-connectors/release/${{ matrix.module }}*.jar
+          key: assembly-java-${{ github.run_id }}

--- a/.github/workflows/java-release.yml
+++ b/.github/workflows/java-release.yml
@@ -1,0 +1,95 @@
+name: Publish New Java Release
+on:
+  push:
+    tags:
+      - "*"
+  workflow_dispatch:
+
+jobs:
+  validate-tag:
+    runs-on: ubuntu-latest
+    outputs:
+      draft_release: ${{ steps.get_tag.outputs.draft_release }}
+      tag: ${{ steps.get_tag.outputs.tag }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Get tag, release mode
+        shell: bash
+        id: get_tag
+        run: |
+          if [[ ${GITHUB_REF##*/} =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]];
+          then
+              draft_release=false
+          elif [[ ${GITHUB_REF##*/} =~ ^[0-9]+\.[0-9]+\.[0-9]+(-(alpha|beta|rc)(\.[0-9]+)?)?(\+[A-Za-z0-9.]+)?$ ]];
+          then
+              draft_release=true
+          else
+              echo "Exiting, github ref needs to be a tag with format x.y.z or x.y.z-(alpha|beta|rc)"
+              exit 1
+          fi
+          echo "draft_release=$draft_release" >> $GITHUB_OUTPUT
+          echo "tag=${GITHUB_REF##*/}" >> $GITHUB_OUTPUT
+
+  build:
+    needs:
+      - validate-tag
+    uses: ./.github/workflows/java-build.yml
+    with:
+      version: ${{ needs.validate-tag.outputs.tag }}
+    secrets: inherit
+
+  create-release:
+    runs-on: ubuntu-latest
+    needs:
+      - validate-tag
+      - build
+    strategy:
+      # Avoid parallel uploads
+      max-parallel: 1
+      # GitHub will NOT cancel all in-progress and queued jobs in the matrix if any job in the matrix fails, which could create inconsistencies.
+      # If any matrix job fails, the job will be marked as failure
+      fail-fast: false
+      matrix:
+        module: ${{fromJSON(needs.build.outputs.modules)}}
+    env:
+      DRAFT_RELEASE: '${{ needs.validate-tag.outputs.draft_release }}'
+      TAG: ${{ needs.validate-tag.outputs.tag }}
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: Set up JDK 21
+        uses: actions/setup-java@v4
+        with:
+          java-version: '21'
+          distribution: 'temurin'
+          cache: 'gradle'
+
+      - name: Uncache assembly
+        uses: actions/cache/restore@v4
+        with:
+          path: |
+            ./java-connectors/release/${{ matrix.module }}*.jar
+          key: assembly-java-${{ github.run_id }}
+          fail-on-cache-miss: true
+
+      - name: Package Connector
+        shell: bash
+        run: |
+          JAVA_RELEASE_FOLDER=java-connectors/release
+          FOLDER=${{ matrix.module }}-${{ env.TAG }}
+          mkdir -p $FOLDER
+          cp $JAVA_RELEASE_FOLDER/${{ matrix.module }}*.jar LICENSE $FOLDER/
+          zip -r "$FOLDER.zip" $FOLDER/
+
+      - name: Upload binaries to release
+        uses: svenstaro/upload-release-action@v2
+        with:
+          file: ${{ matrix.module }}-${{ env.TAG }}.zip
+          asset_name: "${{ matrix.module }}-${{ env.TAG }}.zip"
+          release_name: 'Stream Reactor ${{ env.TAG }}'
+          prerelease: ${{ env.DRAFT_RELEASE }}

--- a/.github/workflows/java-release.yml
+++ b/.github/workflows/java-release.yml
@@ -62,10 +62,10 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
-      - name: Set up JDK 21
+      - name: Set up JDK 17
         uses: actions/setup-java@v4
         with:
-          java-version: '21'
+          java-version: '17'
           distribution: 'temurin'
           cache: 'gradle'
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,14 +22,14 @@ jobs:
         shell: bash
         id: get_tag
         run: |
-          if [[ ${GITHUB_REF##*/} =~ ^[0-9]\.[0-9]\.[0-9]$ ]];
+          if [[ ${GITHUB_REF##*/} =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]];
           then
               draft_release=false
-          elif [[ ${GITHUB_REF##*/} =~ ^[0-9]\.[0-9]\.[0-9]+(-(alpha|beta|rc)(\.[0-9]+)?)?(\+[A-Za-z0-9.]+)?$ ]];
+          elif [[ ${GITHUB_REF##*/} =~ ^[0-9]+\.[0-9]+\.[0-9]+(-(alpha|beta|rc)(\.[0-9]+)?)?(\+[A-Za-z0-9.]+)?$ ]];
           then
               draft_release=true
           else
-              echo "Exiting, github ref needs to be a tag with format x.y.z or x.y.z+(alpha|beta|rc)"
+              echo "Exiting, github ref needs to be a tag with format x.y.z or x.y.z-(alpha|beta|rc)"
               exit 1
           fi
           echo "draft_release=$draft_release" >> $GITHUB_OUTPUT

--- a/java-connectors/.gitignore
+++ b/java-connectors/.gitignore
@@ -44,3 +44,4 @@ bin/
 
 ### Lenses-specific ###
 release/
+gradle-modules.txt

--- a/java-connectors/build.gradle
+++ b/java-connectors/build.gradle
@@ -29,17 +29,17 @@ allprojects {
         awaitilityVersion = '4.2.0'
         apacheToConfluentVersionAxis = ["2.8.1": "6.2.2", "3.3.0": "7.3.1"]
 
-        //for jar building
-        rootRelease = "${project.rootDir}/release/"
-        versionDir = "${rootRelease}/${project.description}-${project.version}"
-        confDir = "${versionDir}/conf"
-        libsDir = "${versionDir}/libs"
-
         //Other Manifest Info
         mainClassName = ''
         gitCommitHash = ("git rev-parse HEAD").execute().text.trim()
         gitTag = ("git describe --abbrev=0 --tags").execute().text.trim()
         gitRepo = ("git remote get-url origin").execute().text.trim()
+
+        //for jar building
+        rootRelease = "${project.rootDir}/release/"
+        versionDir = "${rootRelease}/${project.description}-${project.version}"
+        confDir = "${versionDir}/conf"
+        libsDir = "${versionDir}/libs"
     }
 
     repositories {
@@ -138,4 +138,19 @@ allprojects {
 
 task prepareRelease(dependsOn: [collectFatJar]) {
     dependsOn subprojects.collectFatJar
+}
+
+task releaseModuleList() {
+    def nonReleaseModules = ["java-reactor", "kafka-connect-cloud-common", "kafka-connect-common"]
+
+    def modulesFile = new File("gradle-modules.txt")
+    modulesFile.delete()
+    modulesFile.createNewFile()
+
+    def modulesBuilder = new StringBuilder("[")
+    allprojects.name.stream()
+            .filter {moduleName -> !nonReleaseModules.contains(moduleName)}
+            .forEach {moduleName -> modulesBuilder.append("\"" + moduleName + "\",") }
+    modulesBuilder.deleteCharAt(modulesBuilder.lastIndexOf(",")).append("]")
+    modulesFile.append(modulesBuilder)
 }

--- a/java-connectors/build.gradle
+++ b/java-connectors/build.gradle
@@ -7,7 +7,7 @@ plugins {
 allprojects {
 
     group = "io.lenses.streamreactor"
-    version = "1.0-SNAPSHOT"
+    version = "6.4.0-SNAPSHOT"
     description = "stream-reactor"
 
     apply plugin: 'java'

--- a/java-connectors/build.gradle
+++ b/java-connectors/build.gradle
@@ -141,7 +141,8 @@ task prepareRelease(dependsOn: [collectFatJar]) {
 }
 
 task releaseModuleList() {
-    def nonReleaseModules = ["java-reactor", "kafka-connect-cloud-common", "kafka-connect-common"]
+    def nonReleaseModules = ["java-reactor", "kafka-connect-cloud-common",
+                             "kafka-connect-common", "kafka-connect-query-language"]
 
     def modulesFile = new File("gradle-modules.txt")
     modulesFile.delete()


### PR DESCRIPTION
#### Description

Those changes to `Gradle` build and new scripts to GitHub Actions should allow `sbt` and `Gradle` builds to work simultaneously in order to allow for both java and scala connectors to be released alongside. This should also provide the base for further modules to be build by java and used by Scala.

#### Testing
Below testing was done:

- [x] Tests of Gradle build script changes locally
- [x] Github actions tests on my fork ( https://github.com/GoMati-MU/stream-reactor )