### PR TITLE
ADL connector: Change getRangeContentMD5 to false on ADL readWithResponse call

### DIFF
--- a/kafka-connect-azure-datalake/src/main/scala/io/lenses/streamreactor/connect/datalake/storage/DatalakeStorageInterface.scala
+++ b/kafka-connect-azure-datalake/src/main/scala/io/lenses/streamreactor/connect/datalake/storage/DatalakeStorageInterface.scala
@@ -286,7 +286,7 @@ class DatalakeStorageInterface(connectorTaskId: ConnectorTaskId, client: DataLak
             null,
             null,
             null,
-            true,
+            false,
             null,
             Context.NONE,
           )

--- a/kafka-connect-azure-datalake/src/test/scala/io/lenses/streamreactor/connect/datalake/storage/DatalakeStorageInterfaceTest.scala
+++ b/kafka-connect-azure-datalake/src/test/scala/io/lenses/streamreactor/connect/datalake/storage/DatalakeStorageInterfaceTest.scala
@@ -424,7 +424,7 @@ class DatalakeStorageInterfaceTest
       byteArrayOutputStream: ByteArrayOutputStream =>
         byteArrayOutputStream.write(expectedContent.getBytes)
         byteArrayOutputStream.flush()
-        
+
         new FileReadResponse(
           new FileReadAsyncResponse(
             new HttpRequest(HttpMethod.GET, "https://test-url"), 
@@ -436,7 +436,6 @@ class DatalakeStorageInterfaceTest
         )
     }
     val result = storageInterface.getBlobAsStringAndEtag(bucket, path)
-    println(result)
 
     result.value should be((expectedEtag, expectedContent))
   }

--- a/kafka-connect-azure-datalake/src/test/scala/io/lenses/streamreactor/connect/datalake/storage/DatalakeStorageInterfaceTest.scala
+++ b/kafka-connect-azure-datalake/src/test/scala/io/lenses/streamreactor/connect/datalake/storage/DatalakeStorageInterfaceTest.scala
@@ -17,13 +17,23 @@ package io.lenses.streamreactor.connect.datalake.storage
 
 import cats.implicits.catsSyntaxOptionId
 import cats.implicits.none
+import com.azure.core.http.HttpHeaders
+import com.azure.core.http.HttpMethod
+import com.azure.core.http.HttpRequest
 import com.azure.core.http.rest.Response
+import com.azure.core.util.Context
+import com.azure.core.util.FluxUtil
 import com.azure.storage.common.ParallelTransferOptions
 import com.azure.storage.file.datalake.DataLakeFileClient
 import com.azure.storage.file.datalake.DataLakeFileSystemClient
 import com.azure.storage.file.datalake.DataLakeServiceClient
 import com.azure.storage.file.datalake.models.DataLakeRequestConditions
 import com.azure.storage.file.datalake.models.DataLakeStorageException
+import com.azure.storage.file.datalake.models.DownloadRetryOptions
+import com.azure.storage.file.datalake.models.FileRange
+import com.azure.storage.file.datalake.models.FileReadAsyncResponse
+import com.azure.storage.file.datalake.models.FileReadHeaders
+import com.azure.storage.file.datalake.models.FileReadResponse
 import com.azure.storage.file.datalake.models.ListPathsOptions
 import com.azure.storage.file.datalake.models.PathInfo
 import io.lenses.streamreactor.connect.cloud.common.config.ConnectorTaskId
@@ -390,6 +400,45 @@ class DatalakeStorageInterfaceTest
     val result = storageInterface.getBlobAsString(bucket, path)
 
     result.left.value should be(a[GeneralFileLoadError])
+  }
+
+  "getBlobAsStringAndEtag" should "return the etag and the blob content as a string when successful" in {
+    val bucket = "test-bucket"
+    val path   = "test-path"
+
+    val expectedEtag = "etag"
+    val expectedContent = "Kwisatz Haderach"
+    when(
+      client.getFileSystemClient(bucket)
+        .getFileClient(path)
+        .readWithResponse(
+          any[ByteArrayOutputStream], 
+          any[FileRange], 
+          any[DownloadRetryOptions], 
+          any[DataLakeRequestConditions], 
+          any[Boolean], 
+          any[Duration], 
+          any[Context]
+        )
+    ).thenAnswer {
+      byteArrayOutputStream: ByteArrayOutputStream =>
+        byteArrayOutputStream.write(expectedContent.getBytes)
+        byteArrayOutputStream.flush()
+        
+        new FileReadResponse(
+          new FileReadAsyncResponse(
+            new HttpRequest(HttpMethod.GET, "https://test-url"), 
+            200, 
+            new HttpHeaders(), 
+            FluxUtil.toFluxByteBuffer(new ByteArrayInputStream("".getBytes())), 
+            new FileReadHeaders().setETag(expectedEtag)
+          )
+        )
+    }
+    val result = storageInterface.getBlobAsStringAndEtag(bucket, path)
+    println(result)
+
+    result.value should be((expectedEtag, expectedContent))
   }
 
   "writeStringToFile" should "upload the data string to the specified path when successful" in {


### PR DESCRIPTION
The purpose of this change is to fix issue #1842 

- Change the `getRangeContentMD5` parameter on the ADL readWithResponse call from `true` to `false`.
- Add unit test.