### PR TITLE
feat azure-datalake: add Service Principal authentication

### DIFF
--- a/kafka-connect-azure-datalake/src/main/scala/io/lenses/streamreactor/connect/datalake/auth/DatalakeClientCreator.scala
+++ b/kafka-connect-azure-datalake/src/main/scala/io/lenses/streamreactor/connect/datalake/auth/DatalakeClientCreator.scala
@@ -19,6 +19,7 @@ import com.azure.core.http.HttpClient
 import com.azure.core.util.Configuration
 import com.azure.core.util.ConfigurationBuilder
 import com.azure.core.util.HttpClientOptions
+import com.azure.identity.ClientSecretCredentialBuilder
 import com.azure.identity.DefaultAzureCredentialBuilder
 import com.azure.storage.common.StorageSharedKeyCredential
 import com.azure.storage.file.datalake.DataLakeServiceClient
@@ -27,8 +28,10 @@ import io.lenses.streamreactor.connect.cloud.common.auth.ClientCreator
 import io.lenses.streamreactor.connect.datalake.config.AuthMode
 import io.lenses.streamreactor.connect.datalake.config.AuthMode.ConnectionString
 import io.lenses.streamreactor.connect.datalake.config.AuthMode.Credentials
+import io.lenses.streamreactor.connect.datalake.config.AuthMode.ServicePrincipal
 import io.lenses.streamreactor.connect.datalake.config.AzureConnectionConfig
 import io.lenses.streamreactor.connect.datalake.config.ConnectionPoolConfig
+import org.apache.kafka.common.config.ConfigException
 
 import java.time.Duration
 import scala.util.Try
@@ -43,6 +46,8 @@ object DatalakeClientCreator extends ClientCreator[AzureConnectionConfig, DataLa
         createDataLakeClientWithConnectionString(csam)
       case cam: AuthMode.Credentials =>
         createDataLakeClientWithSharedKey(config, cam)
+      case spam: AuthMode.ServicePrincipal =>
+        createDataLakeClientWithServicePrincipal(config, spam)
       case AuthMode.Default =>
         createDataLakeClientWithDefaultCredential(config)
       case _ =>
@@ -105,4 +110,41 @@ object DatalakeClientCreator extends ClientCreator[AzureConnectionConfig, DataLa
 
       builder.buildClient()
     }.toEither
+
+  private def createDataLakeClientWithServicePrincipal(
+    config:   AzureConnectionConfig,
+    authMode: ServicePrincipal,
+  ): Either[Throwable, DataLakeServiceClient] =
+    for {
+      endpoint <- resolveEndpoint(config, authMode.accountName)
+      client <- Try {
+        val credential = new ClientSecretCredentialBuilder()
+          .clientId(authMode.clientId)
+          .tenantId(authMode.tenantId)
+          .clientSecret(authMode.clientSecret.value())
+          .build()
+
+        new DataLakeServiceClientBuilder()
+          .credential(credential)
+          .httpClient(createHttpClient(config))
+          .endpoint(endpoint)
+          .buildClient()
+      }.toEither
+    } yield client
+
+  /**
+   * A service principal carries no storage account information, so the data lake endpoint has to come from the
+   * explicit endpoint setting, or be derived from the configured account name.
+   */
+  private def resolveEndpoint(
+    config:      AzureConnectionConfig,
+    accountName: Option[String],
+  ): Either[Throwable, String] =
+    config.endpoint.map(_.trim).filter(_.nonEmpty)
+      .orElse(accountName.map(name => s"https://$name.dfs.core.windows.net"))
+      .toRight(
+        new ConfigException(
+          "Either `connect.datalake.endpoint` or `connect.datalake.azure.account.name` must be set when `connect.datalake.azure.auth.mode` is `serviceprincipal`",
+        ),
+      )
 }

--- a/kafka-connect-azure-datalake/src/main/scala/io/lenses/streamreactor/connect/datalake/config/AuthModeSettings.scala
+++ b/kafka-connect-azure-datalake/src/main/scala/io/lenses/streamreactor/connect/datalake/config/AuthModeSettings.scala
@@ -37,6 +37,13 @@ object AuthMode {
 
   case class ConnectionString(connectionString: String) extends AuthMode
 
+  case class ServicePrincipal(
+    clientId:     String,
+    tenantId:     String,
+    clientSecret: Password,
+    accountName:  Option[String],
+  ) extends AuthMode
+
   case object Default extends AuthMode
 
 }
