### PR TITLE
Address gradlew issue when running sbt gradleSpotlessApply

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -481,8 +481,8 @@ gradleSpotlessApply := {
   // Specify the desired working directory for the external process
   val targetDirectory = baseDirectory.value / "java-connectors"
 
-  // Execute 'gradle spotlessApply' in the specified directory
-  val exitCode = Process("gradlew spotlessApply", targetDirectory).!
+  // Execute './gradle spotlessApply' in the specified directory
+  val exitCode = Process("./gradlew spotlessApply", targetDirectory).!
 
   if (exitCode != 0) {
     throw new RuntimeException("gradlew spotlessApply command failed")


### PR DESCRIPTION
Calls local gradlew file (if Gradle not installed)