### PR TITLE
fix(kafaka-connect-mqtt): Only remove leading slash on target

### DIFF
--- a/kafka-connect-mqtt/src/main/scala/io/lenses/streamreactor/connect/mqtt/source/MqttManager.scala
+++ b/kafka-connect-mqtt/src/main/scala/io/lenses/streamreactor/connect/mqtt/source/MqttManager.scala
@@ -101,7 +101,7 @@ class MqttManager(
       )
 
     val kafkaTopic = kcql.getTarget match {
-      case "$"   => topic.replaceFirst("/", "").replaceAll("/+", "_").replaceAll("/", "_")
+      case "$"   => topic.replaceFirst("^/", "").replaceAll("/+", "_").replaceAll("/", "_")
       case other => other
     }
 

--- a/kafka-connect-mqtt/src/main/scala/io/lenses/streamreactor/connect/mqtt/source/MqttManager.scala
+++ b/kafka-connect-mqtt/src/main/scala/io/lenses/streamreactor/connect/mqtt/source/MqttManager.scala
@@ -100,10 +100,7 @@ class MqttManager(
         ),
       )
 
-    val kafkaTopic = kcql.getTarget match {
-      case "$"   => topic.replaceFirst("^/", "").replaceAll("/+", "_").replaceAll("/", "_")
-      case other => other
-    }
+    val kafkaTopic = MqttManager.replaceSlashes(kcql, topic)
 
     val converter = convertersMap.getOrElse(
       wildcard,
@@ -172,4 +169,12 @@ class MqttManager(
       logger.warn(s"Resubscribed to topic $topic with QoS $qos")
     else logger.info(s"Subscribed to topic $topic with QoS $qos")
   }
+}
+
+object MqttManager {
+    def replaceSlashes(kcql: Kcql, topic: String): String =
+      kcql.getTarget match {
+        case "$"   => topic.replaceFirst("^/", "").replaceAll("/+", "_").replaceAll("/", "_")
+        case other => other
+      }
 }

--- a/kafka-connect-mqtt/src/test/scala/io/lenses/streamreactor/connect/mqtt/source/MqttManagerTest.scala
+++ b/kafka-connect-mqtt/src/test/scala/io/lenses/streamreactor/connect/mqtt/source/MqttManagerTest.scala
@@ -1,0 +1,57 @@
+package io.lenses.streamreactor.connect.mqtt.source
+
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+import io.lenses.kcql.Kcql
+
+class MqttManagerTest extends AnyWordSpec with Matchers {
+
+    "The MqttManager" when {
+        "calling remplaceSlashes" should {
+            "replace all slashes from dynamic MQTT topic name when converting it to a Kafka topic target " in {
+                val sources = Array(
+                    "/I/Love/Kafka",
+                    "/I/Love/Kafka/Very/Very/Much",
+                    "Foo/Bar/Baz",
+                    "/my/topic"
+                )
+
+                val kcqlStatements = sources.map {
+                    t => s"INSERT INTO `$$` SELECT * FROM $t"
+                }
+
+                val kcqls = Kcql.parseMultiple(kcqlStatements.mkString("; "))
+
+                val expectedTargets = Array(
+                    "I_Love_Kafka",
+                    "I_Love_Kafka_Very_Very_Much",
+                    "Foo_Bar_Baz",
+                    "my_topic"
+                )
+
+
+                val cases = kcqls.toArray.lazyZip(sources).lazyZip(expectedTargets)
+
+                cases.map {
+                    case (kcql: Kcql, source: String, expected: String) => MqttManager.replaceSlashes(kcql, source) should equal(expected)
+                }
+            }
+            "do nothing in other cases and return the actual targeted topic" in {
+
+                val sources = Array("xyz", "zyx")
+                val expectedTargets = Array(
+                    "abc",
+                    "def"
+                )
+
+                val kcqls = Kcql.parseMultiple("INSERT INTO abc SELECT * FROM xyz; INSERT INTO def SELECT * FROM zyx;");
+
+                val cases = kcqls.toArray.lazyZip(sources).lazyZip(expectedTargets)
+
+                cases.map {
+                    case (kcql: Kcql, source: String, expected: String) => MqttManager.replaceSlashes(kcql, source) should equal(expected)
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
* Leading slash from MQTT topic should be removed when converting to Kafaka topic target.
* If no leading slash in MQTT topic exists, the first slash should _not_ be stripped and instead replaced with and underscore, as with the remaining slashes.

For example:

MQTT topic `/I/Love/Kafka` should be converted to `I_Love_Kafka`.
However, MQTT topic `Foo/Bar/Baz` should not be converted to `FooBar_Baz` but instead to `Foo_Bar_Baz`.

Relates to https://github.com/lensesio/stream-reactor/issues/799

I would like to add tests, but there seem to be no test cases around `$` targets, and I am a little unsure of how to instrument the connector for unit-testing.  Some guidance from maintainers would be appreciated.