### PR TITLE
Add `ADOPTERS.md`

### DIFF
--- a/ADOPTERS.md
+++ b/ADOPTERS.md
@@ -1,0 +1,8 @@
+# Stream Reactor Adopters
+
+If you're currently using Lenses.io [Stream Reactor](https://github.com/lensesio/stream-reactor) or [SMT](https://github.com/lensesio/kafka-connect-smt) Kafka connector plugins in production, please let us know by adding your company below.
+
+
+| Organization | Contact             | Usage Description                                                                 |
+| ------------ |---------------------|-----------------------------------------------------------------------------------|
+| [Skillsoft](https://www.skillsoft.com/) | [@brandon-powers](https://github.com/brandon-powers) | Amazon S3 sink & source connectors + SMTs for Apache Kafka backup and disaster recovery. |


### PR DESCRIPTION
👋 

This PR adds an `ADOPTERS.md` file, along with an initial entry for Skillsoft, following the model from Strimzi & Kafka with _Powered By_.

The goal is that once created, it will encourage others that are currently using the connectors to update here, including existing Lenses.io customers + open-source users (e.g. CERN with MQTT). 