### PR TITLE
Fix availableProcessors for powerful processors

### DIFF
--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -62,7 +62,7 @@ object Settings extends Dependencies {
   val currentYear = Year.now().getValue()
 
   object ScalacFlags {
-    val availableProcessors: String = java.lang.Runtime.getRuntime.availableProcessors.toString
+    val availableProcessors: String = Math.min(java.lang.Runtime.getRuntime.availableProcessors, 16).toString
 
     val commonOptions = Seq(
       // standard settings


### PR DESCRIPTION
There are errors in build log when trying to build via SBT, because `backend-parallelism` must be between 1 and 16

![image](https://github.com/user-attachments/assets/c83925c5-48b9-4da2-ae0a-efc18dbda036)

This requests fixes this problem