### PR TITLE
LC-200 Skip Glacier stored objects

### DIFF
--- a/kafka-connect-aws-s3/src/main/scala/io/lenses/streamreactor/connect/aws/s3/storage/AwsS3StorageFilter.scala
+++ b/kafka-connect-aws-s3/src/main/scala/io/lenses/streamreactor/connect/aws/s3/storage/AwsS3StorageFilter.scala
@@ -25,8 +25,10 @@ import software.amazon.awssdk.services.s3.model.S3Object
   */
 object AwsS3StorageFilter {
 
-  def filterOut(o: S3Object) =
-    o.storageClass() == ObjectStorageClass.GLACIER ||
-      o.storageClass() == ObjectStorageClass.DEEP_ARCHIVE ||
-      o.storageClass() == ObjectStorageClass.GLACIER_IR
+  private val archiveStorageClasses = Set(
+    ObjectStorageClass.GLACIER,
+    ObjectStorageClass.DEEP_ARCHIVE,
+    ObjectStorageClass.GLACIER_IR,
+  )
+  def filterOut(o: S3Object): Boolean = archiveStorageClasses.contains(o.storageClass)
 }

--- a/kafka-connect-aws-s3/src/main/scala/io/lenses/streamreactor/connect/aws/s3/storage/AwsS3StorageFilter.scala
+++ b/kafka-connect-aws-s3/src/main/scala/io/lenses/streamreactor/connect/aws/s3/storage/AwsS3StorageFilter.scala
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2017-2024 Lenses.io Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.lenses.streamreactor.connect.aws.s3.storage
+
+import software.amazon.awssdk.services.s3.model.ObjectStorageClass
+import software.amazon.awssdk.services.s3.model.S3Object
+
+/**
+  * Avoids reading objects that are in Glacier or Deep Archive storage classes.
+  * These objects are not immediately available and require a restore operation to be performed.
+  * This filter is used to avoid reading these objects and failing the task and thus the connector
+  */
+object AwsS3StorageFilter {
+
+  def filterOut(o: S3Object) =
+    o.storageClass() == ObjectStorageClass.GLACIER ||
+      o.storageClass() == ObjectStorageClass.DEEP_ARCHIVE ||
+      o.storageClass() == ObjectStorageClass.GLACIER_IR
+}


### PR DESCRIPTION
The path of listing keys was missed. This meant that for scenarios where the S3 is read with a LastModified order, the change was not working.

It also removes the logging because it is extensive with every poll of the keys.