@@ -47,6 +54,9 @@ trait AuthModeSettingsConfigKeys extends WithConnectorPrefix {
   protected val AZURE_ACCOUNT_NAME:      String = s"$connectorPrefix.azure.account.name"
   protected val AZURE_ACCOUNT_KEY:       String = s"$connectorPrefix.azure.account.key"
   protected val AZURE_CONNECTION_STRING: String = s"$connectorPrefix.azure.connection.string"
+  protected val AZURE_CLIENT_ID:         String = s"$connectorPrefix.azure.client.id"
+  protected val AZURE_TENANT_ID:         String = s"$connectorPrefix.azure.tenant.id"
+  protected val AZURE_CLIENT_SECRET:     String = s"$connectorPrefix.azure.client.secret"
 
   def withAuthModeSettings(configDef: ConfigDef): ConfigDef =
     configDef.define(
@@ -54,7 +64,7 @@ trait AuthModeSettingsConfigKeys extends WithConnectorPrefix {
       Type.STRING,
       AuthMode.Default.toString,
       Importance.HIGH,
-      "Authenticate mode, 'credentials', 'connectionstring' or 'default'",
+      "Authenticate mode, 'credentials', 'connectionstring', 'serviceprincipal' or 'default'",
     )
       .define(
         AZURE_ACCOUNT_NAME,
@@ -75,6 +85,24 @@ trait AuthModeSettingsConfigKeys extends WithConnectorPrefix {
         "",
         Importance.HIGH,
         "Azure Account Key",
+      ).define(
+        AZURE_CLIENT_ID,
+        Type.STRING,
+        "",
+        Importance.HIGH,
+        "Azure Entra ID application (client) id, used by the 'serviceprincipal' auth mode",
+      ).define(
+        AZURE_TENANT_ID,
+        Type.STRING,
+        "",
+        Importance.HIGH,
+        "Azure Entra ID directory (tenant) id, used by the 'serviceprincipal' auth mode",
+      ).define(
+        AZURE_CLIENT_SECRET,
+        Type.PASSWORD,
+        "",
+        Importance.HIGH,
+        "Azure Entra ID application client secret, used by the 'serviceprincipal' auth mode",
       )
 }
 
@@ -93,6 +121,18 @@ trait AuthModeSettings extends BaseSettings with AuthModeSettingsConfigKeys {
         for {
           cString <- Try(getPassword(AZURE_CONNECTION_STRING)).toEither
         } yield AuthMode.ConnectionString(cString.value())
+      case Some("serviceprincipal") =>
+        for {
+          clientId     <- Try(getString(AZURE_CLIENT_ID)).toEither
+          tenantId     <- Try(getString(AZURE_TENANT_ID)).toEither
+          clientSecret <- Try(getPassword(AZURE_CLIENT_SECRET)).toEither
+          accountName  <- Try(Option(getString(AZURE_ACCOUNT_NAME))).toEither
+        } yield AuthMode.ServicePrincipal(
+          clientId,
+          tenantId,
+          clientSecret,
+          accountName.map(_.trim).filter(_.nonEmpty),
+        )
       case Some("default")       => AuthMode.Default.asRight
       case Some(invalidAuthMode) => new ConfigException(s"Unsupported auth mode `$invalidAuthMode`").asLeft
       case None                  => AuthMode.Default.asRight

--- a/kafka-connect-azure-datalake/src/test/scala/io/lenses/streamreactor/connect/datalake/auth/DatalakeClientCreatorTest.scala
+++ b/kafka-connect-azure-datalake/src/test/scala/io/lenses/streamreactor/connect/datalake/auth/DatalakeClientCreatorTest.scala
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2017-2026 Lenses.io Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.lenses.streamreactor.connect.datalake.auth
+
+import io.lenses.streamreactor.connect.datalake.config.AuthMode
+import io.lenses.streamreactor.connect.datalake.config.AuthModeSettingsTest
+import io.lenses.streamreactor.connect.datalake.config.AzureConfigSettings
+import io.lenses.streamreactor.connect.datalake.config.AzureConnectionConfig
+import org.apache.kafka.common.config.ConfigException
+import org.apache.kafka.common.config.types.Password
+import org.scalatest.EitherValues
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.should.Matchers
+
+class DatalakeClientCreatorTest extends AnyFunSuite with Matchers with EitherValues {
+
+  private def servicePrincipal(accountName: Option[String] = None): AuthMode.ServicePrincipal =
+    AuthMode.ServicePrincipal(
+      clientId     = "5c9a4b1e-1111-2222-3333-444455556666",
+      tenantId     = "9f8e7d6c-aaaa-bbbb-cccc-ddddeeeeffff",
+      clientSecret = new Password("not-a-real-secret"),
+      accountName  = accountName,
+    )
+
+  test("service principal auth mode uses the explicitly configured endpoint") {
+    val config = AzureConnectionConfig(
+      authMode = servicePrincipal(),
+      endpoint = Some("https://myaccount.dfs.core.windows.net"),
+    )
+
+    DatalakeClientCreator.make(config).value.getAccountUrl should be("https://myaccount.dfs.core.windows.net")
+  }
+
+  test("service principal auth mode derives the endpoint from the account name") {
+    val config = AzureConnectionConfig(authMode = servicePrincipal(Some("myaccount")))
+
+    DatalakeClientCreator.make(config).value.getAccountUrl should be("https://myaccount.dfs.core.windows.net")
+  }
+
+  test("service principal auth mode prefers the endpoint over the account name") {
+    val config = AzureConnectionConfig(
+      authMode = servicePrincipal(Some("myaccount")),
+      endpoint = Some("https://otheraccount.dfs.core.windows.net"),
+    )
+
+    DatalakeClientCreator.make(config).value.getAccountUrl should be("https://otheraccount.dfs.core.windows.net")
+  }
+
+  test("service principal auth mode falls back to the account name when the endpoint is blank") {
+    val config = AzureConnectionConfig(authMode = servicePrincipal(Some("myaccount")), endpoint = Some("   "))
+
+    DatalakeClientCreator.make(config).value.getAccountUrl should be("https://myaccount.dfs.core.windows.net")
+  }
+
+  test("service principal auth mode fails when neither endpoint nor account name is configured") {
+    val error = DatalakeClientCreator.make(AzureConnectionConfig(authMode = servicePrincipal())).left.value
+
+    error shouldBe a[ConfigException]
+    error.getMessage should include(AzureConfigSettings.ENDPOINT)
+    error.getMessage should include(AuthModeSettingsTest.Keys.accountName)
+    error.getMessage should include(AuthModeSettingsTest.Keys.authMode)
+  }
+
+  test("creates a client for the shared key auth mode") {
+    val config = AzureConnectionConfig(
+      authMode = AuthMode.Credentials("myaccount", new Password("not-a-real-secret")),
+      endpoint = Some("https://myaccount.dfs.core.windows.net"),
+    )
+
+    DatalakeClientCreator.make(config).value.getAccountUrl should be("https://myaccount.dfs.core.windows.net")
+  }
+}

--- a/kafka-connect-azure-datalake/src/test/scala/io/lenses/streamreactor/connect/datalake/config/AuthModeSettingTest.scala
+++ b/kafka-connect-azure-datalake/src/test/scala/io/lenses/streamreactor/connect/datalake/config/AuthModeSettingTest.scala
@@ -1,0 +1,128 @@
+/*
+ * Copyright 2017-2026 Lenses.io Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.lenses.streamreactor.connect.datalake.config
+
+import io.lenses.streamreactor.common.config.base.traits.BaseConfig
+import org.apache.kafka.common.config.ConfigDef
+import org.apache.kafka.common.config.ConfigException
+import org.scalatest.EitherValues
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.should.Matchers
+
+object AuthModeSettingsTest {
+
+  object Keys extends AuthModeSettingsConfigKeys {
+    override def connectorPrefix: String = AzureConfigSettings.CONNECTOR_PREFIX
+
+    val configDef: ConfigDef = withAuthModeSettings(new ConfigDef())
+
+    val authMode:         String = AUTH_MODE
+    val accountName:      String = AZURE_ACCOUNT_NAME
+    val accountKey:       String = AZURE_ACCOUNT_KEY
+    val connectionString: String = AZURE_CONNECTION_STRING
+    val clientId:         String = AZURE_CLIENT_ID
+    val tenantId:         String = AZURE_TENANT_ID
+    val clientSecret:     String = AZURE_CLIENT_SECRET
+  }
+
+  class TestSettings(props: Map[String, AnyRef])
+    extends BaseConfig(AzureConfigSettings.CONNECTOR_PREFIX, Keys.configDef, props)
+      with AuthModeSettings
+}
+
+class AuthModeSettingsTest extends AnyFunSuite with Matchers with EitherValues {
+
+  import AuthModeSettingsTest._
+
+  private val ClientIdValue     = "5c9a4b1e-1111-2222-3333-444455556666"
+  private val TenantIdValue     = "9f8e7d6c-aaaa-bbbb-cccc-ddddeeeeffff"
+  private val ClientSecretValue = "super-secret-value"
+
+  private def servicePrincipalProps(extra: (String, AnyRef)*): Map[String, AnyRef] =
+    Map[String, AnyRef](
+      Keys.authMode     -> "serviceprincipal",
+      Keys.clientId     -> ClientIdValue,
+      Keys.tenantId     -> TenantIdValue,
+      Keys.clientSecret -> ClientSecretValue,
+    ) ++ extra
+
+  private def authMode(props: Map[String, AnyRef]) = new TestSettings(props).getAuthMode
+
+  test("parses a service principal auth mode without an account name") {
+    val result = authMode(servicePrincipalProps()).value
+
+    result shouldBe a[AuthMode.ServicePrincipal]
+    val sp = result.asInstanceOf[AuthMode.ServicePrincipal]
+    sp.clientId should be(ClientIdValue)
+    sp.tenantId should be(TenantIdValue)
+    sp.clientSecret.value() should be(ClientSecretValue)
+    sp.accountName should be(None)
+  }
+
+  test("parses a service principal auth mode with an account name") {
+    val result = authMode(servicePrincipalProps(Keys.accountName -> "mystorageaccount")).value
+
+    result.asInstanceOf[AuthMode.ServicePrincipal].accountName should be(Some("mystorageaccount"))
+  }
+
+  test("ignores a blank account name for the service principal auth mode") {
+    val result = authMode(servicePrincipalProps(Keys.accountName -> "   ")).value
+
+    result.asInstanceOf[AuthMode.ServicePrincipal].accountName should be(None)
+  }
+
+  test("accepts the service principal auth mode irrespective of case and surrounding whitespace") {
+    val result = authMode(servicePrincipalProps(Keys.authMode -> "  ServicePrincipal ")).value
+
+    result shouldBe a[AuthMode.ServicePrincipal]
+  }
+
+  test("parses the credentials auth mode") {
+    val result = authMode(
+      Map[String, AnyRef](
+        Keys.authMode    -> "credentials",
+        Keys.accountName -> "mystorageaccount",
+        Keys.accountKey  -> "account-key",
+      ),
+    ).value
+
+    result shouldBe a[AuthMode.Credentials]
+    result.asInstanceOf[AuthMode.Credentials].accountName should be("mystorageaccount")
+  }
+
+  test("parses the connection string auth mode") {
+    val result = authMode(
+      Map[String, AnyRef](
+        Keys.authMode         -> "connectionstring",
+        Keys.connectionString -> "connection-string",
+      ),
+    ).value
+
+    result should be(AuthMode.ConnectionString("connection-string"))
+  }
+
+  test("still defaults to the default auth mode") {
+    authMode(Map.empty[String, AnyRef]).value should be(AuthMode.Default)
+    authMode(Map[String, AnyRef](Keys.authMode -> "default")).value should be(AuthMode.Default)
+  }
+
+  test("rejects an unsupported auth mode") {
+    val error = authMode(Map[String, AnyRef](Keys.authMode -> "unsupported")).left.value
+
+    error shouldBe a[ConfigException]
+    error.getMessage should include("unsupported")
+  }
+}


### PR DESCRIPTION
## Summary

Adds Microsoft Entra ID Service Principal authentication to the Azure Data Lake Storage Gen2 sink connector.

The new `serviceprincipal` authentication mode uses the OAuth 2.0 client credentials flow through the Azure SDK `ClientSecretCredential`.

This provides an alternative to storage account keys and connection strings for environments where connector access is managed through Microsoft Entra ID identities and Azure RBAC.

Closes #2270.

## Changes

### New authentication mode

Adds the following authentication mode:

```properties
connect.datalake.azure.auth.mode=serviceprincipal
```

The connector creates an Azure SDK `ClientSecretCredential` from these values and provides it to the `DataLakeServiceClientBuilder`.

Because a Service Principal does not identify the target storage account, the ADLS service endpoint is resolved:

1. `connect.datalake.endpoint`, if explicitly configured and non-blank.
2. `https://<account-name>.dfs.core.windows.net`, derived from connect.datalake.azure.account.name.
3. A `ConfigException` if neither an endpoint nor an account name is available.

When both values are configured, the explicit endpoint takes precedence.

### Configuration examples
```properties
connect.datalake.azure.auth.mode=serviceprincipal
connect.datalake.azure.client.id=<application-client-id>
connect.datalake.azure.tenant.id=<directory-tenant-id>
connect.datalake.azure.client.secret=<application-client-secret>
connect.datalake.azure.account.name=<storage-account-name>
```

## Backwards compatibility

The change is backwards compatible.

The existing authentication modes remain available and unchanged:
- default
- credentials
- connectionstring

The new behaviour is activated only when the authentication mode is explicitly set to `serviceprincipal`.