### PR TITLE
fix to prefer tag before build script version for java JARs

### DIFF
--- a/java-connectors/build.gradle
+++ b/java-connectors/build.gradle
@@ -94,11 +94,10 @@ allprojects {
     }
 
     shadowJar {
-        def artifactVersion = (gitTag == null || gitTag.isBlank()) ?
-                project.version : gitTag
+        def artifactVersion = gitTag?.trim() ? gitTag : project.version
 
         manifest {
-            attributes("StreamReactor-Version": project.version,
+            attributes("StreamReactor-Version": artifactVersion,
                     "Kafka-Version": kafkaVersion,
                     "Created-By": "Lenses",
                     "Created-At": new Date().format("YYYYMMDDHHmm"),

--- a/java-connectors/build.gradle
+++ b/java-connectors/build.gradle
@@ -94,6 +94,8 @@ allprojects {
     }
 
     shadowJar {
+        def artifactVersion = (gitTag == null || gitTag.isBlank()) ?
+                project.version : gitTag
 
         manifest {
             attributes("StreamReactor-Version": project.version,
@@ -107,7 +109,7 @@ allprojects {
             )
         }
         configurations = [project.configurations.compileClasspath]
-        //archiveBaseName = "${project.name}-${project.version}-${kafkaVersion}-all"
+        archiveFileName = "${project.name}-${artifactVersion}-all.jar"
         zip64 true
 
         mergeServiceFiles {


### PR DESCRIPTION
Fix to prefer latest git tag before build script version when building java connector JARs