### PR TITLE
Feat/java license headers

### DIFF
--- a/java-connectors/build.gradle
+++ b/java-connectors/build.gradle
@@ -1,5 +1,6 @@
 plugins {
     id 'com.github.johnrengelman.shadow' version '8.1.1'
+    id 'org.cadixdev.licenser' version '0.6.1'
     id 'java'
     id 'java-library'
 }
@@ -13,6 +14,7 @@ allprojects {
     apply plugin: 'java'
     apply plugin: 'java-library'
     apply plugin: 'com.github.johnrengelman.shadow'
+    apply plugin: 'org.cadixdev.licenser'
 
     java {
         setSourceCompatibility(JavaVersion.VERSION_11)
@@ -71,6 +73,21 @@ allprojects {
         }
     }
 
+    license {
+        include("**/**.java", "**/**Test.java")
+        header = project.file("${project.rootDir}/HEADER.txt")
+        newLine = false
+
+        style {
+            java = 'BLOCK_COMMENT'
+        }
+
+        properties {
+            name = 'Lenses.io'
+            year = LocalDate.now().year
+        }
+    }
+
     jar {
         manifest {
             attributes("StreamReactor-Version": project.version,
@@ -126,6 +143,7 @@ allprojects {
         }
 
     }
+    compileJava.dependsOn("updateLicenses")
 
     task fatJar(dependsOn: [test, jar, shadowJar])
 

--- a/java-connectors/kafka-connect-azure-eventhubs/src/main/java/io/lenses/streamreactor/connect/azure/eventhubs/config/AzureEventHubsConfigConstants.java
+++ b/java-connectors/kafka-connect-azure-eventhubs/src/main/java/io/lenses/streamreactor/connect/azure/eventhubs/config/AzureEventHubsConfigConstants.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2017-2024 Lenses.io Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.lenses.streamreactor.connect.azure.eventhubs.config;
 
 import io.lenses.streamreactor.connect.azure.eventhubs.source.AzureEventHubsSourceConnector;

--- a/java-connectors/kafka-connect-azure-eventhubs/src/main/java/io/lenses/streamreactor/connect/azure/eventhubs/config/AzureEventHubsSourceConfig.java
+++ b/java-connectors/kafka-connect-azure-eventhubs/src/main/java/io/lenses/streamreactor/connect/azure/eventhubs/config/AzureEventHubsSourceConfig.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2017-2024 Lenses.io Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.lenses.streamreactor.connect.azure.eventhubs.config;
 
 import io.lenses.streamreactor.common.config.base.BaseConfig;

--- a/java-connectors/kafka-connect-azure-eventhubs/src/main/java/io/lenses/streamreactor/connect/azure/eventhubs/config/SourceDataType.java
+++ b/java-connectors/kafka-connect-azure-eventhubs/src/main/java/io/lenses/streamreactor/connect/azure/eventhubs/config/SourceDataType.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2017-2024 Lenses.io Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.lenses.streamreactor.connect.azure.eventhubs.config;
 
 import java.util.Arrays;

--- a/java-connectors/kafka-connect-azure-eventhubs/src/main/java/io/lenses/streamreactor/connect/azure/eventhubs/mapping/SourceRecordMapper.java
+++ b/java-connectors/kafka-connect-azure-eventhubs/src/main/java/io/lenses/streamreactor/connect/azure/eventhubs/mapping/SourceRecordMapper.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2017-2024 Lenses.io Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.lenses.streamreactor.connect.azure.eventhubs.mapping;
 
 import java.util.Map;

--- a/java-connectors/kafka-connect-azure-eventhubs/src/main/java/io/lenses/streamreactor/connect/azure/eventhubs/source/AzureConsumerRebalancerListener.java
+++ b/java-connectors/kafka-connect-azure-eventhubs/src/main/java/io/lenses/streamreactor/connect/azure/eventhubs/source/AzureConsumerRebalancerListener.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2017-2024 Lenses.io Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.lenses.streamreactor.connect.azure.eventhubs.source;
 
 import io.lenses.streamreactor.connect.azure.eventhubs.source.TopicPartitionOffsetProvider.AzureOffsetMarker;

--- a/java-connectors/kafka-connect-azure-eventhubs/src/main/java/io/lenses/streamreactor/connect/azure/eventhubs/source/AzureEventHubsSourceConnector.java
+++ b/java-connectors/kafka-connect-azure-eventhubs/src/main/java/io/lenses/streamreactor/connect/azure/eventhubs/source/AzureEventHubsSourceConnector.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2017-2024 Lenses.io Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.lenses.streamreactor.connect.azure.eventhubs.source;
 
 import static io.lenses.streamreactor.common.util.AsciiArtPrinter.printAsciiHeader;

--- a/java-connectors/kafka-connect-azure-eventhubs/src/main/java/io/lenses/streamreactor/connect/azure/eventhubs/source/AzureEventHubsSourceTask.java
+++ b/java-connectors/kafka-connect-azure-eventhubs/src/main/java/io/lenses/streamreactor/connect/azure/eventhubs/source/AzureEventHubsSourceTask.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2017-2024 Lenses.io Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.lenses.streamreactor.connect.azure.eventhubs.source;
 
 import static java.util.Optional.ofNullable;

--- a/java-connectors/kafka-connect-azure-eventhubs/src/main/java/io/lenses/streamreactor/connect/azure/eventhubs/source/BlockingQueueProducer.java
+++ b/java-connectors/kafka-connect-azure-eventhubs/src/main/java/io/lenses/streamreactor/connect/azure/eventhubs/source/BlockingQueueProducer.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2017-2024 Lenses.io Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.lenses.streamreactor.connect.azure.eventhubs.source;
 
 import java.time.Duration;

--- a/java-connectors/kafka-connect-azure-eventhubs/src/main/java/io/lenses/streamreactor/connect/azure/eventhubs/source/BlockingQueueProducerProvider.java
+++ b/java-connectors/kafka-connect-azure-eventhubs/src/main/java/io/lenses/streamreactor/connect/azure/eventhubs/source/BlockingQueueProducerProvider.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2017-2024 Lenses.io Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.lenses.streamreactor.connect.azure.eventhubs.source;
 
 import io.lenses.streamreactor.connect.azure.eventhubs.config.AzureEventHubsConfigConstants;

--- a/java-connectors/kafka-connect-azure-eventhubs/src/main/java/io/lenses/streamreactor/connect/azure/eventhubs/source/EventHubsKafkaConsumerController.java
+++ b/java-connectors/kafka-connect-azure-eventhubs/src/main/java/io/lenses/streamreactor/connect/azure/eventhubs/source/EventHubsKafkaConsumerController.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2017-2024 Lenses.io Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.lenses.streamreactor.connect.azure.eventhubs.source;
 
 import static io.lenses.streamreactor.connect.azure.eventhubs.mapping.SourceRecordMapper.mapSourceRecordIncludingHeaders;

--- a/java-connectors/kafka-connect-azure-eventhubs/src/main/java/io/lenses/streamreactor/connect/azure/eventhubs/source/KafkaByteBlockingQueuedProducer.java
+++ b/java-connectors/kafka-connect-azure-eventhubs/src/main/java/io/lenses/streamreactor/connect/azure/eventhubs/source/KafkaByteBlockingQueuedProducer.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2017-2024 Lenses.io Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.lenses.streamreactor.connect.azure.eventhubs.source;
 
 import io.lenses.streamreactor.connect.azure.eventhubs.config.SourceDataType.KeyValueTypes;

--- a/java-connectors/kafka-connect-azure-eventhubs/src/main/java/io/lenses/streamreactor/connect/azure/eventhubs/source/ProducerProvider.java
+++ b/java-connectors/kafka-connect-azure-eventhubs/src/main/java/io/lenses/streamreactor/connect/azure/eventhubs/source/ProducerProvider.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2017-2024 Lenses.io Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.lenses.streamreactor.connect.azure.eventhubs.source;
 
 import io.lenses.streamreactor.connect.azure.eventhubs.config.AzureEventHubsSourceConfig;

--- a/java-connectors/kafka-connect-azure-eventhubs/src/main/java/io/lenses/streamreactor/connect/azure/eventhubs/source/TopicPartitionOffsetProvider.java
+++ b/java-connectors/kafka-connect-azure-eventhubs/src/main/java/io/lenses/streamreactor/connect/azure/eventhubs/source/TopicPartitionOffsetProvider.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2017-2024 Lenses.io Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.lenses.streamreactor.connect.azure.eventhubs.source;
 
 import java.util.HashMap;

--- a/java-connectors/kafka-connect-azure-eventhubs/src/main/java/io/lenses/streamreactor/connect/azure/eventhubs/util/KcqlConfigPort.java
+++ b/java-connectors/kafka-connect-azure-eventhubs/src/main/java/io/lenses/streamreactor/connect/azure/eventhubs/util/KcqlConfigPort.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2017-2024 Lenses.io Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.lenses.streamreactor.connect.azure.eventhubs.util;
 
 import io.lenses.kcql.Kcql;

--- a/java-connectors/kafka-connect-azure-eventhubs/src/test/java/io/lenses/streamreactor/connect/azure/eventhubs/config/SourceDataTypeTest.java
+++ b/java-connectors/kafka-connect-azure-eventhubs/src/test/java/io/lenses/streamreactor/connect/azure/eventhubs/config/SourceDataTypeTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2017-2024 Lenses.io Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.lenses.streamreactor.connect.azure.eventhubs.config;
 
 import static org.apache.kafka.connect.data.Schema.OPTIONAL_BYTES_SCHEMA;

--- a/java-connectors/kafka-connect-azure-eventhubs/src/test/java/io/lenses/streamreactor/connect/azure/eventhubs/mapping/SourceRecordMapperTest.java
+++ b/java-connectors/kafka-connect-azure-eventhubs/src/test/java/io/lenses/streamreactor/connect/azure/eventhubs/mapping/SourceRecordMapperTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2017-2024 Lenses.io Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.lenses.streamreactor.connect.azure.eventhubs.mapping;
 
 import static java.util.Collections.singletonList;

--- a/java-connectors/kafka-connect-azure-eventhubs/src/test/java/io/lenses/streamreactor/connect/azure/eventhubs/source/AzureConsumerRebalancerListenerTest.java
+++ b/java-connectors/kafka-connect-azure-eventhubs/src/test/java/io/lenses/streamreactor/connect/azure/eventhubs/source/AzureConsumerRebalancerListenerTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2017-2024 Lenses.io Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.lenses.streamreactor.connect.azure.eventhubs.source;
 
 import static org.mockito.ArgumentMatchers.any;

--- a/java-connectors/kafka-connect-azure-eventhubs/src/test/java/io/lenses/streamreactor/connect/azure/eventhubs/source/AzureEventHubsSourceConnectorTest.java
+++ b/java-connectors/kafka-connect-azure-eventhubs/src/test/java/io/lenses/streamreactor/connect/azure/eventhubs/source/AzureEventHubsSourceConnectorTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2017-2024 Lenses.io Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.lenses.streamreactor.connect.azure.eventhubs.source;
 
 import static org.apache.kafka.connect.source.ExactlyOnceSupport.SUPPORTED;

--- a/java-connectors/kafka-connect-azure-eventhubs/src/test/java/io/lenses/streamreactor/connect/azure/eventhubs/source/AzureEventHubsSourceTaskTest.java
+++ b/java-connectors/kafka-connect-azure-eventhubs/src/test/java/io/lenses/streamreactor/connect/azure/eventhubs/source/AzureEventHubsSourceTaskTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2017-2024 Lenses.io Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.lenses.streamreactor.connect.azure.eventhubs.source;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;

--- a/java-connectors/kafka-connect-azure-eventhubs/src/test/java/io/lenses/streamreactor/connect/azure/eventhubs/source/BlockingQueueProducerProviderTest.java
+++ b/java-connectors/kafka-connect-azure-eventhubs/src/test/java/io/lenses/streamreactor/connect/azure/eventhubs/source/BlockingQueueProducerProviderTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2017-2024 Lenses.io Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.lenses.streamreactor.connect.azure.eventhubs.source;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;

--- a/java-connectors/kafka-connect-azure-eventhubs/src/test/java/io/lenses/streamreactor/connect/azure/eventhubs/source/EventHubsKafkaConsumerControllerTest.java
+++ b/java-connectors/kafka-connect-azure-eventhubs/src/test/java/io/lenses/streamreactor/connect/azure/eventhubs/source/EventHubsKafkaConsumerControllerTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2017-2024 Lenses.io Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.lenses.streamreactor.connect.azure.eventhubs.source;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;

--- a/java-connectors/kafka-connect-azure-eventhubs/src/test/java/io/lenses/streamreactor/connect/azure/eventhubs/source/KafkaByteBlockingQueuedProducerTest.java
+++ b/java-connectors/kafka-connect-azure-eventhubs/src/test/java/io/lenses/streamreactor/connect/azure/eventhubs/source/KafkaByteBlockingQueuedProducerTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2017-2024 Lenses.io Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.lenses.streamreactor.connect.azure.eventhubs.source;
 
 import static org.mockito.ArgumentMatchers.eq;

--- a/java-connectors/kafka-connect-azure-eventhubs/src/test/java/io/lenses/streamreactor/connect/azure/eventhubs/source/TopicPartitionOffsetProviderTest.java
+++ b/java-connectors/kafka-connect-azure-eventhubs/src/test/java/io/lenses/streamreactor/connect/azure/eventhubs/source/TopicPartitionOffsetProviderTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2017-2024 Lenses.io Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.lenses.streamreactor.connect.azure.eventhubs.source;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;

--- a/java-connectors/kafka-connect-azure-eventhubs/src/test/java/io/lenses/streamreactor/connect/azure/eventhubs/util/KcqlConfigPortTest.java
+++ b/java-connectors/kafka-connect-azure-eventhubs/src/test/java/io/lenses/streamreactor/connect/azure/eventhubs/util/KcqlConfigPortTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2017-2024 Lenses.io Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.lenses.streamreactor.connect.azure.eventhubs.util;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;

--- a/java-connectors/kafka-connect-cloud-common/src/main/java/io/lenses/java/streamreactor/Main.java
+++ b/java-connectors/kafka-connect-cloud-common/src/main/java/io/lenses/java/streamreactor/Main.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2017-2024 Lenses.io Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.lenses.java.streamreactor;
 
 public class Main {

--- a/java-connectors/kafka-connect-common/src/main/java/io/lenses/streamreactor/common/config/base/BaseConfig.java
+++ b/java-connectors/kafka-connect-common/src/main/java/io/lenses/streamreactor/common/config/base/BaseConfig.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2017-2024 Lenses.io Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.lenses.streamreactor.common.config.base;
 
 import java.util.Map;

--- a/java-connectors/kafka-connect-common/src/main/java/io/lenses/streamreactor/common/config/base/constants/TraitConfigConst.java
+++ b/java-connectors/kafka-connect-common/src/main/java/io/lenses/streamreactor/common/config/base/constants/TraitConfigConst.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2017-2024 Lenses.io Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.lenses.streamreactor.common.config.base.constants;
 
 public class TraitConfigConst {

--- a/java-connectors/kafka-connect-common/src/main/java/io/lenses/streamreactor/common/config/base/intf/BaseSettings.java
+++ b/java-connectors/kafka-connect-common/src/main/java/io/lenses/streamreactor/common/config/base/intf/BaseSettings.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2017-2024 Lenses.io Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.lenses.streamreactor.common.config.base.intf;
 
 import java.util.List;

--- a/java-connectors/kafka-connect-common/src/main/java/io/lenses/streamreactor/common/config/base/intf/ConnectorPrefixed.java
+++ b/java-connectors/kafka-connect-common/src/main/java/io/lenses/streamreactor/common/config/base/intf/ConnectorPrefixed.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2017-2024 Lenses.io Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.lenses.streamreactor.common.config.base.intf;
 
 /**

--- a/java-connectors/kafka-connect-common/src/main/java/io/lenses/streamreactor/common/config/base/intf/DatabaseSettings.java
+++ b/java-connectors/kafka-connect-common/src/main/java/io/lenses/streamreactor/common/config/base/intf/DatabaseSettings.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2017-2024 Lenses.io Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.lenses.streamreactor.common.config.base.intf;
 
 import io.lenses.streamreactor.common.config.base.constants.TraitConfigConst;

--- a/java-connectors/kafka-connect-common/src/main/java/io/lenses/streamreactor/common/config/base/intf/ErrorPolicySettings.java
+++ b/java-connectors/kafka-connect-common/src/main/java/io/lenses/streamreactor/common/config/base/intf/ErrorPolicySettings.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2017-2024 Lenses.io Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.lenses.streamreactor.common.config.base.intf;
 
 import io.lenses.streamreactor.common.errors.ErrorPolicy;

--- a/java-connectors/kafka-connect-common/src/main/java/io/lenses/streamreactor/common/config/base/intf/KcqlSettings.java
+++ b/java-connectors/kafka-connect-common/src/main/java/io/lenses/streamreactor/common/config/base/intf/KcqlSettings.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2017-2024 Lenses.io Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.lenses.streamreactor.common.config.base.intf;
 
 import io.lenses.streamreactor.common.config.base.constants.TraitConfigConst;

--- a/java-connectors/kafka-connect-common/src/main/java/io/lenses/streamreactor/common/config/base/intf/NumberRetriesSettings.java
+++ b/java-connectors/kafka-connect-common/src/main/java/io/lenses/streamreactor/common/config/base/intf/NumberRetriesSettings.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2017-2024 Lenses.io Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.lenses.streamreactor.common.config.base.intf;
 
 import io.lenses.streamreactor.common.config.base.constants.TraitConfigConst;

--- a/java-connectors/kafka-connect-common/src/main/java/io/lenses/streamreactor/common/config/base/intf/UserSettings.java
+++ b/java-connectors/kafka-connect-common/src/main/java/io/lenses/streamreactor/common/config/base/intf/UserSettings.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2017-2024 Lenses.io Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.lenses.streamreactor.common.config.base.intf;
 
 import io.lenses.streamreactor.common.config.base.constants.TraitConfigConst;

--- a/java-connectors/kafka-connect-common/src/main/java/io/lenses/streamreactor/common/errors/ErrorPolicy.java
+++ b/java-connectors/kafka-connect-common/src/main/java/io/lenses/streamreactor/common/errors/ErrorPolicy.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2017-2024 Lenses.io Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.lenses.streamreactor.common.errors;
 
 public interface ErrorPolicy {

--- a/java-connectors/kafka-connect-common/src/main/java/io/lenses/streamreactor/common/errors/ErrorPolicyEnum.java
+++ b/java-connectors/kafka-connect-common/src/main/java/io/lenses/streamreactor/common/errors/ErrorPolicyEnum.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2017-2024 Lenses.io Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.lenses.streamreactor.common.errors;
 
 import static java.util.Optional.ofNullable;

--- a/java-connectors/kafka-connect-common/src/main/java/io/lenses/streamreactor/common/errors/NoopErrorPolicy.java
+++ b/java-connectors/kafka-connect-common/src/main/java/io/lenses/streamreactor/common/errors/NoopErrorPolicy.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2017-2024 Lenses.io Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.lenses.streamreactor.common.errors;
 
 import lombok.extern.slf4j.Slf4j;

--- a/java-connectors/kafka-connect-common/src/main/java/io/lenses/streamreactor/common/errors/RetryErrorPolicy.java
+++ b/java-connectors/kafka-connect-common/src/main/java/io/lenses/streamreactor/common/errors/RetryErrorPolicy.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2017-2024 Lenses.io Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.lenses.streamreactor.common.errors;
 
 import lombok.extern.slf4j.Slf4j;

--- a/java-connectors/kafka-connect-common/src/main/java/io/lenses/streamreactor/common/errors/ThrowErrorPolicy.java
+++ b/java-connectors/kafka-connect-common/src/main/java/io/lenses/streamreactor/common/errors/ThrowErrorPolicy.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2017-2024 Lenses.io Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.lenses.streamreactor.common.errors;
 
 import lombok.extern.slf4j.Slf4j;

--- a/java-connectors/kafka-connect-common/src/main/java/io/lenses/streamreactor/common/util/AsciiArtPrinter.java
+++ b/java-connectors/kafka-connect-common/src/main/java/io/lenses/streamreactor/common/util/AsciiArtPrinter.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2017-2024 Lenses.io Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.lenses.streamreactor.common.util;
 
 import static java.util.Optional.ofNullable;

--- a/java-connectors/kafka-connect-common/src/main/java/io/lenses/streamreactor/common/util/InputStreamHandler.java
+++ b/java-connectors/kafka-connect-common/src/main/java/io/lenses/streamreactor/common/util/InputStreamHandler.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2017-2024 Lenses.io Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.lenses.streamreactor.common.util;
 
 import java.io.IOException;

--- a/java-connectors/kafka-connect-common/src/main/java/io/lenses/streamreactor/common/util/JarManifest.java
+++ b/java-connectors/kafka-connect-common/src/main/java/io/lenses/streamreactor/common/util/JarManifest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2017-2024 Lenses.io Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.lenses.streamreactor.common.util;
 
 import static io.lenses.streamreactor.common.util.JarManifest.ManifestAttributes.GIT_HASH;

--- a/java-connectors/kafka-connect-common/src/main/java/io/lenses/streamreactor/common/util/ProgressCounter.java
+++ b/java-connectors/kafka-connect-common/src/main/java/io/lenses/streamreactor/common/util/ProgressCounter.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2017-2024 Lenses.io Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.lenses.streamreactor.common.util;
 
 import java.text.SimpleDateFormat;

--- a/java-connectors/kafka-connect-common/src/main/java/io/lenses/streamreactor/common/util/StringUtils.java
+++ b/java-connectors/kafka-connect-common/src/main/java/io/lenses/streamreactor/common/util/StringUtils.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2017-2024 Lenses.io Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.lenses.streamreactor.common.util;
 
 /**

--- a/java-connectors/kafka-connect-common/src/test/java/io/lenses/streamreactor/common/util/JarManifestTest.java
+++ b/java-connectors/kafka-connect-common/src/test/java/io/lenses/streamreactor/common/util/JarManifestTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2017-2024 Lenses.io Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.lenses.streamreactor.common.util;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;

--- a/java-connectors/kafka-connect-query-language/build.gradle
+++ b/java-connectors/kafka-connect-query-language/build.gradle
@@ -49,7 +49,8 @@ project(":kafka-connect-query-language") {
         archives javadocJar, sourcesJar
     }
 
-    compileJava.dependsOn generateGrammarSource
+    //order should be: generateGrammarSource -> updateLicenseMain -> compileJava
+    updateLicenseMain.dependsOn("generateGrammarSource")
 
     task compile(dependsOn: 'compileJava')
     task fatJarNoTest(dependsOn: 'shadowJar')


### PR DESCRIPTION
#### Description

This is to add Apache 2.0 license headers to source files and add plugin that will automatically add them during build.

#### Testing
Testing internally for the command line Gradle build command.