### PR TITLE
Java Automatic Formatting (Config Only)

### DIFF
--- a/.github/workflows/java-build.yml
+++ b/.github/workflows/java-build.yml
@@ -56,7 +56,10 @@ jobs:
         with:
           gradle-version: 8.6
 
-      - name: Check License Headers and Test with Gradle
+      - name: Formatting and Headers Check
+        run: cd 'java-connectors' && ./gradlew ${{ matrix.module }}:spotlessCheck
+
+      - name: Test with Gradle
         run: cd 'java-connectors' && ./gradlew ${{ matrix.module }}:test
 
   build-and-cache:

--- a/build.sbt
+++ b/build.sbt
@@ -7,6 +7,7 @@ import sbt.*
 import sbt.Project.projectToLocalProject
 
 import java.io.File
+import scala.sys.process._
 
 ThisBuild / scalaVersion := Dependencies.scalaVersion
 
@@ -474,10 +475,25 @@ addCommandAlias(
   "validateAll",
   "headerCheck;test:headerCheck;it:headerCheck;fun:headerCheck;scalafmtCheckAll;test-common/scalafmtCheck;test-common/headerCheck",
 )
+
+lazy val gradleSpotlessApply = taskKey[Unit]("Run 'gradle spotlessApply' via external process")
+gradleSpotlessApply := {
+  // Specify the desired working directory for the external process
+  val targetDirectory = baseDirectory.value / "java-connectors"
+
+  // Execute 'gradle spotlessApply' in the specified directory
+  val exitCode = Process("gradle spotlessApply", targetDirectory).!
+
+  if (exitCode != 0) {
+    throw new RuntimeException("gradle spotlessApply command failed")
+  }
+}
+
 addCommandAlias(
   "formatAll",
-  "headerCreateAll;scalafmtAll;scalafmtSbt;test-common/scalafmt;test-common/headerCreateAll",
+  ";headerCreateAll;scalafmtAll;scalafmtSbt;test-common/scalafmt;test-common/headerCreateAll;gradleSpotlessApply",
 )
+
 addCommandAlias("fullTest", ";test;it:test;fun:test")
 addCommandAlias("fullCoverageTest", ";coverage;test;it:test;coverageReport;coverageAggregate")
 

--- a/java-connectors/HEADER.txt
+++ b/java-connectors/HEADER.txt
@@ -1,13 +1,15 @@
-Copyright 2017-${year} ${name} Ltd
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
+/*
+ * Copyright 2017-$YEAR Lenses.io Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */

--- a/java-connectors/build.gradle
+++ b/java-connectors/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'com.github.johnrengelman.shadow' version '8.1.1'
-    id 'org.cadixdev.licenser' version '0.6.1'
+    id "com.diffplug.spotless" version "6.25.0"
     id 'java'
     id 'java-library'
 }
@@ -14,7 +14,7 @@ allprojects {
     apply plugin: 'java'
     apply plugin: 'java-library'
     apply plugin: 'com.github.johnrengelman.shadow'
-    apply plugin: 'org.cadixdev.licenser'
+    apply plugin: 'com.diffplug.spotless'
 
     java {
         setSourceCompatibility(JavaVersion.VERSION_11)
@@ -75,22 +75,6 @@ allprojects {
         }
     }
 
-    license {
-        include("**/**.java", "**/**Test.java")
-        exclude("**/kcql/antlr4/**.java") //antlr generated files
-        header = project.file("${project.rootDir}/HEADER.txt")
-        newLine = false
-
-        style {
-            java = 'BLOCK_COMMENT'
-        }
-
-        properties {
-            name = 'Lenses.io'
-            year = LocalDate.now().year
-        }
-    }
-
     jar {
         manifest {
             attributes("StreamReactor-Version": project.version,
@@ -145,8 +129,27 @@ allprojects {
 //        exclude(dependency("com.google.guava:guava:28.1-android"))
         }
 
+
+        spotless {
+
+            format 'misc', {
+                // define the files to apply `misc` to
+                target '*.gradle', '.gitattributes', '.gitignore'
+
+                // define the steps to apply to those files
+                trimTrailingWhitespace()
+                indentWithSpaces() // or spaces. Takes an integer argument if you don't like 4
+                endWithNewline()
+            }
+            java {
+                googleJavaFormat().reflowLongStrings().skipJavadocFormatting()
+                removeUnusedImports()
+                licenseHeaderFile(rootProject.file("HEADER.txt"))
+            }
+        }
+
     }
-    compileJava.dependsOn("checkLicenses")
+    //compileJava.dependsOn("checkLicenses")
 
     task fatJar(dependsOn: [test, jar, shadowJar])
 
@@ -162,7 +165,7 @@ task prepareRelease(dependsOn: [collectFatJar]) {
 
 task releaseModuleList() {
     def nonReleaseModules = ["java-reactor", "kafka-connect-cloud-common",
-                             "kafka-connect-common", "kafka-connect-query-language"]
+                            "kafka-connect-common", "kafka-connect-query-language"]
 
     def modulesFile = new File("gradle-modules.txt")
     modulesFile.delete()

--- a/java-connectors/kafka-connect-query-language/build.gradle
+++ b/java-connectors/kafka-connect-query-language/build.gradle
@@ -50,7 +50,7 @@ project(":kafka-connect-query-language") {
     }
 
     //order should be: generateGrammarSource -> updateLicenseMain -> compileJava
-    checkLicenseMain.dependsOn("generateGrammarSource")
+    //spotlessApply.dependsOn("generateGrammarSource")
 
     task compile(dependsOn: 'compileJava')
     task fatJarNoTest(dependsOn: 'shadowJar')


### PR DESCRIPTION
* Adds autoformatting via [Spotless](https://github.com/diffplug/spotless) and tweaks the buld to enforce formatting.  This also takes care of the license headers, too, in place of the other plugin.
    * `sbt formatAll` command has been updated so that it will run the Spotless Gradle format.
    * to just reformat java code you can run `gradle spotlessApply`.
    * TODO: Align team IDE formats/preferred styles.

This PR only has the config changes to enable formatting.  No autoformatting has been applied at this point.  This allows us to define the style we want before formatting.

The formatting style can be tweaked using [the configuration in the gradle file](https://github.com/lensesio/stream-reactor/pull/1193/files#diff-0792be191ed6b0e384ee253ea969a436ff2810da6050c1dc85b5e40a915b72e4R144-R148).

Currently it is Google's style with minor tweaks.

It is not expected that this PR will be able to build until the formatting changes have been applied, as it adds the format checking to the build.
