### PR TITLE
LC-187 Avoid adapting the partition fields value (#1137)

### DIFF
--- a/kafka-connect-cloud-common/src/main/scala/io/lenses/streamreactor/connect/cloud/common/sink/naming/CloudKeyNamer.scala
+++ b/kafka-connect-cloud-common/src/main/scala/io/lenses/streamreactor/connect/cloud/common/sink/naming/CloudKeyNamer.scala
@@ -197,13 +197,8 @@ class CloudKeyNamer(
         }
     }
 
-  private def getFieldStringValue(struct: SinkData, partitionName: Option[PartitionNamePath]) =
-    adaptErrorResponse(SinkDataExtractor.extractPathFromSinkData(struct)(partitionName)).fold(Option.empty[String])(
-      fieldVal =>
-        Option(fieldVal
-          .replace("/", "-")
-          .replace("\\", "-")),
-    )
+  private def getFieldStringValue(struct: SinkData, partitionName: Option[PartitionNamePath]): Option[String] =
+    adaptErrorResponse(SinkDataExtractor.extractPathFromSinkData(struct)(partitionName))
 
   private def getPartitionValueFromSinkData(sinkData: SinkData, partitionName: PartitionNamePath): String =
     getFieldStringValue(sinkData, Option(partitionName)).getOrElse("[missing]")


### PR DESCRIPTION
* LC-187 Avoid adapting the partition fields value

At the moment an SMT can control the format of the key. For example, it can set it to: yyyy-MM-dd/HH. But the connector replaces the `/` and thus breaks the key.

The change removes the code to replace the value and adds a test for it.

